### PR TITLE
Add angle_wraparound joint limit property.

### DIFF
--- a/joint_limits_interface/include/joint_limits_interface/joint_limits.h
+++ b/joint_limits_interface/include/joint_limits_interface/joint_limits.h
@@ -46,7 +46,8 @@ struct JointLimits
       has_velocity_limits(false),
       has_acceleration_limits(false),
       has_jerk_limits(false),
-      has_effort_limits(false)
+      has_effort_limits(false),
+      angle_wraparound(false)
   {}
 
   double min_position;
@@ -61,6 +62,7 @@ struct JointLimits
   bool   has_acceleration_limits;
   bool   has_jerk_limits;
   bool   has_effort_limits;
+  bool   angle_wraparound;
 };
 
 struct SoftJointLimits

--- a/joint_limits_interface/include/joint_limits_interface/joint_limits_rosparam.h
+++ b/joint_limits_interface/include/joint_limits_interface/joint_limits_rosparam.h
@@ -105,6 +105,12 @@ bool getJointLimits(const std::string& joint_name, const ros::NodeHandle& nh, Jo
       limits.min_position = min_pos;
       limits.max_position = max_pos;
     }
+
+    bool angle_wraparound;
+    if (!has_position_limits && limits_nh.getParam("angle_wraparound", angle_wraparound))
+    {
+      limits.angle_wraparound = angle_wraparound;
+    }
   }
 
   // Velocity limits

--- a/joint_limits_interface/include/joint_limits_interface/joint_limits_urdf.h
+++ b/joint_limits_interface/include/joint_limits_interface/joint_limits_urdf.h
@@ -62,6 +62,11 @@ bool getJointLimits(boost::shared_ptr<const urdf::Joint> urdf_joint, JointLimits
     limits.max_position = urdf_joint->limits->upper;
   }
 
+  if (!limits.has_position_limits && urdf_joint->type == urdf::Joint::CONTINUOUS)
+  {
+    limits.angle_wraparound = true;
+  }
+
   limits.has_velocity_limits = true;
   limits.max_velocity = urdf_joint->limits->velocity;
 

--- a/joint_limits_interface/test/joint_limits_rosparam.yaml
+++ b/joint_limits_interface/test/joint_limits_rosparam.yaml
@@ -11,6 +11,7 @@ joint_limits:
     max_jerk: 100.0
     has_effort_limits: true
     max_effort: 20.0
+    angle_wraparound: true # should be ignored, has position limits
 
   yinfoo_joint:
     has_position_limits: true
@@ -33,6 +34,7 @@ joint_limits:
     has_acceleration_limits: false
     has_jerk_limits: false
     has_effort_limits: false
+    angle_wraparound: true # should be accepted, has no position limits
 
   bar_joint:
     has_velocity_limits: true

--- a/joint_limits_interface/test/joint_limits_rosparam_test.cpp
+++ b/joint_limits_interface/test/joint_limits_rosparam_test.cpp
@@ -73,6 +73,8 @@ TEST(JointLimitsRosParamTest, GetJointLimits)
 
     EXPECT_TRUE(limits.has_effort_limits);
     EXPECT_EQ(20.0, limits.max_effort);
+
+    EXPECT_FALSE(limits.angle_wraparound);
   }
 
   // Specifying flags but not values should set nothing
@@ -115,6 +117,7 @@ TEST(JointLimitsRosParamTest, GetJointLimits)
     EXPECT_FALSE(limits.has_acceleration_limits);
     EXPECT_FALSE(limits.has_jerk_limits);
     EXPECT_FALSE(limits.has_effort_limits);
+    EXPECT_TRUE(limits.angle_wraparound);
   }
 
   // Incomplete position limits specification does not get loaded

--- a/joint_limits_interface/test/joint_limits_urdf_test.cpp
+++ b/joint_limits_interface/test/joint_limits_urdf_test.cpp
@@ -88,6 +88,7 @@ TEST_F(JointLimitsUrdfTest, GetJointLimits)
 
     // Position
     EXPECT_FALSE(limits.has_position_limits);
+    EXPECT_TRUE(limits.angle_wraparound);
 
     // Velocity
     EXPECT_TRUE(limits.has_velocity_limits);
@@ -112,6 +113,7 @@ TEST_F(JointLimitsUrdfTest, GetJointLimits)
     EXPECT_TRUE(limits.has_position_limits);
     EXPECT_DOUBLE_EQ(urdf_joint->limits->lower, limits.min_position);
     EXPECT_DOUBLE_EQ(urdf_joint->limits->upper, limits.max_position);
+    EXPECT_FALSE(limits.angle_wraparound);
 
     // Velocity
     EXPECT_TRUE(limits.has_velocity_limits);
@@ -136,6 +138,7 @@ TEST_F(JointLimitsUrdfTest, GetJointLimits)
     EXPECT_TRUE(limits.has_position_limits);
     EXPECT_DOUBLE_EQ(urdf_joint->limits->lower, limits.min_position);
     EXPECT_DOUBLE_EQ(urdf_joint->limits->upper, limits.max_position);
+    EXPECT_FALSE(limits.angle_wraparound);
 
     // Velocity
     EXPECT_TRUE(limits.has_velocity_limits);


### PR DESCRIPTION
For full compatibility with MoveIt!'s joint limit specification.
Note that we still have the extra effort and jerk specification.
