### PR TITLE
Added transmission parsing of XML/URDF files

### DIFF
--- a/transmission_interface/CMakeLists.txt
+++ b/transmission_interface/CMakeLists.txt
@@ -10,6 +10,8 @@ if(USE_ROSBUILD)
   set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin)
   set(LIBRARY_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/lib)
 
+  # TODO: add tranmission parser to ROSBUILD - I don't know how to use rosbuild
+
   rosbuild_add_gtest(simple_transmission_test           test/simple_transmission_test.cpp)
   rosbuild_add_gtest(differential_transmission_test     test/differential_transmission_test.cpp)
   rosbuild_add_gtest(four_bar_linkage_transmission_test test/four_bar_linkage_transmission_test.cpp)
@@ -26,13 +28,27 @@ else()
   # Load catkin and all dependencies required for this package
   find_package(catkin REQUIRED hardware_interface)
 
-  include_directories(include ${catkin_INCLUDE_DIRS})
+  ## Build 
+  include_directories(
+    include 
+    ${catkin_INCLUDE_DIRS}
+  )
+  link_directories(${catkin_LIBRARY_DIRS})
+
+  # Transmission Paraser Library
+  add_library(${PROJECT_NAME}_parser
+    src/transmission_parser.cpp
+  )
+  target_link_libraries(${PROJECT_NAME}_parser ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
   # Declare a catkin package
   catkin_package(
+    LIBRARIES
+      ${PROJECT_NAME}_parser
     INCLUDE_DIRS include
-    )
+  )
 
+  # Tests
   catkin_add_gtest(simple_transmission_test           test/simple_transmission_test.cpp)
   catkin_add_gtest(differential_transmission_test     test/differential_transmission_test.cpp)
   catkin_add_gtest(four_bar_linkage_transmission_test test/four_bar_linkage_transmission_test.cpp)

--- a/transmission_interface/include/transmission_interface/transmission_info.h
+++ b/transmission_interface/include/transmission_interface/transmission_info.h
@@ -1,0 +1,86 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2013, Open Source Robotics Foundation
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Open Source Robotics Foundation
+ *     nor the names of its contributors may be
+ *     used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/*
+  Author: Dave Coleman
+  Desc:   Structs to hold tranmission data loaded straight from XML (URDF)
+*/
+
+#ifndef TRANSMISSION_INTERFACE_INFO_H
+#define TRANSMISSION_INTERFACE_INFO_H
+
+#include <vector>
+#include <string>
+
+// XML
+#include <tinyxml.h>
+
+namespace transmission_interface
+{
+
+/** 
+ * \brief Contains semantic info about a given joint loaded from XML (URDF)
+ */
+struct JointInfo
+{
+  std::string name_;
+  std::string hardware_interface_;
+  std::string role_;
+  TiXmlElement* xml_element_;
+};
+
+/** 
+ * \brief Contains semantic info about a given actuator loaded from XML (URDF)
+ */
+struct ActuatorInfo {
+  std::string name_;
+  std::string hardware_interface_;
+  TiXmlElement* xml_element_;
+};
+
+/** 
+ * \brief Contains semantic info about a given transmission loaded from XML (URDF)
+ */
+struct TransmissionInfo
+{
+  std::string name_;
+  std::string type_;
+  std::vector<JointInfo> joints_;
+  std::vector<ActuatorInfo> actuators_;
+};
+
+} // namespace
+
+#endif

