### PR TITLE
Fix controller_manager.cpp reload-libraries/getControllerNames not clearing names first

### DIFF
--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -125,6 +125,7 @@ controller_interface::ControllerBase* ControllerManager::getControllerByName(con
 void ControllerManager::getControllerNames(std::vector<std::string> &names)
 {
   boost::recursive_mutex::scoped_lock guard(controllers_lock_);
+  names.clear();
   std::vector<ControllerSpec> &controllers = controllers_lists_[current_controllers_list_];
   for (size_t i = 0; i < controllers.size(); ++i)
   {


### PR DESCRIPTION
getControllerNames now clears names before adding current names.  This fixes a bug in reloadControllerLibrariesSrv where the method is called twice in a row without first clearing the list.

Steps to reproduce:
- Spawn controller
- Stop controller
- reload-libraries

controller_manager.cpp:501: bool controller_manager::ControllerManager::reloadControllerLibrariesSrv(controller_manager_msgs::ReloadControllerLibraries::Request&, controller_manager_msgs::ReloadControllerLibraries::Response&): Assertion `controllers.empty()' failed.
