### PR TITLE
Adding conventional PID computation, deprecating current PID computation

### DIFF
--- a/control_toolbox/include/control_toolbox/pid.h
+++ b/control_toolbox/include/control_toolbox/pid.h
@@ -221,6 +221,10 @@ public:
    * function is equivalent to calling \ref setError with negated error
    * arguments.
    *
+   * \deprecated This function assumes <tt> p_error = (state - target) </tt> which is an
+   * unconventional definition of the error. Please use \ref setError instead,
+   * which assumes <tt> error = (target - state) </tt>.
+   *
    * \param p_error  Error since last call (p_state-p_target)
    * \param dt Change in time since last call
    */
@@ -231,6 +235,10 @@ public:
    * allows the user to pass in a precomputed derivative error. NOTE: this
    * function is equivalent to calling \ref setError with negated error
    * arguments.
+   *
+   * \deprecated This function assumes <tt> p_error = (state - target) </tt> which is an
+   * unconventional definition of the error. Please use \ref setError instead,
+   * which assumes <tt> error = (target - state) </tt>.
    *
    * \param error  Error since last call (p_state-p_target)
    * \param error_dot d(Error)/dt since last call

--- a/control_toolbox/include/control_toolbox/pid.h
+++ b/control_toolbox/include/control_toolbox/pid.h
@@ -193,15 +193,16 @@ public:
   void getGains(double &p, double &i, double &d, double &i_max, double &i_min);
 
   /*!
-   * \brief Set the PID error and compute the PID command with nonuniform
-   * time step size. 
+   * \brief Set the PID error and compute the PID command with nonuniform time
+   * step size. The derivative error is computed from the change in the error
+   * and the timestep \c dt.
    *
-   * \param p_error  Error since last call (error = target - state)
+   * \param error  Error since last call (error = target - state)
    * \param dt Change in time since last call
    *
    * \returns PID command
    */
-  double setError(double p_error, ros::Duration dt);
+  double setError(double error, ros::Duration dt);
 
   /*!
    * \brief Set the PID error and compute the PID command with nonuniform

--- a/control_toolbox/include/control_toolbox/pid.h
+++ b/control_toolbox/include/control_toolbox/pid.h
@@ -125,14 +125,6 @@ public:
   ~Pid();
 
   /*!
-   * \brief Update the Pid loop with nonuniform time step size.
-   *
-   * \param p_error  Error since last call (p_state-p_target)
-   * \param dt Change in time since last call
-   */
-  double updatePid(double p_error, ros::Duration dt);
-
-  /*!
    * \brief Initialize PID-gains and integral term limits:[iMax:iMin]-[I1:I2]
    *
    * \param P  The proportional gain.
@@ -201,14 +193,51 @@ public:
   void getGains(double &p, double &i, double &d, double &i_max, double &i_min);
 
   /*!
+   * \brief Set the PID error and compute the PID command with nonuniform
+   * time step size. 
+   *
+   * \param p_error  Error since last call (p_state-p_target)
+   * \param dt Change in time since last call
+   *
+   * \returns PID command
+   */
+  double setError(double p_error, ros::Duration dt);
+
+  /*!
+   * \brief Set the PID error and compute the PID command with nonuniform
+   * time step size. This also allows the user to pass in a precomputed
+   * derivative error. 
+   *
+   * \param error Error since last call (target-state)
+   * \param error_dot d(Error)/dt since last call
+   * \param dt Change in time since last call
+   *
+   * \returns PID command
+   */
+  double setError(double error, double error_dot, ros::Duration dt);
+
+  /*!
+   * \brief Update the Pid loop with nonuniform time step size. NOTE: this
+   * function is equivalent to calling \ref setError with negated error
+   * arguments.
+   *
+   * \param p_error  Error since last call (p_state-p_target)
+   * \param dt Change in time since last call
+   */
+  ROS_DEPRECATED double updatePid(double p_error, ros::Duration dt);
+
+  /*!
    * \brief Update the Pid loop with nonuniform time step size. This update call 
-   * allows the user to pass in a precomputed derivative error. 
+   * allows the user to pass in a precomputed derivative error. NOTE: this
+   * function is equivalent to calling \ref setError with negated error
+   * arguments.
    *
    * \param error  Error since last call (p_state-p_target)
    * \param error_dot d(Error)/dt since last call
    * \param dt Change in time since last call
    */
-  double updatePid(double error, double error_dot, ros::Duration dt);
+  ROS_DEPRECATED double updatePid(double error, double error_dot, ros::Duration dt);
+
 
   Pid &operator =(const Pid& p)
   {

--- a/control_toolbox/include/control_toolbox/pid.h
+++ b/control_toolbox/include/control_toolbox/pid.h
@@ -196,7 +196,7 @@ public:
    * \brief Set the PID error and compute the PID command with nonuniform
    * time step size. 
    *
-   * \param p_error  Error since last call (p_state-p_target)
+   * \param p_error  Error since last call (error = target - state)
    * \param dt Change in time since last call
    *
    * \returns PID command
@@ -208,7 +208,7 @@ public:
    * time step size. This also allows the user to pass in a precomputed
    * derivative error. 
    *
-   * \param error Error since last call (target-state)
+   * \param error Error since last call (error = target - state)
    * \param error_dot d(Error)/dt since last call
    * \param dt Change in time since last call
    *

--- a/control_toolbox/src/pid.cpp
+++ b/control_toolbox/src/pid.cpp
@@ -136,8 +136,7 @@ bool Pid::init(const ros::NodeHandle &node)
   return true;
 }
 
-
-double Pid::updatePid(double error, ros::Duration dt)
+double Pid::setError(double error, ros::Duration dt)
 {
   double p_term, d_term, i_term;
   p_error_ = error; //this is pError = pState-pTarget
@@ -167,20 +166,24 @@ double Pid::updatePid(double error, ros::Duration dt)
   }
 
   // Calculate the derivative error
-  if (dt.toSec() != 0)
+  if (dt.toSec() > 0.0)
   {
     d_error_ = (p_error_ - p_error_last_) / dt.toSec();
     p_error_last_ = p_error_;
   }
   // Calculate derivative contribution to command
   d_term = d_gain_ * d_error_;
-  cmd_ = -p_term - i_term - d_term;
+  cmd_ = p_term + i_term + d_term;
 
   return cmd_;
 }
 
+double Pid::updatePid(double error, ros::Duration dt)
+{
+  return this->setError(-1.0*error, dt);
+}
 
-double Pid::updatePid(double error, double error_dot, ros::Duration dt)
+double Pid::setError(double error, double error_dot, ros::Duration dt)
 {
   double p_term, d_term, i_term;
   p_error_ = error; //this is pError = pState-pTarget
@@ -213,9 +216,14 @@ double Pid::updatePid(double error, double error_dot, ros::Duration dt)
 
   // Calculate derivative contribution to command
   d_term = d_gain_ * d_error_;
-  cmd_ = -p_term - i_term - d_term;
+  cmd_ = p_term + i_term + d_term;
 
   return cmd_;
+}
+
+double Pid::updatePid(double error, double error_dot, ros::Duration dt)
+{
+  return this->setError(-1.0*error, -1.0*error_dot, dt);
 }
 
 


### PR DESCRIPTION
This PR adds a member function with two signatures called `Pid::setError()` and adds deprecation warnings to the current `Pid::updatePid()` member functions, along with appropriate documentation.

This new member function is identical to the deprecated functions, except that it implements the conventional  sign of the input to a PID controller (error = target - current) discussed in this issue: https://github.com/willowgarage/ros_controllers/issues/2
