### PR TITLE
CMakeLists fix to fit with OpenEmbedded/Yocto meta-ros layer.

### DIFF
--- a/controller_manager_tests/CMakeLists.txt
+++ b/controller_manager_tests/CMakeLists.txt
@@ -52,10 +52,12 @@ else()
   add_executable(dummy_app src/dummy_app.cpp)
   target_link_libraries(dummy_app ${PROJECT_NAME} ${catkin_LIBRARIES})
 
-  add_executable(cm_test test/cm_test.cpp)
-  add_dependencies(tests cm_test)
-  target_link_libraries(cm_test ${GTEST_LIBRARIES} ${catkin_LIBRARIES})
-  add_rostest(test/cm_test.test)
+  if(CATKIN_ENABLE_TESTING)
+    add_executable(cm_test test/cm_test.cpp)
+    add_dependencies(tests cm_test)
+    target_link_libraries(cm_test ${GTEST_LIBRARIES} ${catkin_LIBRARIES})
+    add_rostest(test/cm_test.test)
+  endif()
 
   # Install
   install(DIRECTORY include/${PROJECT_NAME}/

--- a/hardware_interface/CMakeLists.txt
+++ b/hardware_interface/CMakeLists.txt
@@ -40,29 +40,31 @@ else()
     INCLUDE_DIRS include
     )
 
-  catkin_add_gtest(hardware_resource_manager_test  test/hardware_resource_manager_test.cpp)
-  target_link_libraries(hardware_resource_manager_test ${catkin_LIBRARIES})
+  if(CATKIN_ENABLE_TESTING)
+    catkin_add_gtest(hardware_resource_manager_test  test/hardware_resource_manager_test.cpp)
+    target_link_libraries(hardware_resource_manager_test ${catkin_LIBRARIES})
 
-  catkin_add_gtest(actuator_state_interface_test   test/actuator_state_interface_test.cpp)
-  target_link_libraries(actuator_state_interface_test ${catkin_LIBRARIES})
+    catkin_add_gtest(actuator_state_interface_test   test/actuator_state_interface_test.cpp)
+    target_link_libraries(actuator_state_interface_test ${catkin_LIBRARIES})
 
-  catkin_add_gtest(actuator_command_interface_test test/actuator_command_interface_test.cpp)
-  target_link_libraries(actuator_command_interface_test ${catkin_LIBRARIES})
+    catkin_add_gtest(actuator_command_interface_test test/actuator_command_interface_test.cpp)
+    target_link_libraries(actuator_command_interface_test ${catkin_LIBRARIES})
 
-  catkin_add_gtest(joint_state_interface_test      test/joint_state_interface_test.cpp)
-  target_link_libraries(joint_state_interface_test ${catkin_LIBRARIES})
+    catkin_add_gtest(joint_state_interface_test      test/joint_state_interface_test.cpp)
+    target_link_libraries(joint_state_interface_test ${catkin_LIBRARIES})
 
-  catkin_add_gtest(joint_command_interface_test    test/joint_command_interface_test.cpp)
-  target_link_libraries(joint_command_interface_test ${catkin_LIBRARIES})
+    catkin_add_gtest(joint_command_interface_test    test/joint_command_interface_test.cpp)
+    target_link_libraries(joint_command_interface_test ${catkin_LIBRARIES})
 
-  catkin_add_gtest(force_torque_sensor_interface_test test/force_torque_sensor_interface_test.cpp)
-  target_link_libraries(force_torque_sensor_interface_test ${catkin_LIBRARIES})
+    catkin_add_gtest(force_torque_sensor_interface_test test/force_torque_sensor_interface_test.cpp)
+    target_link_libraries(force_torque_sensor_interface_test ${catkin_LIBRARIES})
 
