### PR TITLE
Alternative fix to getControllersByName mutex-locking requirements

### DIFF
--- a/controller_manager/include/controller_manager/controller_manager.h
+++ b/controller_manager/include/controller_manager/controller_manager.h
@@ -161,7 +161,6 @@ public:
   /*\}*/
 
 protected:
-  // controllers_lock_ must be locked before calling
   virtual controller_interface::ControllerBase* getControllerByNameImpl(const std::string& name);
 
 private:
@@ -186,7 +185,9 @@ private:
    * The controllers list is double-buffered to avoid needing to lock the
    * real-time thread when switching controllers in the non-real-time thread.
    *\{*/
-  boost::mutex controllers_lock_;
+  /// Mutex protecting the current controllers list
+  boost::recursive_mutex controllers_lock_;
+  /// Double-buffered controllers list
   std::vector<ControllerSpec> controllers_lists_[2];
   /// The index of the current controllers list
   int current_controllers_list_;

--- a/controller_manager/include/controller_manager/controller_manager.h
+++ b/controller_manager/include/controller_manager/controller_manager.h
@@ -141,8 +141,12 @@ public:
                         const std::vector<std::string>& stop_controllers,
                         const int strictness);
 
-  /// Get a controller by name.
-  controller_interface::ControllerBase* getControllerByName(const std::string& name);
+  /** \brief Get a controller by name.
+   *
+   * \param name The name of a controller 
+   * \returns An up-casted pointer to the controller identified by \c name 
+   */
+  virtual controller_interface::ControllerBase* getControllerByName(const std::string& name);
 
   /** \brief Register a controller loader.
    *
@@ -160,8 +164,6 @@ public:
   void registerControllerLoader(boost::shared_ptr<ControllerLoaderInterface> controller_loader);
   /*\}*/
 
-protected:
-  virtual controller_interface::ControllerBase* getControllerByNameImpl(const std::string& name);
 
 private:
   void getControllerNames(std::vector<std::string> &v);
@@ -215,12 +217,6 @@ private:
   ros::ServiceServer srv_unload_controller_, srv_switch_controller_, srv_reload_libraries_;
   /*\}*/
 };
-
-inline controller_interface::ControllerBase* ControllerManager::getControllerByName(const std::string& name)
-{
-  boost::mutex::scoped_lock guard(controllers_lock_);
-  return getControllerByNameImpl(name);
-}
 
 }
 #endif

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -110,6 +110,9 @@ void ControllerManager::update(const ros::Time& time, const ros::Duration& perio
 
 controller_interface::ControllerBase* ControllerManager::getControllerByNameImpl(const std::string& name)
 {
+  // Lock recursive mutex in this context
+  boost::mutex::scoped_lock guard(controllers_lock_);
+
   std::vector<ControllerSpec> &controllers = controllers_lists_[current_controllers_list_];
   for (size_t i = 0; i < controllers.size(); ++i)
   {

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -108,10 +108,10 @@ void ControllerManager::update(const ros::Time& time, const ros::Duration& perio
   }
 }
 
-controller_interface::ControllerBase* ControllerManager::getControllerByNameImpl(const std::string& name)
+controller_interface::ControllerBase* ControllerManager::getControllerByName(const std::string& name)
 {
   // Lock recursive mutex in this context
-  boost::mutex::scoped_lock guard(controllers_lock_);
+  boost::recursive_mutex::scoped_lock guard(controllers_lock_);
 
   std::vector<ControllerSpec> &controllers = controllers_lists_[current_controllers_list_];
   for (size_t i = 0; i < controllers.size(); ++i)
@@ -124,7 +124,7 @@ controller_interface::ControllerBase* ControllerManager::getControllerByNameImpl
 
 void ControllerManager::getControllerNames(std::vector<std::string> &names)
 {
-  boost::mutex::scoped_lock guard(controllers_lock_);
+  boost::recursive_mutex::scoped_lock guard(controllers_lock_);
   std::vector<ControllerSpec> &controllers = controllers_lists_[current_controllers_list_];
   for (size_t i = 0; i < controllers.size(); ++i)
   {
@@ -138,7 +138,7 @@ bool ControllerManager::loadController(const std::string& name)
   ROS_DEBUG("Will load controller '%s'", name.c_str());
 
   // lock controllers
-  boost::mutex::scoped_lock guard(controllers_lock_);
+  boost::recursive_mutex::scoped_lock guard(controllers_lock_);
 
   // get reference to controller list
   int free_controllers_list = (current_controllers_list_ + 1) % 2;
@@ -274,7 +274,7 @@ bool ControllerManager::unloadController(const std::string &name)
   ROS_DEBUG("Will unload controller '%s'", name.c_str());
 
   // lock the controllers
-  boost::mutex::scoped_lock guard(controllers_lock_);
+  boost::recursive_mutex::scoped_lock guard(controllers_lock_);
 
   // get reference to controller list
   int free_controllers_list = (current_controllers_list_ + 1) % 2;
@@ -354,13 +354,13 @@ bool ControllerManager::switchController(const std::vector<std::string>& start_c
     ROS_DEBUG(" - stopping controller %s", stop_controllers[i].c_str());
 
   // lock controllers
-  boost::mutex::scoped_lock guard(controllers_lock_);
+  boost::recursive_mutex::scoped_lock guard(controllers_lock_);
 
   controller_interface::ControllerBase* ct;
   // list all controllers to stop
   for (unsigned int i=0; i<stop_controllers.size(); i++)
   {
-    ct = getControllerByNameImpl(stop_controllers[i]);
+    ct = getControllerByName(stop_controllers[i]);
     if (ct == NULL){
       if (strictness ==  controller_manager_msgs::SwitchController::Request::STRICT){
         ROS_ERROR("Could not stop controller with name %s because no controller with this name exists",
@@ -384,7 +384,7 @@ bool ControllerManager::switchController(const std::vector<std::string>& start_c
   // list all controllers to start
   for (unsigned int i=0; i<start_controllers.size(); i++)
   {
-    ct = getControllerByNameImpl(start_controllers[i]);
+    ct = getControllerByName(start_controllers[i]);
     if (ct == NULL){
       if (strictness ==  controller_manager_msgs::SwitchController::Request::STRICT){
         ROS_ERROR("Could not start controller with name %s because no controller with this name exists",
@@ -554,7 +554,7 @@ bool ControllerManager::listControllersSrv(
   ROS_DEBUG("list controller service locked");
 
   // lock controllers to get all names/types/states
-  boost::mutex::scoped_lock controller_guard(controllers_lock_);
+  boost::recursive_mutex::scoped_lock controller_guard(controllers_lock_);
   std::vector<ControllerSpec> &controllers = controllers_lists_[current_controllers_list_];
   resp.controller.resize(controllers.size());
 


### PR DESCRIPTION
`ControllerManager::getControllerByName()` requires that the `controllers_lock_` is locked. 

There was a previous fix to this implemented [here](https://github.com/willowgarage/ros_control/pull/15#issuecomment-13596141) but instead of having a public and protected function, it could alternatively be solved by using a reentrant / recursive mutex instead of a unique mutex. This could keep the API a little cleaner, and also allow for more convenience functions like `getControllerByName()`.
