### PR TITLE
Tests for bad integral bounds in control_toolbox::Pid 

### DIFF
--- a/control_toolbox/CMakeLists.txt
+++ b/control_toolbox/CMakeLists.txt
@@ -15,3 +15,7 @@ rosbuild_add_library(control_toolbox
 target_link_libraries(control_toolbox tinyxml)
  
 # rosbuild_add_executable(test_linear test/linear.cpp)
+
+# Tests
+rosbuild_add_gtest(test/pid_tests test/pid_tests.cpp) 
+target_link_libraries(test/pid_tests control_toolbox)

--- a/control_toolbox/test/pid_tests.cpp
+++ b/control_toolbox/test/pid_tests.cpp
@@ -1,0 +1,33 @@
+
+#include <ros/ros.h>
+
+#include <gtest/gtest.h>
+
+#include <control_toolbox/pid.h>
+
+using namespace control_toolbox;
+
+TEST(ParameterTest, zeroITermBadIBoundsTest)
+{
+  RecordProperty("description","This test checks robustness against poorly-defined integral term bounds.");
+
+  Pid pid(1.0, 0.0, 0.0, -1.0, 0.0);
+
+  double cmd = 0.0;
+  double pe,ie,de;
+
+  cmd = pid.updatePid(-1.0, ros::Duration(1.0));
+  pid.getCurrentPIDErrors(&pe,&ie,&de);
+  EXPECT_EQ(-1.0, ie);
+  EXPECT_EQ(2.0, cmd);
+
+  cmd = pid.updatePid(-1.0, ros::Duration(1.0));
+  pid.getCurrentPIDErrors(&pe,&ie,&de);
+  EXPECT_EQ(-2.0, ie);
+  EXPECT_EQ(2.0, cmd);
+}
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/control_toolbox/test/pid_tests.cpp
+++ b/control_toolbox/test/pid_tests.cpp
@@ -5,11 +5,13 @@
 
 #include <control_toolbox/pid.h>
 
+#include <boost/math/special_functions/fpclassify.hpp>
+
 using namespace control_toolbox;
 
 TEST(ParameterTest, zeroITermBadIBoundsTest)
 {
-  RecordProperty("description","This test checks robustness against poorly-defined integral term bounds.");
+  RecordProperty("description","This test checks robustness against divide-by-zero errors when given integral term bounds which do not include 0.0.");
 
   Pid pid(1.0, 0.0, 0.0, -1.0, 0.0);
 
@@ -18,13 +20,58 @@ TEST(ParameterTest, zeroITermBadIBoundsTest)
 
   cmd = pid.updatePid(-1.0, ros::Duration(1.0));
   pid.getCurrentPIDErrors(&pe,&ie,&de);
-  EXPECT_EQ(-1.0, ie);
-  EXPECT_EQ(2.0, cmd);
+  EXPECT_FALSE(boost::math::isinf(ie));
+  EXPECT_FALSE(boost::math::isnan(cmd));
 
   cmd = pid.updatePid(-1.0, ros::Duration(1.0));
   pid.getCurrentPIDErrors(&pe,&ie,&de);
-  EXPECT_EQ(-2.0, ie);
-  EXPECT_EQ(2.0, cmd);
+  EXPECT_FALSE(boost::math::isinf(ie));
+  EXPECT_FALSE(boost::math::isnan(cmd));
+}
+
+TEST(ParameterTest, integrationWindupTest)
+{
+  RecordProperty("description","This test succeeds if the integral error is prevented from winding up when the integral gain is non-zero.");
+
+  Pid pid(0.0, 1.0, 0.0, 1.0, -1.0);
+
+  double cmd = 0.0;
+  double pe,ie,de;
+
+  cmd = pid.updatePid(-1.0, ros::Duration(1.0));
+  pid.getCurrentPIDErrors(&pe,&ie,&de);
+  EXPECT_EQ(-1.0, ie);
+  EXPECT_EQ(1.0, cmd);
+
+  cmd = pid.updatePid(-1.0, ros::Duration(1.0));
+  pid.getCurrentPIDErrors(&pe,&ie,&de);
+  EXPECT_EQ(-1.0, ie);
+  EXPECT_EQ(1.0, cmd);
+}
+
+TEST(ParameterTest, integrationWindupZeroGainTest)
+{
+  RecordProperty("description","This test succeeds if the integral error is prevented from winding up when the integral gain is zero. If the integral error is allowed to wind up while it is disabled, it can cause sudden jumps to the minimum or maximum bound in control command when re-enabled.");
+
+  double i_gain = 0.0;
+  double i_min = -1.0;
+  double i_max = 1.0;
+  Pid pid(0.0, i_gain, 0.0, i_max, i_min);
+
+  double cmd = 0.0;
+  double pe,ie,de;
+
+  cmd = pid.updatePid(-1.0, ros::Duration(1.0));
+  pid.getCurrentPIDErrors(&pe,&ie,&de);
+  EXPECT_LE(i_min, ie);
+  EXPECT_LE(ie, i_max);
+  EXPECT_EQ(0.0, cmd);
+
+  cmd = pid.updatePid(-1.0, ros::Duration(1.0));
+  pid.getCurrentPIDErrors(&pe,&ie,&de);
+  EXPECT_LE(i_min, ie);
+  EXPECT_LE(ie, i_max);
+  EXPECT_EQ(0.0, cmd);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
There are some strange corner-cases with the way the `control_toolbox:Pid` class deals with integral term. These tests expose them.