-  catkin_add_gtest(imu_sensor_interface_test       test/imu_sensor_interface_test.cpp)
-  target_link_libraries(imu_sensor_interface_test ${catkin_LIBRARIES})
+    catkin_add_gtest(imu_sensor_interface_test       test/imu_sensor_interface_test.cpp)
+    target_link_libraries(imu_sensor_interface_test ${catkin_LIBRARIES})
 
-  catkin_add_gtest(robot_hw_test                   test/robot_hw_test.cpp)
-  target_link_libraries(robot_hw_test ${catkin_LIBRARIES})
+    catkin_add_gtest(robot_hw_test                   test/robot_hw_test.cpp)
+    target_link_libraries(robot_hw_test ${catkin_LIBRARIES})
+  endif()
 
   # Install
   install(DIRECTORY include/${PROJECT_NAME}/

--- a/joint_limits_interface/CMakeLists.txt
+++ b/joint_limits_interface/CMakeLists.txt
@@ -43,16 +43,18 @@ else()
       ${urdfdom_LIBRARIES}
   )
 
-  catkin_add_gtest(joint_limits_interface_test test/joint_limits_interface_test.cpp)
-  target_link_libraries(joint_limits_interface_test ${catkin_LIBRARIES})
+  if(CATKIN_ENABLE_TESTING)
+    catkin_add_gtest(joint_limits_interface_test test/joint_limits_interface_test.cpp)
+    target_link_libraries(joint_limits_interface_test ${catkin_LIBRARIES})
 
-  catkin_add_gtest(joint_limits_urdf_test      test/joint_limits_urdf_test.cpp)
-  target_link_libraries(joint_limits_urdf_test ${catkin_LIBRARIES})
+    catkin_add_gtest(joint_limits_urdf_test      test/joint_limits_urdf_test.cpp)
+    target_link_libraries(joint_limits_urdf_test ${catkin_LIBRARIES})
 
-  catkin_add_gtest(joint_limits_rosparam_test  test/joint_limits_urdf_test.cpp)
-  target_link_libraries(joint_limits_rosparam_test ${catkin_LIBRARIES})
+    catkin_add_gtest(joint_limits_rosparam_test  test/joint_limits_urdf_test.cpp)
+    target_link_libraries(joint_limits_rosparam_test ${catkin_LIBRARIES})
 
-  add_rostest(test/joint_limits_rosparam.test)
+    add_rostest(test/joint_limits_rosparam.test)
+  endif()
 
   # Install
   install(DIRECTORY include/${PROJECT_NAME}/

--- a/transmission_interface/CMakeLists.txt
+++ b/transmission_interface/CMakeLists.txt
@@ -85,11 +85,13 @@ else()
 ## Testing ##
 #############
 
-  catkin_add_gtest(simple_transmission_test           test/simple_transmission_test.cpp)
-  catkin_add_gtest(differential_transmission_test     test/differential_transmission_test.cpp)
-  catkin_add_gtest(four_bar_linkage_transmission_test test/four_bar_linkage_transmission_test.cpp)
-  catkin_add_gtest(transmission_interface_test        test/transmission_interface_test.cpp)
-  target_link_libraries(transmission_interface_test ${catkin_LIBRARIES} ${TinyXML_LIBRARIES})
+  if(CATKIN_ENABLE_TESTING)
+    catkin_add_gtest(simple_transmission_test           test/simple_transmission_test.cpp)
+    catkin_add_gtest(differential_transmission_test     test/differential_transmission_test.cpp)
+    catkin_add_gtest(four_bar_linkage_transmission_test test/four_bar_linkage_transmission_test.cpp)
+    catkin_add_gtest(transmission_interface_test        test/transmission_interface_test.cpp)
+    target_link_libraries(transmission_interface_test ${catkin_LIBRARIES} ${TinyXML_LIBRARIES})
+  endif()
 
 
 endif()


### PR DESCRIPTION
Increase the compatibility of the ros_control code with
meta-ros, an OpenEmbedded/Yocto layer that provides recipes for ROS
packages disabling catking checking the variable CATKIN_ENABLE_TESTING.

Please review and merge.
