### PR TITLE
joint_limits_interface broken in Groocy and Hydro

### DIFF
--- a/joint_limits_interface/CMakeLists.txt
+++ b/joint_limits_interface/CMakeLists.txt
@@ -28,8 +28,14 @@ else()
   # Declare catkin package
   catkin_package(
     CATKIN_DEPENDS roscpp
-    INCLUDE_DIRS include
-    )
+    INCLUDE_DIRS
+      include
+      ${urdfdom_INCLUDE_DIRS}
+    LIBRARIES
+      ${urdfdom_LIBRARIES}
+  )
+
+  include_directories(SYSTEM ${urdfdom_INCLUDE_DIRS})
 
   catkin_add_gtest(joint_limits_interface_test test/joint_limits_interface_test.cpp)
   catkin_add_gtest(joint_limits_urdf_test      test/joint_limits_urdf_test.cpp)

--- a/joint_limits_interface/include/joint_limits_interface/joint_limits_urdf.h
+++ b/joint_limits_interface/include/joint_limits_interface/joint_limits_urdf.h
@@ -30,7 +30,12 @@
 #ifndef JOINT_LIMITS_INTERFACE_JOINT_LIMITS_URDF_H
 #define JOINT_LIMITS_INTERFACE_JOINT_LIMITS_URDF_H
 
-#include <urdf_interface/joint.h>
+#include <ros/common.h>
+#if ROS_VERSION_MINIMUM(1, 9, 0) // TODO: Deprecate this conditional when Fuerte support is EOL'd
+  #include <urdf_model/joint.h> // Fuerte.
+#else
+  #include <urdf_interface/joint.h> // Groovy and later
+#endif
 #include <joint_limits_interface/joint_limits.h>
 
 namespace joint_limits_interface

--- a/joint_limits_interface/manifest.xml
+++ b/joint_limits_interface/manifest.xml
@@ -10,6 +10,7 @@
   <depend package="roscpp" />
   <depend package="rostest" />
   <depend package="hardware_interface" />
+  <depend package="urdf_interface" />
 
   <export>
     <cpp cflags="-I${prefix}/include" />

--- a/joint_limits_interface/package.xml
+++ b/joint_limits_interface/package.xml
@@ -15,9 +15,11 @@
   <build_depend>rostest</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>hardware_interface</build_depend>
+  <build_depend>urdfdom</build_depend>
 
   <run_depend>roscpp</run_depend>
   <run_depend>hardware_interface</run_depend>
+  <run_depend>urdfdom</run_depend>
 
   <export>
     <cpp cflags="-I${prefix}/include"/>


### PR DESCRIPTION
Hey Groovy and Hydro folks,

I just realized that the `joint_limits_interface` package has a URDF dependency, which in Fuerte is `urdf_interface`, and since Groovy is `urdfdom`. Building the tests for this package should be broken ,as the dependency got removed in recent commits/merges. This PR should address the issue. Please review and accept if correct.

@jbohren, @davetcoleman