--- a/transmission_interface/include/transmission_interface/transmission_parser.h
+++ b/transmission_interface/include/transmission_interface/transmission_parser.h
@@ -1,0 +1,97 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2013, Open Source Robotics Foundation
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Open Source Robotics Foundation
+ *     nor the names of its contributors may be
+ *     used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* 
+   Author: Dave Coleman
+   Desc:   Parses <transmission> elements into corresponding structs from XML (URDF)
+*/
+
+// ros_control
+#include <transmission_interface/transmission_info.h>
+
+// ROS
+#include <ros/ros.h>
+
+// XML
+#include <tinyxml.h>
+
+namespace transmission_interface
+{
+
+class TransmissionParser
+{
+public:
+  /**
+   * @brief Constructor
+   */
+  TransmissionParser()
+  {
+  }
+
+  /**
+   * @brief Destructor
+   */
+  ~TransmissionParser()
+  {
+  }
+
+  /**
+   * @brief Parses the tranmission elements of a URDF
+   * @param urdf_string - XML string of a valid URDF file that contains <tranmission> elements
+   * @param transmissions - vector of loaded transmission meta data
+   * @return true if parsing was successful
+   */
+  static bool parse(const std::string& urdf_string, std::vector<TransmissionInfo>& transmissions);
+
+private:
+  /**
+   * @brief Parses the joint elements within tranmission elements of a URDF
+   * @param trans_it - pointer to the current XML element being parsed
+   * @param joints - resulting list of joints in the transmission
+   * @return true if successful
+   */
+  static bool parseJoints(TiXmlElement *trans_it, std::vector<JointInfo>& joints);
+
+  /**
+   * @brief Parses the actuator elements within tranmission elements of a URDF
+   * @param trans_it - pointer to the current XML element being parsed
+   * @param actuators - resulting list of actuators in the transmission
+   * @return true if successful
+   */
+  static bool parseActuators(TiXmlElement *trans_it, std::vector<ActuatorInfo>& actuators);
+
+}; // class
+
+} // namespace

--- a/transmission_interface/src/transmission_parser.cpp
+++ b/transmission_interface/src/transmission_parser.cpp
@@ -1,0 +1,221 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2013, Open Source Robotics Foundation
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Open Source Robotics Foundation
+ *     nor the names of its contributors may be
+ *     used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/*
+  Author: Dave Coleman
+  Desc:   Parses <transmission> elements into corresponding structs from XML (URDF)
+*/
+
+#include "transmission_interface/transmission_parser.h"
+
+namespace transmission_interface
+{
+
+bool TransmissionParser::parse(const std::string& urdf, std::vector<TransmissionInfo>& transmissions)
+{
+  // initialize TiXmlDocument doc with a string
+  TiXmlDocument doc;
+  if (!doc.Parse(urdf.c_str()) && doc.Error())
+  {
+    ROS_ERROR("Could not load the gazebo_ros_control plugin's"
+      " configuration file: %s\n", urdf.c_str());
+    return false;
+  }
+
+  // Debug
+  //doc.Print();
+  //std::cout << *(doc.RootElement()) << std::endl;
+
+  // Find joints in transmission tags
+  TiXmlElement *root = doc.RootElement();
+
+  // Constructs the transmissions by parsing custom xml.
+  TiXmlElement *trans_it = NULL;
+  for (trans_it = root->FirstChildElement("transmission"); trans_it;
+       trans_it = trans_it->NextSiblingElement("transmission"))
+  {
+    transmission_interface::TransmissionInfo transmission;
+
+    // Transmission name
+    if(trans_it->Attribute("name"))
+    {
+      transmission.name_ = trans_it->Attribute("name");
+    }
+    else
+    {
+      ROS_ERROR_STREAM_NAMED("parser","No name attribute for transmission tag!");
+      continue;
+    }
+
+    // Transmission type
+    TiXmlElement *type_child = trans_it->FirstChildElement("type");
+    if(!type_child)
+    {
+      ROS_ERROR_STREAM_NAMED("parser","No type element found for transmission "
+        << transmission.name_);
+      continue;
+    }
+    transmission.type_ = type_child->GetText();
+    if(transmission.type_.empty())
+    {
+      ROS_ERROR_STREAM_NAMED("parser","No type string found for transmission "
+        << transmission.name_);
+      continue;
+    }
+
+    // Load joints
+    if(!parseJoints(trans_it, transmission.joints_))
+    {
+      ROS_ERROR_STREAM_NAMED("parser","Failed to load joints for transmission "
+        << transmission.name_);
+      continue;
+    }
+
+    // Load actuators
+    if(!parseActuators(trans_it, transmission.actuators_))
+    {
+      ROS_ERROR_STREAM_NAMED("parser","Failed to load actuators for transmission "
+        << transmission.name_);
+      continue;
+    }
+    
+    // Save loaded transmission
+    transmissions.push_back(transmission);
+    
+  } // end for <transmission>
+
+  if( transmissions.empty() )
+  {
+    ROS_DEBUG_STREAM_NAMED("parser","No tranmissions found.");
+  }
+
+  return true;
+}
+
+bool TransmissionParser::parseJoints(TiXmlElement *trans_it, std::vector<JointInfo>& joints)
+{
+  // Loop through each available joint
+  TiXmlElement *joint_it = NULL;
+  for (joint_it = trans_it->FirstChildElement("joint"); joint_it;
+       joint_it = joint_it->NextSiblingElement("joint"))
+  {
+    // Create new joint
+    transmission_interface::JointInfo joint;
+
+    // Joint xml element
+    joint.xml_element_ = joint_it;
+
+    // Joint name
+    if(joint_it->Attribute("name"))
+    {
+      joint.name_ = joint_it->Attribute("name");
+    }
+    else
+    {
+      ROS_ERROR_STREAM_NAMED("parser","No name attribute for joint");
+      return false;
+    }
+
+    // \todo: implement other generic joint properties
+
+    // Add joint to vector
+    joints.push_back(joint);
+  }
+
+  if(joints.empty())
+  {
+    ROS_ERROR_STREAM_NAMED("parser","No joint element found");
+    return false;
+  }
+
+  return true;
+}
+
+bool TransmissionParser::parseActuators(TiXmlElement *trans_it, std::vector<ActuatorInfo>& actuators)
+{
+  // Loop through each available actuator
+  TiXmlElement *actuator_it = NULL;
+  for (actuator_it = trans_it->FirstChildElement("actuator"); actuator_it;
+       actuator_it = actuator_it->NextSiblingElement("actuator"))
+  {
+    // Create new actuator
+    transmission_interface::ActuatorInfo actuator;
+
+    // Actuator xml element
+    actuator.xml_element_ = actuator_it;
+
+    // Actuator name
+    if(actuator_it->Attribute("name"))
+    {
+      actuator.name_ = actuator_it->Attribute("name");
+    }
+    else
+    {
+      ROS_ERROR_STREAM_NAMED("parser","No name attribute for actuator");
+      return false;
+    }
+
+    // Hardware interface
+    TiXmlElement *hardware_interface_child = actuator_it->FirstChildElement("hardwareInterface");
+    if(!hardware_interface_child)
+    {
+      ROS_ERROR_STREAM_NAMED("parser","No hardware interface element found for actuator '"
+        << actuator.name_ << "'");
+      continue;
+    }
+    actuator.hardware_interface_ = hardware_interface_child->GetText();
+    if(actuator.hardware_interface_.empty())
+    {
+      ROS_ERROR_STREAM_NAMED("parser","No hardware interface string found for actuator '"
+        << actuator.name_ << "'");
+      continue;
+    }    
+
+    // \todo: implement other generic actuator properties
+
+    // Add actuator to vector
+    actuators.push_back(actuator);
+  }
+
+  if(actuators.empty())
+  {
+    ROS_ERROR_STREAM_NAMED("parser","No actuator element found");
+    return false;
+  }
+
+  return true;
+}
+
+} // namespace


