### PR TITLE
Fix exception throwing logic.

### DIFF
--- a/hardware_interface/include/hardware_interface/internal/named_resource_manager.h
+++ b/hardware_interface/include/hardware_interface/internal/named_resource_manager.h
@@ -28,6 +28,7 @@
 #ifndef HARDWARE_INTERFACE_INTERNAL_NAMED_RESOURCE_MANAGER_H
 #define HARDWARE_INTERFACE_INTERNAL_NAMED_RESOURCE_MANAGER_H
 
+#include <stdexcept>
 #include <string>
 #include <map>
 #include <vector>
@@ -88,7 +89,7 @@ public:
 
     if (it == resource_map_.end())
     {
-      throw;
+      throw std::invalid_argument("Could not find resource.");
     }
     return it->second;
   }


### PR DESCRIPTION
My previous pull request was using throw without arguments, which is used only for re-throwing, and since there was nothing to rethrow, terminate() was being called. Now a proper exception is thrown.

This reminds me that there should be more complete unit tests in place. I've started to write some for hardware_interface, but they're not complete yet. I'll try to get them to a decent state and submit a pull request.
