### PR TITLE
Using zero i_gain_ to turn off integral control did unsavory things.

### DIFF
--- a/control_toolbox/include/control_toolbox/pid.h
+++ b/control_toolbox/include/control_toolbox/pid.h
@@ -60,9 +60,8 @@ namespace control_toolbox {
     where: <br>
     <UL TYPE="none">
     <LI>  \f$ p_{term}  = p_{gain} * p_{error} \f$
-    <LI>  \f$ i_{term}  = i_{gain} * i_{error} \f$
+    <LI>  \f$ i_{term}  = i_{term} + \int{i_{gain} * p_{error} * dt} \f$
     <LI>  \f$ d_{term}  = d_{gain} * d_{error} \f$
-    <LI>  \f$ i_{error} = i_{error} + p_{error} * dt \f$
     <LI>  \f$ d_{error} = (p_{error} - p_{error last}) / dt \f$
     </UL>
 
@@ -79,7 +78,7 @@ namespace control_toolbox {
 
     @param i Integral gain
 
-    @param i_clamp Min/max bounds for the integral windup, the clamp is applied to the \f$i_{term}\f$ and not the \f$i_{error}\f$
+    @param i_clamp Min/max bounds for the integral windup, the clamp is applied to the \f$i_{term}\f$
 
     @section Usage
 
@@ -221,7 +220,7 @@ public:
     i_max_ = p.i_max_;
     i_min_ = p.i_min_;
 
-    p_error_last_ = p_error_ = i_error_ = d_error_ = cmd_ = 0.0;
+    p_error_last_ = p_error_ = i_term_ = d_error_ = cmd_ = 0.0;
     return *this;
   }
 
@@ -229,7 +228,7 @@ private:
   double p_error_last_; /**< _Save position state for derivative state calculation. */
   double p_error_; /**< Position error. */
   double d_error_; /**< Derivative error. */
-  double i_error_; /**< Integator error. */
+  double i_term_;  /**< Integral term. */
   double p_gain_;  /**< Proportional gain. */
   double i_gain_;  /**< Integral gain. */
   double d_gain_;  /**< Derivative gain. */

--- a/control_toolbox/src/pid.cpp
+++ b/control_toolbox/src/pid.cpp
@@ -159,7 +159,7 @@ double Pid::setError(double error, ros::Duration dt)
 
 double Pid::updatePid(double error, ros::Duration dt)
 {
-  double p_term, d_term, i_term;
+  double p_term, d_term;
   p_error_ = error; //this is pError = pState-pTarget
 
   if (dt == ros::Duration(0.0) || std::isnan(error) || std::isinf(error))
@@ -168,23 +168,11 @@ double Pid::updatePid(double error, ros::Duration dt)
   // Calculate proportional contribution to command
   p_term = p_gain_ * p_error_;
 
-  // Calculate the integral error
-  i_error_ = i_error_ + dt.toSec() * p_error_;
-
   //Calculate integral contribution to command
-  i_term = i_gain_ * i_error_;
+  i_term_ = i_term_ + i_gain_ * dt.toSec() * p_error_;
 
-  // Limit i_term so that the limit is meaningful in the output
-  if (i_term > i_max_)
-  {
-    i_term = i_max_;
-    i_error_=i_term/i_gain_;
-  }
-  else if (i_term < i_min_)
-  {
-    i_term = i_min_;
-    i_error_=i_term/i_gain_;
-  }
+  // Limit i_term_ so that the limit is meaningful in the output
+  i_term_ = std::max( i_min_, std::min( i_term_, i_max_) );
 
   // Calculate the derivative error
   if (dt.toSec() > 0.0)
@@ -227,33 +215,22 @@ double Pid::setError(double error, double error_dot, ros::Duration dt)
 
 double Pid::updatePid(double error, double error_dot, ros::Duration dt)
 {
-  double p_term, d_term, i_term;
+  double p_term, d_term;
   p_error_ = error; //this is pError = pState-pTarget
   d_error_ = error_dot;
 
   if (dt == ros::Duration(0.0) || std::isnan(error) || std::isinf(error) || std::isnan(error_dot) || std::isinf(error_dot))
     return 0.0;
 
+
   // Calculate proportional contribution to command
   p_term = p_gain_ * p_error_;
 
-  // Calculate the integral error
-  i_error_ = i_error_ + dt.toSec() * p_error_;
-
   //Calculate integral contribution to command
-  i_term = i_gain_ * i_error_;
+  i_term_ = i_term_ + i_gain_ * dt.toSec() * p_error_;
 
-  // Limit i_term so that the limit is meaningful in the output
-  if (i_term > i_max_)
-  {
-    i_term = i_max_;
-    i_error_=i_term/i_gain_;
-  }
-  else if (i_term < i_min_)
-  {
-    i_term = i_min_;
-    i_error_=i_term/i_gain_;
-  }
+  // Limit i_term_ so that the limit is meaningful in the output
+  i_term_ = std::max( i_min_, std::min( i_term_, i_max_) );
 
   // Calculate derivative contribution to command
   d_term = d_gain_ * d_error_;

--- a/control_toolbox/src/pid.cpp
+++ b/control_toolbox/src/pid.cpp
@@ -183,7 +183,6 @@ double Pid::setError(double error, double error_dot, ros::Duration dt)
 
   // Calculate derivative contribution to command
   d_term = d_gain_ * d_error_;
-  cmd_ = -p_term - i_term_ - d_term;
   cmd_ = p_term + i_term_ + d_term;
 
   return cmd_;

--- a/control_toolbox/src/pid.cpp
+++ b/control_toolbox/src/pid.cpp
@@ -60,7 +60,7 @@ void Pid::reset()
   p_error_last_ = 0.0;
   p_error_ = 0.0;
   d_error_ = 0.0;
-  i_error_ = 0.0;
+  i_term_  = 0.0;
   cmd_ = 0.0;
 }
 
@@ -130,7 +130,7 @@ bool Pid::init(const ros::NodeHandle &node)
 
 double Pid::updatePid(double error, ros::Duration dt)
 {
-  double p_term, d_term, i_term;
+  double p_term, d_term;
   p_error_ = error; //this is pError = pState-pTarget
 
   if (dt == ros::Duration(0.0) || std::isnan(error) || std::isinf(error))
@@ -139,23 +139,11 @@ double Pid::updatePid(double error, ros::Duration dt)
   // Calculate proportional contribution to command
   p_term = p_gain_ * p_error_;
 
-  // Calculate the integral error
-  i_error_ = i_error_ + dt.toSec() * p_error_;
-
   //Calculate integral contribution to command
-  i_term = i_gain_ * i_error_;
+  i_term_ = i_term_ + i_gain_ * dt.toSec() * p_error_;
 
-  // Limit i_term so that the limit is meaningful in the output
-  if (i_term > i_max_)
-  {
-    i_term = i_max_;
-    i_error_=i_term/i_gain_;
-  }
-  else if (i_term < i_min_)
-  {
-    i_term = i_min_;
-    i_error_=i_term/i_gain_;
-  }
+  // Limit i_term_ so that the limit is meaningful in the output
+  i_term_ = std::max( i_min_, std::min( i_term_, i_max_) );
 
   // Calculate the derivative error
   if (dt.toSec() != 0)
@@ -165,7 +153,7 @@ double Pid::updatePid(double error, ros::Duration dt)
   }
   // Calculate derivative contribution to command
   d_term = d_gain_ * d_error_;
-  cmd_ = -p_term - i_term - d_term;
+  cmd_ = -p_term - i_term_ - d_term;
 
   return cmd_;
 }
@@ -173,7 +161,7 @@ double Pid::updatePid(double error, ros::Duration dt)
 
 double Pid::updatePid(double error, double error_dot, ros::Duration dt)
 {
-  double p_term, d_term, i_term;
+  double p_term, d_term;
   p_error_ = error; //this is pError = pState-pTarget
   d_error_ = error_dot;
 
@@ -184,27 +172,15 @@ double Pid::updatePid(double error, double error_dot, ros::Duration dt)
   // Calculate proportional contribution to command
   p_term = p_gain_ * p_error_;
 
-  // Calculate the integral error
-  i_error_ = i_error_ + dt.toSec() * p_error_;
-
   //Calculate integral contribution to command
-  i_term = i_gain_ * i_error_;
+  i_term_ = i_term_ + i_gain_ * dt.toSec() * p_error_;
 
-  // Limit i_term so that the limit is meaningful in the output
-  if (i_term > i_max_)
-  {
-    i_term = i_max_;
-    i_error_=i_term/i_gain_;
-  }
-  else if (i_term < i_min_)
-  {
-    i_term = i_min_;
-    i_error_=i_term/i_gain_;
-  }
+  // Limit i_term_ so that the limit is meaningful in the output
+  i_term_ = std::max( i_min_, std::min( i_term_, i_max_) );
 
   // Calculate derivative contribution to command
   d_term = d_gain_ * d_error_;
-  cmd_ = -p_term - i_term - d_term;
+  cmd_ = -p_term - i_term_ - d_term;
 
   return cmd_;
 }
@@ -224,7 +200,7 @@ double Pid::getCurrentCmd()
 void Pid::getCurrentPIDErrors(double *pe, double *ie, double *de)
 {
   *pe = p_error_;
-  *ie = i_error_;
+  *ie = i_gain_ ? i_term_/i_gain_ : 0.0;
   *de = d_error_;
 }
 

--- a/control_toolbox/src/pid.cpp
+++ b/control_toolbox/src/pid.cpp
@@ -182,7 +182,7 @@ double Pid::updatePid(double error, ros::Duration dt)
   }
   // Calculate derivative contribution to command
   d_term = d_gain_ * d_error_;
-  cmd_ = - p_term - i_term - d_term;
+  cmd_ = - p_term - i_term_ - d_term;
 
   return cmd_;
 }
@@ -234,7 +234,7 @@ double Pid::updatePid(double error, double error_dot, ros::Duration dt)
 
   // Calculate derivative contribution to command
   d_term = d_gain_ * d_error_;
-  cmd_ = - p_term - i_term - d_term;
+  cmd_ = - p_term - i_term_ - d_term;
 
   return cmd_;
 }


### PR DESCRIPTION
If the user did not want integral control and set i_gain_ to zero, then dividing by i_gain_ would set i_error_ to NaN.  This is not desired.  Instead, replace the use of division to create i_term with direct integration of i_term_.

Replace private member i_error_ with i_term_.

In getCurrentPIDErrors(): create & return i_error_ with the same old meaning and units. NOTE: i_error_ is not needed internally anywhere else.