### PR DESCRIPTION
This creates the data structures and parser to follow a transmission format outlined in the following two examples:

**Simple transmission**

``` xml
<transmission name="simple_trans">
  <type>transmission_interface/SimpleTransmission</type>
  <joint name="foo_joint"/>
  <actuator name="foo_motor">
    <hardwareInterface>EffortJointInterface</hardwareInterface>
    <mechanicalReduction>50</mechanicalReduction>
  </actuator>
</transmission>
```

**Finger**

``` xml
<transmission name="finger_trans">
  <type>transmission_interface/FingerTransmission</type>
  <joint name="f1_joint">
    <role>proximal_knuckle</role>
    <hardwareInterface>EffortJointInterface</hardwareInterface>
    <mechanicalReduction>3</mechanicalReduction>
  </joint>
  <joint name="f2_joint">
    <role>distal_knuckle</role>
    <hardwareInterface>EffortJointInterface</hardwareInterface>
    <mechanicalReduction>2</mechanicalReduction>
  </joint>
  <actuator name="finger_motor">
    <hardwareInterface>EffortJointInterface</hardwareInterface>
    <mechanicalReduction>50</mechanicalReduction>
  </actuator>
</transmission>
```

There's one TODO that needs to be done asap:

```
# TODO: add tranmission parser to ROSBUILD - I don't know how to use rosbuild
```
