### PR TITLE
Attempt to fix transmission interface tinyxml build error

### DIFF
--- a/transmission_interface/CMakeLists.txt
+++ b/transmission_interface/CMakeLists.txt
@@ -28,7 +28,9 @@ if(USE_ROSBUILD)
 else()
 
   # Load catkin and all dependencies required for this package
-  find_package(catkin REQUIRED hardware_interface)
+  find_package(catkin REQUIRED 
+    hardware_interface
+    )
 
   # Build
   include_directories(
@@ -41,13 +43,15 @@ else()
   add_library(${PROJECT_NAME}_parser
     src/transmission_parser.cpp
   )
-  target_link_libraries(${PROJECT_NAME}_parser ${catkin_LIBRARIES} tinyxml)
+  target_link_libraries(${PROJECT_NAME}_parser ${catkin_LIBRARIES} ${tinyxml_libraries} tinyxml)
 
   # Declare a catkin package
   catkin_package(
     DEPENDS tinyxml
-    LIBRARIES ${PROJECT_NAME}_parser
-    INCLUDE_DIRS include
+    LIBRARIES 
+      ${PROJECT_NAME}_parser
+    INCLUDE_DIRS 
+      include
   )
 
   # Tests
@@ -55,7 +59,7 @@ else()
   catkin_add_gtest(differential_transmission_test     test/differential_transmission_test.cpp)
   catkin_add_gtest(four_bar_linkage_transmission_test test/four_bar_linkage_transmission_test.cpp)
   catkin_add_gtest(transmission_interface_test        test/transmission_interface_test.cpp)
-  target_link_libraries(transmission_interface_test ${catkin_LIBRARIES})
+  target_link_libraries(transmission_interface_test ${catkin_LIBRARIES} ${tinyxml_libraries})
 
   # Install
   install(DIRECTORY include/${PROJECT_NAME}/


### PR DESCRIPTION
I'm not sure if this fixes the issue or not, I could not replicate the build failures on my computer.

Currently Jenkins says:

```
/tmp/buildd/ros-hydro-transmission-interface-0.5.0-0precise-20130719-0615/include/transmission_interface/transmission_info.h:48:21: fatal error: tinyxml.h: No such file or directory
```

@adolfo-rt 
