### PR TITLE
Fixing inconsistent formatting / naming, and reducing some duplicated code

### DIFF
--- a/control_toolbox/include/control_toolbox/pid.h
+++ b/control_toolbox/include/control_toolbox/pid.h
@@ -109,15 +109,15 @@ public:
 
   /*!
    * \brief Constructor, zeros out Pid values when created and
-   * initialize Pid-gains and integral term limits:[iMax:iMin]-[I1:I2].
+   * initialize Pid-gains and integral term limits.
    *
-   * \param P  The proportional gain.
-   * \param I  The integral gain.
-   * \param D  The derivative gain.
-   * \param I1 The integral upper limit.
-   * \param I2 The integral lower limit.
+   * \param p  The proportional gain.
+   * \param i  The integral gain.
+   * \param d  The derivative gain.
+   * \param i_max The integral upper limit.
+   * \param i_min The integral lower limit.
    */
-  Pid(double P = 0.0, double I = 0.0, double D = 0.0, double I1 = 0.0, double I2 = -0.0);
+  Pid(double p = 0.0, double i = 0.0, double d = 0.0, double i_max = 0.0, double i_min = -0.0);
 
   /*!
    * \brief Destructor of Pid class.
@@ -133,15 +133,15 @@ public:
   double updatePid(double p_error, ros::Duration dt);
 
   /*!
-   * \brief Initialize PID-gains and integral term limits:[iMax:iMin]-[I1:I2]
+   * \brief Initialize PID-gains and integral term limits.
    *
-   * \param P  The proportional gain.
-   * \param I  The integral gain.
-   * \param D  The derivative gain.
-   * \param I1 The integral upper limit.
-   * \param I2 The integral lower limit.
+   * \param p  The proportional gain.
+   * \param i  The integral gain.
+   * \param d  The derivative gain.
+   * \param i_max The integral upper limit.
+   * \param i_min The integral lower limit.
    */
-  void initPid(double P, double I, double D, double I1, double I2);
+  void initPid(double p, double i, double d, double i_max, double i_min);
   
   /*!                                                                                                   
    * \brief Initialize PID with the parameters in a namespace                               
@@ -182,13 +182,13 @@ public:
 
   /*!
    * \brief Set PID gains for the controller.
-   * \param P  The proportional gain.
-   * \param I  The integral gain.
-   * \param D  The derivative gain.
-   * \param i_max
-   * \param i_min
+   * \param p  The proportional gain.
+   * \param i  The integral gain.
+   * \param d  The derivative gain.
+   * \param i_max The integral upper limit.
+   * \param i_min The integral lower limit.
    */
-  void setGains(double P, double I, double D, double i_max, double i_min);
+  void setGains(double p, double i, double d, double i_max, double i_min);
 
   /*!
    * \brief Get PID gains for the controller.

--- a/control_toolbox/src/pid.cpp
+++ b/control_toolbox/src/pid.cpp
@@ -39,28 +39,19 @@
 
 namespace control_toolbox {
 
-Pid::Pid(double P, double I, double D, double I1, double I2) :
-  p_gain_(P), i_gain_(I), d_gain_(D), i_max_(I1), i_min_(I2)
+Pid::Pid(double p, double i, double d, double i_max, double i_min) :
+  p_gain_(p), i_gain_(i), d_gain_(d), i_max_(i_max), i_min_(i_min)
 {
-  p_error_last_ = 0.0;
-  p_error_ = 0.0;
-  d_error_ = 0.0;
-  i_error_ = 0.0;
-  cmd_ = 0.0;
+  this->reset();
 }
 
 Pid::~Pid()
 {
 }
 
-void Pid::initPid(double P, double I, double D, double I1, double I2)
+void Pid::initPid(double p, double i, double d, double i_max, double i_min)
 {
-  p_gain_ = P;
-  i_gain_ = I;
-  d_gain_ = D;
-  i_max_ = I1;
-  i_min_ = I2;
-
+  this->setGains(p,i,d,i_max,i_min);
   reset();
 }
 
@@ -82,13 +73,13 @@ void Pid::getGains(double &p, double &i, double &d, double &i_max, double &i_min
   i_min = i_min_;
 }
 
-void Pid::setGains(double P, double I, double D, double I1, double I2)
+void Pid::setGains(double p, double i, double d, double i_max, double i_min)
 {
-  p_gain_ = P;
-  i_gain_ = I;
-  d_gain_ = D;
-  i_max_ = I1;
-  i_min_ = I2;
+  p_gain_ = p;
+  i_gain_ = i;
+  d_gain_ = d;
+  i_max_ = i_max;
+  i_min_ = i_min;
 }
 
 bool Pid::initParam(const std::string& prefix)


### PR DESCRIPTION
- The variable arguments "I1" and "I2" are meaningless without reading the inline parameter comments. These were changed to have meaningful names: "i_max" and "i_min" respectively. 
- The P,I,D variables in arguments were changed to be more consistent with the rest of the API: p,i,d
- Some duplicated initialization code in the constructor was removed, and replaced with a call to the `reset()` function (which does the same thing as the removed code).
- Some duplicated member-setting code in `initPid` was removed, and replaced with a call to the `setPid()` function (which does the same thing as the removed code).

This PR changes neither the API nor the behavior of this library.
