### PR TITLE
Rename TransmissionException class

### DIFF
--- a/transmission_interface/include/transmission_interface/differential_transmission.h
+++ b/transmission_interface/include/transmission_interface/differential_transmission.h
@@ -35,7 +35,7 @@
 #include <vector>
 
 #include <transmission_interface/transmission.h>
-#include <transmission_interface/transmission_exception.h>
+#include <transmission_interface/transmission_interface_exception.h>
 
 namespace transmission_interface
 {
@@ -206,7 +206,7 @@ inline DifferentialTransmission::DifferentialTransmission(const std::vector<doub
       2 != jnt_reduction_.size()   ||
       2 != jnt_offset_.size())
   {
-    throw TransmissionException("Reduction and offset vectors of a differential transmission must have size 2.");
+    throw TransmissionInterfaceException("Reduction and offset vectors of a differential transmission must have size 2.");
   }
 
   if (0.0 == actuator_reduction[0] ||
@@ -215,7 +215,7 @@ inline DifferentialTransmission::DifferentialTransmission(const std::vector<doub
       0.0 == jnt_reduction_[1]
   )
   {
-    throw TransmissionException("Transmission reduction ratios cannot be zero.");
+    throw TransmissionInterfaceException("Transmission reduction ratios cannot be zero.");
   }
 }
 

--- a/transmission_interface/include/transmission_interface/four_bar_linkage_transmission.h
+++ b/transmission_interface/include/transmission_interface/four_bar_linkage_transmission.h
@@ -36,7 +36,7 @@
 #include <vector>
 
 #include <transmission_interface/transmission.h>
-#include <transmission_interface/transmission_exception.h>
+#include <transmission_interface/transmission_interface_exception.h>
 
 namespace transmission_interface
 {
@@ -200,12 +200,12 @@ inline FourBarLinkageTransmission::FourBarLinkageTransmission(const std::vector<
   if (2 != actuator_reduction.size() ||
       2 != jnt_offset_.size())
   {
-    throw TransmissionException("Reduction and offset vectors of a four-bar linkage transmission must have size 2.");
+    throw TransmissionInterfaceException("Reduction and offset vectors of a four-bar linkage transmission must have size 2.");
   }
   if (0.0 == actuator_reduction[0] ||
       0.0 == actuator_reduction[1])
   {
-    throw TransmissionException("Transmission reduction ratios cannot be zero.");
+    throw TransmissionInterfaceException("Transmission reduction ratios cannot be zero.");
   }
 }
 

--- a/transmission_interface/include/transmission_interface/simple_transmission.h
+++ b/transmission_interface/include/transmission_interface/simple_transmission.h
@@ -35,7 +35,7 @@
 #include <vector>
 
 #include <transmission_interface/transmission.h>
-#include <transmission_interface/transmission_exception.h>
+#include <transmission_interface/transmission_interface_exception.h>
 
 namespace transmission_interface
 {
@@ -177,7 +177,7 @@ inline SimpleTransmission::SimpleTransmission(const double reduction,
 {
   if (0.0 == reduction_)
   {
-    throw TransmissionException("Transmission reduction ratio cannot be zero.");
+    throw TransmissionInterfaceException("Transmission reduction ratio cannot be zero.");
   }
 }
 

--- a/transmission_interface/include/transmission_interface/transmission_interface.h
+++ b/transmission_interface/include/transmission_interface/transmission_interface.h
@@ -35,7 +35,7 @@
 #include <vector>
 
 #include <transmission_interface/transmission.h>
-#include <transmission_interface/transmission_exception.h>
+#include <transmission_interface/transmission_interface_exception.h>
 
 namespace transmission_interface
 {
@@ -78,68 +78,68 @@ protected:
     // Precondition: Valid transmission
     if (!transmission_)
     {
-      throw TransmissionException("Unspecified transmission.");
+      throw TransmissionInterfaceException("Unspecified transmission.");
     }
 
     // Catch trivial error: All data vectors are empty (handle can't do anything without data)
     if (actuator_data.position.empty() && actuator_data.velocity.empty() && actuator_data.effort.empty() &&
         joint_data.position.empty() && joint_data.velocity.empty() && joint_data.effort.empty())
     {
-       throw TransmissionException("All data vectors are empty. Transmission instance can't do anything!.");
+       throw TransmissionInterfaceException("All data vectors are empty. Transmission instance can't do anything!.");
     }
 
     // Precondition: All non-empty data vectors must have sizes consistent with the transmission
     if (!actuator_data.position.empty() && actuator_data.position.size() != transmission_->numActuators())
     {
-      throw TransmissionException("Actuator position data size does not match transmission.");
+      throw TransmissionInterfaceException("Actuator position data size does not match transmission.");
     }
     if (!actuator_data.velocity.empty() && actuator_data.velocity.size() != transmission_->numActuators())
     {
-      throw TransmissionException("Actuator velocity data size does not match transmission.");
+      throw TransmissionInterfaceException("Actuator velocity data size does not match transmission.");
     }
     if (!actuator_data.effort.empty() && actuator_data.effort.size() != transmission_->numActuators())
     {
-      throw TransmissionException("Actuator effort data size does not match transmission.");
+      throw TransmissionInterfaceException("Actuator effort data size does not match transmission.");
     }
 
     if (!joint_data.position.empty() && joint_data.position.size() != transmission_->numJoints())
     {
-      throw TransmissionException("Joint position data size does not match transmission.");
+      throw TransmissionInterfaceException("Joint position data size does not match transmission.");
     }
     if (!joint_data.velocity.empty() && joint_data.velocity.size() != transmission_->numJoints())
     {
-      throw TransmissionException("Joint velocity data size does not match transmission.");
+      throw TransmissionInterfaceException("Joint velocity data size does not match transmission.");
     }
     if (!joint_data.effort.empty() && joint_data.effort.size() != transmission_->numJoints())
     {
-      throw TransmissionException("Joint effort data size does not match transmission.");
+      throw TransmissionInterfaceException("Joint effort data size does not match transmission.");
     }
 
     // Precondition: Valid pointers to raw data
     if (!hasValidPointers(actuator_data.position))
     {
-      throw TransmissionException("Actuator position data contains null pointers.");
+      throw TransmissionInterfaceException("Actuator position data contains null pointers.");
     }
     if (!hasValidPointers(actuator_data.velocity))
     {
-      throw TransmissionException("Actuator velocity data contains null pointers.");
+      throw TransmissionInterfaceException("Actuator velocity data contains null pointers.");
     }
     if (!hasValidPointers(actuator_data.effort))
     {
-      throw TransmissionException("Actuator effort data contains null pointers.");
+      throw TransmissionInterfaceException("Actuator effort data contains null pointers.");
     }
 
     if (!hasValidPointers(joint_data.position))
     {
-      throw TransmissionException("Joint position data contains null pointers.");
+      throw TransmissionInterfaceException("Joint position data contains null pointers.");
     }
     if (!hasValidPointers(joint_data.velocity))
     {
-      throw TransmissionException("Joint velocity data contains null pointers.");
+      throw TransmissionInterfaceException("Joint velocity data contains null pointers.");
     }
     if (!hasValidPointers(joint_data.effort))
     {
-      throw TransmissionException("Joint effort data contains null pointers.");
+      throw TransmissionInterfaceException("Joint effort data contains null pointers.");
     }
   }
 
@@ -380,7 +380,7 @@ public:
     typename HandleMap::const_iterator it = handle_map_.find(name);
     if (it == handle_map_.end())
     {
-      throw TransmissionException("Could not find transmission [" + name + "].");
+      throw TransmissionInterfaceException("Could not find transmission [" + name + "].");
     }
     return it->second;
   }

--- a/transmission_interface/include/transmission_interface/transmission_interface_exception.h
+++ b/transmission_interface/include/transmission_interface/transmission_interface_exception.h
@@ -1,4 +1,3 @@
- 
 ///////////////////////////////////////////////////////////////////////////////
 // Copyright (C) 2013, PAL Robotics S.L.
 //
@@ -26,19 +25,19 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //////////////////////////////////////////////////////////////////////////////
 
-#ifndef TRANSMISSION_INTERFACE_TRANSMISSION_EXCEPTION_H
-#define TRANSMISSION_INTERFACE_TRANSMISSION_EXCEPTION_H
+#ifndef TRANSMISSION_INTERFACE_TRANSMISSION_INTERFACE_EXCEPTION_H
+#define TRANSMISSION_INTERFACE_TRANSMISSION_INTERFACE_EXCEPTION_H
 
 #include <exception>
 
 namespace transmission_interface
 {
 
-class TransmissionException: public std::exception
+class TransmissionInterfaceException: public std::exception
 {
 public:
-  TransmissionException(const std::string& message) : msg(message) {}
-  virtual ~TransmissionException() throw() {}
+  TransmissionInterfaceException(const std::string& message) : msg(message) {}
+  virtual ~TransmissionInterfaceException() throw() {}
   virtual const char* what() const throw() {return msg.c_str();}
 private:
   std::string msg;
@@ -46,4 +45,4 @@ private:
 
 } // transmission_interface
 
-#endif // TRANSMISSION_INTERFACE_TRANSMISSION_EXCEPTION_H
+#endif // TRANSMISSION_INTERFACE_TRANSMISSION_INTERFACE_EXCEPTION_H

--- a/transmission_interface/test/differential_transmission_test.cpp
+++ b/transmission_interface/test/differential_transmission_test.cpp
@@ -47,28 +47,28 @@ TEST(PreconditionsTest, ExceptionThrowing)
   vector<double> offset_good(2, 1.0);
 
   // Invalid instance creation: Transmission cannot have zero reduction
-  EXPECT_THROW(DifferentialTransmission(reduction_bad1, reduction_good), TransmissionException);
-  EXPECT_THROW(DifferentialTransmission(reduction_bad2, reduction_good), TransmissionException);
-  EXPECT_THROW(DifferentialTransmission(reduction_bad3, reduction_good), TransmissionException);
+  EXPECT_THROW(DifferentialTransmission(reduction_bad1, reduction_good), TransmissionInterfaceException);
+  EXPECT_THROW(DifferentialTransmission(reduction_bad2, reduction_good), TransmissionInterfaceException);
+  EXPECT_THROW(DifferentialTransmission(reduction_bad3, reduction_good), TransmissionInterfaceException);
 
-  EXPECT_THROW(DifferentialTransmission(reduction_good, reduction_bad1), TransmissionException);
-  EXPECT_THROW(DifferentialTransmission(reduction_good, reduction_bad2), TransmissionException);
-  EXPECT_THROW(DifferentialTransmission(reduction_good, reduction_bad3), TransmissionException);
+  EXPECT_THROW(DifferentialTransmission(reduction_good, reduction_bad1), TransmissionInterfaceException);
+  EXPECT_THROW(DifferentialTransmission(reduction_good, reduction_bad2), TransmissionInterfaceException);
+  EXPECT_THROW(DifferentialTransmission(reduction_good, reduction_bad3), TransmissionInterfaceException);
 
-  EXPECT_THROW(DifferentialTransmission(reduction_bad1, reduction_good, offset_good), TransmissionException);
-  EXPECT_THROW(DifferentialTransmission(reduction_bad2, reduction_good, offset_good), TransmissionException);
-  EXPECT_THROW(DifferentialTransmission(reduction_bad3, reduction_good, offset_good), TransmissionException);
+  EXPECT_THROW(DifferentialTransmission(reduction_bad1, reduction_good, offset_good), TransmissionInterfaceException);
+  EXPECT_THROW(DifferentialTransmission(reduction_bad2, reduction_good, offset_good), TransmissionInterfaceException);
+  EXPECT_THROW(DifferentialTransmission(reduction_bad3, reduction_good, offset_good), TransmissionInterfaceException);
 
-  EXPECT_THROW(DifferentialTransmission(reduction_good, reduction_bad1, offset_good), TransmissionException);
-  EXPECT_THROW(DifferentialTransmission(reduction_good, reduction_bad2, offset_good), TransmissionException);
-  EXPECT_THROW(DifferentialTransmission(reduction_good, reduction_bad3, offset_good), TransmissionException);
+  EXPECT_THROW(DifferentialTransmission(reduction_good, reduction_bad1, offset_good), TransmissionInterfaceException);
+  EXPECT_THROW(DifferentialTransmission(reduction_good, reduction_bad2, offset_good), TransmissionInterfaceException);
+  EXPECT_THROW(DifferentialTransmission(reduction_good, reduction_bad3, offset_good), TransmissionInterfaceException);
 
   // Invalid instance creation: Wrong parameter sizes
   vector<double> reduction_bad_size(1, 1.0);
   vector<double>& offset_bad_size = reduction_bad_size;
-  EXPECT_THROW(DifferentialTransmission(reduction_bad_size, reduction_good),              TransmissionException);
-  EXPECT_THROW(DifferentialTransmission(reduction_good, reduction_bad_size),              TransmissionException);
-  EXPECT_THROW(DifferentialTransmission(reduction_good, reduction_good, offset_bad_size), TransmissionException);
+  EXPECT_THROW(DifferentialTransmission(reduction_bad_size, reduction_good),              TransmissionInterfaceException);
+  EXPECT_THROW(DifferentialTransmission(reduction_good, reduction_bad_size),              TransmissionInterfaceException);
+  EXPECT_THROW(DifferentialTransmission(reduction_good, reduction_good, offset_bad_size), TransmissionInterfaceException);
 
   // Valid instance creation
   EXPECT_NO_THROW(DifferentialTransmission(reduction_good, reduction_good));
@@ -276,7 +276,7 @@ protected:
                                       randomVector(2, rand_gen));
         out.push_back(trans);
       }
-      catch(const TransmissionException&)
+      catch(const TransmissionInterfaceException&)
       {
         // NOTE: If by chance a perfect zero is produced by the random number generator, construction will fail
         // We swallow the exception and move on to prevent a test crash.

--- a/transmission_interface/test/four_bar_linkage_transmission_test.cpp
+++ b/transmission_interface/test/four_bar_linkage_transmission_test.cpp
@@ -47,16 +47,16 @@ TEST(PreconditionsTest, ExceptionThrowing)
   vector<double> offset_good(2, 1.0);
 
   // Invalid instance creation: Transmission cannot have zero reduction
-  EXPECT_THROW(FourBarLinkageTransmission trans(reduction_bad1), TransmissionException);
-  EXPECT_THROW(FourBarLinkageTransmission trans(reduction_bad2), TransmissionException);
-  EXPECT_THROW(FourBarLinkageTransmission trans(reduction_bad3), TransmissionException);
+  EXPECT_THROW(FourBarLinkageTransmission trans(reduction_bad1), TransmissionInterfaceException);
+  EXPECT_THROW(FourBarLinkageTransmission trans(reduction_bad2), TransmissionInterfaceException);
+  EXPECT_THROW(FourBarLinkageTransmission trans(reduction_bad3), TransmissionInterfaceException);
 
   // Invalid instance creation: Wrong parameter sizes
   vector<double> reduction_bad_size(1, 1.0);
   vector<double>& offset_bad_size = reduction_bad_size;
-  EXPECT_THROW(FourBarLinkageTransmission trans(reduction_bad_size),        TransmissionException);
-  EXPECT_THROW(FourBarLinkageTransmission(reduction_good, offset_bad_size), TransmissionException);
-  EXPECT_THROW(FourBarLinkageTransmission(reduction_bad_size, offset_good), TransmissionException);
+  EXPECT_THROW(FourBarLinkageTransmission trans(reduction_bad_size),        TransmissionInterfaceException);
+  EXPECT_THROW(FourBarLinkageTransmission(reduction_good, offset_bad_size), TransmissionInterfaceException);
+  EXPECT_THROW(FourBarLinkageTransmission(reduction_bad_size, offset_good), TransmissionInterfaceException);
 
   // Valid instance creation
   EXPECT_NO_THROW(FourBarLinkageTransmission trans(reduction_good));
@@ -262,7 +262,7 @@ protected:
                                          randomVector(2, rand_gen));
         out.push_back(trans);
       }
-      catch(const TransmissionException&)
+      catch(const TransmissionInterfaceException&)
       {
         // NOTE: If by chance a perfect zero is produced by the random number generator, construction will fail
         // We swallow the exception and move on to prevent a test crash.

--- a/transmission_interface/test/simple_transmission_test.cpp
+++ b/transmission_interface/test/simple_transmission_test.cpp
@@ -42,9 +42,9 @@ const double EPS = 1e-6;
 TEST(PreconditionsTest, ExceptionThrowing)
 {
   // Invalid instance creation: Transmission cannot have zero reduction
-  EXPECT_THROW(SimpleTransmission(0.0),       TransmissionException);
-  EXPECT_THROW(SimpleTransmission(0.0,  1.0), TransmissionException);
-  EXPECT_THROW(SimpleTransmission(0.0, -1.0), TransmissionException);
+  EXPECT_THROW(SimpleTransmission(0.0),       TransmissionInterfaceException);
+  EXPECT_THROW(SimpleTransmission(0.0,  1.0), TransmissionInterfaceException);
+  EXPECT_THROW(SimpleTransmission(0.0, -1.0), TransmissionInterfaceException);
 
   // Valid instance creation
   EXPECT_NO_THROW(SimpleTransmission( 1.0));

--- a/transmission_interface/test/transmission_interface_test.cpp
+++ b/transmission_interface/test/transmission_interface_test.cpp
@@ -117,37 +117,37 @@ TEST(HandlePreconditionsTest, BadSize)
     ActuatorData a_data;
     JointData    j_data;
     a_data.position = bad_size_vector;
-    EXPECT_THROW(DummyHandle("trans", &trans, a_data, j_data), TransmissionException);
+    EXPECT_THROW(DummyHandle("trans", &trans, a_data, j_data), TransmissionInterfaceException);
   }
   {
     ActuatorData a_data;
     JointData    j_data;
     a_data.velocity = bad_size_vector;
-    EXPECT_THROW(DummyHandle("trans", &trans, a_data, j_data), TransmissionException);
+    EXPECT_THROW(DummyHandle("trans", &trans, a_data, j_data), TransmissionInterfaceException);
   }
   {
     ActuatorData a_data;
     JointData    j_data;
     a_data.effort = bad_size_vector;
-    EXPECT_THROW(DummyHandle("trans", &trans, a_data, j_data), TransmissionException);
+    EXPECT_THROW(DummyHandle("trans", &trans, a_data, j_data), TransmissionInterfaceException);
   }
   {
     ActuatorData a_data;
     JointData    j_data;
     j_data.position = bad_size_vector;
-    EXPECT_THROW(DummyHandle("trans", &trans, a_data, j_data), TransmissionException);
+    EXPECT_THROW(DummyHandle("trans", &trans, a_data, j_data), TransmissionInterfaceException);
   }
   {
     ActuatorData a_data;
     JointData    j_data;
     j_data.velocity = bad_size_vector;
-    EXPECT_THROW(DummyHandle("trans", &trans, a_data, j_data), TransmissionException);
+    EXPECT_THROW(DummyHandle("trans", &trans, a_data, j_data), TransmissionInterfaceException);
   }
   {
     ActuatorData a_data;
     JointData    j_data;
     j_data.effort = bad_size_vector;
-    EXPECT_THROW(DummyHandle("trans", &trans, a_data, j_data), TransmissionException);
+    EXPECT_THROW(DummyHandle("trans", &trans, a_data, j_data), TransmissionInterfaceException);
   }
 }
 
@@ -155,7 +155,7 @@ TEST(HandlePreconditionsTest, EmptyData)
 {
   SimpleTransmission trans(1.0);
 
-  EXPECT_THROW(DummyHandle("trans", &trans, ActuatorData(), JointData()), TransmissionException);
+  EXPECT_THROW(DummyHandle("trans", &trans, ActuatorData(), JointData()), TransmissionInterfaceException);
 }
 
 TEST(HandlePreconditionsTest, BadTransmissionPointer)
@@ -167,7 +167,7 @@ TEST(HandlePreconditionsTest, BadTransmissionPointer)
   a_data.position = good_vec;
   j_data.position = good_vec;
 
-  EXPECT_THROW(DummyHandle("trans", 0, a_data, j_data), TransmissionException);
+  EXPECT_THROW(DummyHandle("trans", 0, a_data, j_data), TransmissionInterfaceException);
 }
 
 TEST(HandlePreconditionsTest, BadDataPointer)
