### PR TITLE
Adding alternative name for new pid command computation API

### DIFF
--- a/control_toolbox/include/control_toolbox/pid.h
+++ b/control_toolbox/include/control_toolbox/pid.h
@@ -202,7 +202,7 @@ public:
    *
    * \returns PID command
    */
-  double setError(double error, ros::Duration dt);
+  double computeCommand(double error, ros::Duration dt);
 
   /*!
    * \brief Set the PID error and compute the PID command with nonuniform
@@ -215,7 +215,7 @@ public:
    *
    * \returns PID command
    */
-  double setError(double error, double error_dot, ros::Duration dt);
+  double computeCommand(double error, double error_dot, ros::Duration dt);
 
   /*!
    * \brief Update the Pid loop with nonuniform time step size.  

--- a/control_toolbox/src/pid.cpp
+++ b/control_toolbox/src/pid.cpp
@@ -127,7 +127,7 @@ bool Pid::init(const ros::NodeHandle &node)
   return true;
 }
 
-double Pid::setError(double error, ros::Duration dt)
+double Pid::computeCommand(double error, ros::Duration dt)
 {
   double p_term, d_term, i_term;
   p_error_ = error; //this is pError = pState-pTarget
@@ -211,7 +211,7 @@ double Pid::updatePid(double error, ros::Duration dt)
   return cmd_;
 }
 
-double Pid::setError(double error, double error_dot, ros::Duration dt)
+double Pid::computeCommand(double error, double error_dot, ros::Duration dt)
 {
   double p_term, d_term, i_term;
   p_error_ = error; //this is pError = pState-pTarget


### PR DESCRIPTION
This is an alternative name for the new PID command computation API as per the discussion here: https://github.com/willowgarage/ros_controllers/issues/2

Specifically, it makes the new function, which is to replace `updatePid()` called `computeCommand()` since its primary function is to compute the PID output.
