### PR TITLE
Duplicated urdfdom's method of including tinyxml

### DIFF
--- a/transmission_interface/CMakeLists.txt
+++ b/transmission_interface/CMakeLists.txt
@@ -32,14 +32,17 @@ else()
     hardware_interface
   )
 
-  find_library(TINYXML tinyxml)
+  # Include a custom cmake file for TinyXML
+  set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+  include(SearchForTinyXML)
+  include_directories(${tinyxml_include_dirs})
+  link_directories(${tinyxml_library_dirs})
+  add_definitions(${tinyxml_cflags})
 
   # Build
   include_directories(
     include
     ${catkin_INCLUDE_DIRS}
-    ${tinyxml_INCLUDE_DIRS}
-    ${TINYXML}
   )
   link_directories(${catkin_LIBRARY_DIRS})
 
@@ -47,17 +50,14 @@ else()
   add_library(${PROJECT_NAME}_parser
     src/transmission_parser.cpp
   )
-  target_link_libraries(${PROJECT_NAME}_parser ${catkin_LIBRARIES} ${tinyxml_LIBRARIES} ${TINYXML})
+  target_link_libraries(${PROJECT_NAME}_parser ${catkin_LIBRARIES} ${tinyxml_libraries})
 
   # Declare a catkin package
   catkin_package(
-    DEPENDS tinyxml
     LIBRARIES 
       ${PROJECT_NAME}_parser
     INCLUDE_DIRS 
       include
-      ${tinyxml_INCLUDE_DIRS}
-      ${TINYXML}
   )
 
   # Tests
@@ -65,7 +65,7 @@ else()
   catkin_add_gtest(differential_transmission_test     test/differential_transmission_test.cpp)
   catkin_add_gtest(four_bar_linkage_transmission_test test/four_bar_linkage_transmission_test.cpp)
   catkin_add_gtest(transmission_interface_test        test/transmission_interface_test.cpp)
-  target_link_libraries(transmission_interface_test ${catkin_LIBRARIES} ${tinyxml_LIBRARIES})
+  target_link_libraries(transmission_interface_test ${catkin_LIBRARIES} ${tinyxml_libraries})
 
   # Install
   install(DIRECTORY include/${PROJECT_NAME}/

--- a/transmission_interface/CMakeLists.txt
+++ b/transmission_interface/CMakeLists.txt
@@ -35,7 +35,7 @@ else()
   # Include a custom cmake file for TinyXML
   set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
   include(SearchForTinyXML)
-  include_directories(${tinyxml_include_dirs})
+  include_directories(${tinyxml_INCLUDE_DIRS})
   link_directories(${tinyxml_library_dirs})
   add_definitions(${tinyxml_cflags})
 
@@ -50,7 +50,7 @@ else()
   add_library(${PROJECT_NAME}_parser
     src/transmission_parser.cpp
   )
-  target_link_libraries(${PROJECT_NAME}_parser ${catkin_LIBRARIES} ${tinyxml_libraries})
+  target_link_libraries(${PROJECT_NAME}_parser ${catkin_LIBRARIES} ${tinyxml_LIBRARIES})
 
   # Declare a catkin package
   catkin_package(
@@ -65,7 +65,7 @@ else()
   catkin_add_gtest(differential_transmission_test     test/differential_transmission_test.cpp)
   catkin_add_gtest(four_bar_linkage_transmission_test test/four_bar_linkage_transmission_test.cpp)
   catkin_add_gtest(transmission_interface_test        test/transmission_interface_test.cpp)
-  target_link_libraries(transmission_interface_test ${catkin_LIBRARIES} ${tinyxml_libraries})
+  target_link_libraries(transmission_interface_test ${catkin_LIBRARIES} ${tinyxml_LIBRARIES})
 
   # Install
   install(DIRECTORY include/${PROJECT_NAME}/

--- a/transmission_interface/cmake/SearchForTinyXML.cmake
+++ b/transmission_interface/cmake/SearchForTinyXML.cmake
@@ -1,0 +1,20 @@
+find_library(tinyxml_library tinyxml)
+if (tinyxml_library)
+  message (STATUS "Looking for libtinyxml - found")
+  set(tinyxml_libraries ${tinyxml_library})
+endif ()
+
+find_path(tinyxml_include_dirs NAMES tinyxml.h PATH_SUFFIXES tinyxml)
+if (NOT tinyxml_include_dirs)
+   message (STATUS "Looking for tinyxml/tinyxml.hpp or tinyxml/tinyxml.h - not found.")
+endif ()
+
+if (NOT tinyxml_include_dirs OR NOT tinyxml_libraries)
+   include (FindPkgConfig)
+   if (PKG_CONFIG_FOUND)
+     # Find tinyxml
+     pkg_check_modules(tinyxml tinyxml)
+   else()
+     MESSAGE("Missing: tinyxml")
+   endif()
+endif ()

--- a/transmission_interface/cmake/SearchForTinyXML.cmake
+++ b/transmission_interface/cmake/SearchForTinyXML.cmake
@@ -1,15 +1,15 @@
 find_library(tinyxml_library tinyxml)
 if (tinyxml_library)
   message (STATUS "Looking for libtinyxml - found")
-  set(tinyxml_libraries ${tinyxml_library})
+  set(tinyxml_LIBRARIES ${tinyxml_library})
 endif ()
 
-find_path(tinyxml_include_dirs NAMES tinyxml.h PATH_SUFFIXES tinyxml)
-if (NOT tinyxml_include_dirs)
+find_path(tinyxml_INCLUDE_DIRS NAMES tinyxml.h PATH_SUFFIXES tinyxml)
+if (NOT tinyxml_INCLUDE_DIRS)
    message (STATUS "Looking for tinyxml/tinyxml.hpp or tinyxml/tinyxml.h - not found.")
 endif ()
 
-if (NOT tinyxml_include_dirs OR NOT tinyxml_libraries)
+if (NOT tinyxml_INCLUDE_DIRS OR NOT tinyxml_LIBRARIES)
    include (FindPkgConfig)
    if (PKG_CONFIG_FOUND)
      # Find tinyxml

--- a/transmission_interface/package.xml
+++ b/transmission_interface/package.xml
@@ -17,6 +17,9 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>hardware_interface</build_depend>
+  <build_depend>tinyxml</build_depend>
+
+  <run_depend>tinyxml</run_depend>
 
   <export>
     <cpp cflags="-I${prefix}/include"/>


### PR DESCRIPTION
Third attempt to get TinyXML included correctly with CMake.

This is the exact method in URDFDom:
[SearchForTinyXML.cmake](https://bitbucket.org/osrf/urdfdom/src/3ccbac6bfbbe8c0f10998f872faf976ca5a9af50/cmake/SearchForTinyXML.cmake?at=default)

See:
https://github.com/ros-controls/ros_control/commit/8a55e3bb25bb50a91a7866e20d8af6d1077410de
https://github.com/ros/catkin/pull/486

@adolfo-rt @wjwwood 
