### PR TITLE
Fixing backwards-compatibility in updatePid() 

### DIFF
--- a/control_toolbox/include/control_toolbox/pid.h
+++ b/control_toolbox/include/control_toolbox/pid.h
@@ -218,9 +218,7 @@ public:
   double setError(double error, double error_dot, ros::Duration dt);
 
   /*!
-   * \brief Update the Pid loop with nonuniform time step size. NOTE: this
-   * function is equivalent to calling \ref setError with a negated return
-   * value.
+   * \brief Update the Pid loop with nonuniform time step size.  
    *
    * \deprecated This function assumes <tt> p_error = (state - target) </tt>
    * which is an unconventional definition of the error. Please use \ref
@@ -235,9 +233,7 @@ public:
 
   /*!
    * \brief Update the Pid loop with nonuniform time step size. This update
-   * call allows the user to pass in a precomputed derivative error. NOTE: this
-   * function is equivalent to calling \ref setError with a negated return
-   * value.
+   * call allows the user to pass in a precomputed derivative error.  
    *
    * \deprecated This function assumes <tt> p_error = (state - target) </tt>
    * which is an unconventional definition of the error. Please use \ref

--- a/control_toolbox/include/control_toolbox/pid.h
+++ b/control_toolbox/include/control_toolbox/pid.h
@@ -219,12 +219,14 @@ public:
 
   /*!
    * \brief Update the Pid loop with nonuniform time step size. NOTE: this
-   * function is equivalent to calling \ref setError with negated error
-   * arguments.
+   * function is equivalent to calling \ref setError with a negated return
+   * value.
    *
-   * \deprecated This function assumes <tt> p_error = (state - target) </tt> which is an
-   * unconventional definition of the error. Please use \ref setError instead,
-   * which assumes <tt> error = (target - state) </tt>.
+   * \deprecated This function assumes <tt> p_error = (state - target) </tt>
+   * which is an unconventional definition of the error. Please use \ref
+   * setError instead, which assumes <tt> error = (target - state) </tt>. Note
+   * that calls to \ref setError should not be mixed with calls to \ref
+   * updatePid.
    *
    * \param p_error  Error since last call (p_state-p_target)
    * \param dt Change in time since last call
@@ -232,14 +234,16 @@ public:
   ROS_DEPRECATED double updatePid(double p_error, ros::Duration dt);
 
   /*!
-   * \brief Update the Pid loop with nonuniform time step size. This update call 
-   * allows the user to pass in a precomputed derivative error. NOTE: this
-   * function is equivalent to calling \ref setError with negated error
-   * arguments.
+   * \brief Update the Pid loop with nonuniform time step size. This update
+   * call allows the user to pass in a precomputed derivative error. NOTE: this
+   * function is equivalent to calling \ref setError with a negated return
+   * value.
    *
-   * \deprecated This function assumes <tt> p_error = (state - target) </tt> which is an
-   * unconventional definition of the error. Please use \ref setError instead,
-   * which assumes <tt> error = (target - state) </tt>.
+   * \deprecated This function assumes <tt> p_error = (state - target) </tt>
+   * which is an unconventional definition of the error. Please use \ref
+   * setError instead, which assumes <tt> error = (target - state) </tt>. Note
+   * that calls to \ref setError should not be mixed with calls to \ref
+   * updatePid.
    *
    * \param error  Error since last call (p_state-p_target)
    * \param error_dot d(Error)/dt since last call

--- a/control_toolbox/src/pid.cpp
+++ b/control_toolbox/src/pid.cpp
@@ -171,7 +171,7 @@ double Pid::setError(double error, ros::Duration dt)
 
 double Pid::updatePid(double error, ros::Duration dt)
 {
-  return this->setError(-1.0*error, dt);
+  return -1.0*(this->setError(error, dt));
 }
 
 double Pid::setError(double error, double error_dot, ros::Duration dt)
@@ -214,7 +214,7 @@ double Pid::setError(double error, double error_dot, ros::Duration dt)
 
 double Pid::updatePid(double error, double error_dot, ros::Duration dt)
 {
-  return this->setError(-1.0*error, -1.0*error_dot, dt);
+  return -1.0*(this->setError(error, error_dot, dt));
 }
 
 


### PR DESCRIPTION
This makes the internal computations (like the error term of updatePid() keep the same sign that they did before the API change by bringing back the old updatePid() function contents.

Of course mixing calls to `updatePid()` and `setError()` will mess with the value of the integral gain and the derivative computation (anything that depends on the state), so I also added some warnings about that in the documentation.

This regression was detected by the new tests.