@@ -179,37 +179,37 @@ TEST(HandlePreconditionsTest, BadDataPointer)
     ActuatorData a_data;
     JointData    j_data;
     a_data.position = bad_ptr_vector;
-    EXPECT_THROW(DummyHandle("trans", &trans, a_data, j_data), TransmissionException);
+    EXPECT_THROW(DummyHandle("trans", &trans, a_data, j_data), TransmissionInterfaceException);
   }
   {
     ActuatorData a_data;
     JointData    j_data;
     a_data.velocity = bad_ptr_vector;
-    EXPECT_THROW(DummyHandle("trans", &trans, a_data, j_data), TransmissionException);
+    EXPECT_THROW(DummyHandle("trans", &trans, a_data, j_data), TransmissionInterfaceException);
   }
   {
     ActuatorData a_data;
     JointData    j_data;
     a_data.effort = bad_ptr_vector;
-    EXPECT_THROW(DummyHandle("trans", &trans, a_data, j_data), TransmissionException);
+    EXPECT_THROW(DummyHandle("trans", &trans, a_data, j_data), TransmissionInterfaceException);
   }
   {
     ActuatorData a_data;
     JointData    j_data;
     j_data.position = bad_ptr_vector;
-    EXPECT_THROW(DummyHandle("trans", &trans, a_data, j_data), TransmissionException);
+    EXPECT_THROW(DummyHandle("trans", &trans, a_data, j_data), TransmissionInterfaceException);
   }
   {
     ActuatorData a_data;
     JointData    j_data;
     j_data.velocity = bad_ptr_vector;
-    EXPECT_THROW(DummyHandle("trans", &trans, a_data, j_data), TransmissionException);
+    EXPECT_THROW(DummyHandle("trans", &trans, a_data, j_data), TransmissionInterfaceException);
   }
   {
     ActuatorData a_data;
     JointData    j_data;
     j_data.effort = bad_ptr_vector;
-    EXPECT_THROW(DummyHandle("trans", &trans, a_data, j_data), TransmissionException);
+    EXPECT_THROW(DummyHandle("trans", &trans, a_data, j_data), TransmissionInterfaceException);
   }
 }
 
@@ -618,7 +618,7 @@ TEST_F(AccessorTest, AccessorValidation)
   ActuatorToJointPositionHandle trans_handle2 = trans_iface.getTransmissionHandle(trans_names[1]);
   EXPECT_EQ(trans_names[1], trans_handle2.getName());
 
-  EXPECT_THROW(trans_iface.getTransmissionHandle("unregistered_name"), TransmissionException);
+  EXPECT_THROW(trans_iface.getTransmissionHandle("unregistered_name"), TransmissionInterfaceException);
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
Rename TransmissionException to TransmissionInterfaceException. It is more
verbose, but more consistent with the existing HardwareInterfaceException.
