### PR TITLE
Make public getControllerByName method thread-safe.

### DIFF
--- a/controller_manager/include/controller_manager/controller_manager.h
+++ b/controller_manager/include/controller_manager/controller_manager.h
@@ -74,10 +74,12 @@ public:
                         const std::vector<std::string>& stop_controllers,
                         const int strictness);
 
-  // controllers_lock_ must be locked before calling
-  virtual controller_interface::ControllerBase* getControllerByName(const std::string& name);
-
+  controller_interface::ControllerBase* getControllerByName(const std::string& name);
   void registerControllerLoader(boost::shared_ptr<ControllerLoaderInterface> controller_loader);
+
+protected:
+  // controllers_lock_ must be locked before calling
+  virtual controller_interface::ControllerBase* getControllerByNameImpl(const std::string& name);
 
 private:
   void getControllerNames(std::vector<std::string> &v);
@@ -118,6 +120,12 @@ private:
   ros::ServiceServer srv_list_controllers_, srv_list_controller_types_, srv_load_controller_;
   ros::ServiceServer srv_unload_controller_, srv_switch_controller_, srv_reload_libraries_;
 };
+
+inline controller_interface::ControllerBase* ControllerManager::getControllerByName(const std::string& name)
+{
+  boost::mutex::scoped_lock guard(controllers_lock_);
+  return getControllerByNameImpl(name);
+}
 
 }
 #endif

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -110,7 +110,7 @@ void ControllerManager::update(const ros::Time& time, const ros::Duration& perio
   }
 }
 
-controller_interface::ControllerBase* ControllerManager::getControllerByName(const std::string& name)
+controller_interface::ControllerBase* ControllerManager::getControllerByNameImpl(const std::string& name)
 {
   std::vector<ControllerSpec> &controllers = controllers_lists_[current_controllers_list_];
   for (size_t i = 0; i < controllers.size(); ++i)
@@ -357,7 +357,7 @@ bool ControllerManager::switchController(const std::vector<std::string>& start_c
   // list all controllers to stop
   for (unsigned int i=0; i<stop_controllers.size(); i++)
   {
-    ct = getControllerByName(stop_controllers[i]);
+    ct = getControllerByNameImpl(stop_controllers[i]);
     if (ct == NULL){
       if (strictness ==  controller_manager_msgs::SwitchController::Request::STRICT){
         ROS_ERROR("Could not stop controller with name %s because no controller with this name exists",
@@ -381,7 +381,7 @@ bool ControllerManager::switchController(const std::vector<std::string>& start_c
   // list all controllers to start
   for (unsigned int i=0; i<start_controllers.size(); i++)
   {
-    ct = getControllerByName(start_controllers[i]);
+    ct = getControllerByNameImpl(start_controllers[i]);
     if (ct == NULL){
       if (strictness ==  controller_manager_msgs::SwitchController::Request::STRICT){
         ROS_ERROR("Could not start controller with name %s because no controller with this name exists",


### PR DESCRIPTION
Existing virtual non-threadsafe method has been suffixed with -Impl and pushed
to protected class scope. In-class uses call getControllerByNameImpl, as the
lock has already been acquired.
