### PR TITLE
Added optional per-controller update period

### DIFF
--- a/controller_interface/include/controller_interface/controller_base.h
+++ b/controller_interface/include/controller_interface/controller_base.h
@@ -84,29 +84,11 @@ public:
     return (state_ == RUNNING);
   }
 
-  /// Calls \ref update only if this controller is running and the update period has elapsed
-  void updateRequest(const ros::Time& time, const ros::Duration& min_period)
+  /// Calls \ref update only if this controller is running.
+  void updateRequest(const ros::Time& time, const ros::Duration& period)
   {
-    if (state_ != RUNNING) return;
-
-    // get time since last update (update period)
-    ros::Duration period;
-    if (update_period_.isZero()) {
-      period = min_period;
-    } else {
-      if (!last_update_time_.isZero() && (time >= last_update_time_)) {
-        period = time - last_update_time_;
-      } else {
-        period = update_period_;
-      }
-    }
-
-    // update only if update period has elapsed
-    if (period >= update_period_)
-    {
+    if (state_ == RUNNING)
       update(time, period);
-      last_update_time_ = time;
-    }
   }
 
   /// Calls \ref starting only if this controller is initialized or already running
@@ -116,7 +98,6 @@ public:
     if (state_ == RUNNING || state_ == INITIALIZED){
       starting(time);
       state_ = RUNNING;
-      last_update_time_ = ros::Time();
       return true;
     }
     else
@@ -134,34 +115,6 @@ public:
     }
     else
       return false;
-  }
-
-  /** \brief Returns the desired update period of this controller.
-   *
-   * \returns The update period.
-   */
-  const ros::Duration& getUpdatePeriod() const
-  {
-      return update_period_;
-  }
-
-  /** \brief Returns the desired update period of this controller.
-   *
-   * \param period The update period.
-   * \note The controller will never be updated faster than the controller manager.
-   */
-  void setUpdatePeriod(const ros::Duration& period)
-  {
-      update_period_ = period;
-  }
-
-  /** \brief Returns the timestamp of the last controller update.
-   *
-   * \returns The last update timestamp. If the controller has not been updated since it was started, the return value will be ros::Time().
-   */
-  const ros::Time& getLastUpdateTime() const
-  {
-      return last_update_time_;
   }
 
   /*\}*/
@@ -199,12 +152,6 @@ public:
 private:
   ControllerBase(const ControllerBase &c);
   ControllerBase& operator =(const ControllerBase &c);
-
-  /// The update period of the controller
-  ros::Duration update_period_;
-
-  /// The last update time of this controller
-  ros::Time last_update_time_;
 
 };
 

--- a/controller_interface/include/controller_interface/controller_base.h
+++ b/controller_interface/include/controller_interface/controller_base.h
@@ -36,6 +36,8 @@
 #include <ros/node_handle.h>
 #include <hardware_interface/robot_hw.h>
 
+// forward declaration of controller_manager::ControllerManager
+namespace controller_manager { class ControllerManager; }
 
 namespace controller_interface
 {
@@ -90,7 +92,6 @@ public:
     if (state_ == RUNNING) {
       update(time, period);
       last_update_time_ = time;
-      skipped_update_cycles_ = 0;
     }
   }
 
@@ -103,6 +104,7 @@ public:
       state_ = RUNNING;
       last_update_time_ = ros::Time();
       skipped_update_cycles_ = 0;
+      total_update_period_ = ros::Duration();
       return true;
     }
     else
@@ -163,16 +165,20 @@ public:
   /// The current execution state of the controller
   enum {CONSTRUCTED, INITIALIZED, RUNNING} state_;
 
-  /// The number of cycles skipped since the last update
-  int skipped_update_cycles_;
-
-  /// The last update time of this controller
-  ros::Time last_update_time_;
-
-
 private:
   ControllerBase(const ControllerBase &c);
   ControllerBase& operator =(const ControllerBase &c);
+
+  friend class controller_manager::ControllerManager;
+
+  /// The number of cycles skipped since the last update
+  int skipped_update_cycles_;
+
+  /// The total period since the last update
+  ros::Duration total_update_period_;
+
+  /// The last update time of this controller
+  ros::Time last_update_time_;
 
 };
 

--- a/controller_interface/include/controller_interface/controller_base.h
+++ b/controller_interface/include/controller_interface/controller_base.h
@@ -124,7 +124,8 @@ public:
 
   /** \brief Returns the timestamp of the last controller update.
    *
-   * \returns The last update timestamp. If the controller has not been updated since it was started, the return value will be ros::Time().
+   * \returns The last update timestamp. If the controller has not been updated since
+   * it was started, the return value will be ros::Time().
    */
   virtual ros::Time getLastUpdateTime() const
   {

--- a/controller_interface/include/controller_interface/controller_base.h
+++ b/controller_interface/include/controller_interface/controller_base.h
@@ -89,10 +89,8 @@ public:
   /// Calls \ref update only if this controller is running.
   void updateRequest(const ros::Time& time, const ros::Duration& period)
   {
-    if (state_ == RUNNING) {
+    if (state_ == RUNNING)
       update(time, period);
-      last_update_time_ = time;
-    }
   }
 
   /// Calls \ref starting only if this controller is initialized or already running
@@ -102,7 +100,6 @@ public:
     if (state_ == RUNNING || state_ == INITIALIZED){
       starting(time);
       state_ = RUNNING;
-      last_update_time_ = ros::Time();
       skipped_update_cycles_ = 0;
       total_update_period_ = ros::Duration();
       return true;
@@ -122,16 +119,6 @@ public:
     }
     else
       return false;
-  }
-
-  /** \brief Returns the timestamp of the last controller update.
-   *
-   * \returns The last update timestamp. If the controller has not been updated since
-   * it was started, the return value will be ros::Time().
-   */
-  virtual ros::Time getLastUpdateTime() const
-  {
-      return last_update_time_;
   }
 
   /*\}*/
@@ -176,9 +163,6 @@ private:
 
   /// The total period since the last update
   ros::Duration total_update_period_;
-
-  /// The last update time of this controller
-  ros::Time last_update_time_;
 
 };
 

--- a/controller_interface/include/controller_interface/controller_base.h
+++ b/controller_interface/include/controller_interface/controller_base.h
@@ -87,8 +87,11 @@ public:
   /// Calls \ref update only if this controller is running.
   void updateRequest(const ros::Time& time, const ros::Duration& period)
   {
-    if (state_ == RUNNING)
+    if (state_ == RUNNING) {
       update(time, period);
+      last_update_time_ = time;
+      skipped_update_cycles_ = 0;
+    }
   }
 
   /// Calls \ref starting only if this controller is initialized or already running
@@ -98,6 +101,8 @@ public:
     if (state_ == RUNNING || state_ == INITIALIZED){
       starting(time);
       state_ = RUNNING;
+      last_update_time_ = ros::Time();
+      skipped_update_cycles_ = 0;
       return true;
     }
     else
@@ -115,6 +120,15 @@ public:
     }
     else
       return false;
+  }
+
+  /** \brief Returns the timestamp of the last controller update.
+   *
+   * \returns The last update timestamp. If the controller has not been updated since it was started, the return value will be ros::Time().
+   */
+  virtual ros::Time getLastUpdateTime() const
+  {
+      return last_update_time_;
   }
 
   /*\}*/
@@ -147,6 +161,12 @@ public:
 
   /// The current execution state of the controller
   enum {CONSTRUCTED, INITIALIZED, RUNNING} state_;
+
+  /// The number of cycles skipped since the last update
+  int skipped_update_cycles_;
+
+  /// The last update time of this controller
+  ros::Time last_update_time_;
 
 
 private:

--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(controller_manager)
-set(CMAKE_BUILD_TYPE Debug)
 
 if(USE_ROSBUILD)
 

--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(controller_manager)
+set(CMAKE_BUILD_TYPE Debug)
 
 if(USE_ROSBUILD)
 

--- a/controller_manager/include/controller_manager/controller_spec.h
+++ b/controller_manager/include/controller_manager/controller_spec.h
@@ -55,9 +55,7 @@ struct ControllerSpec
 {
   hardware_interface::ControllerInfo info;
   boost::shared_ptr<controller_interface::ControllerBase> c;
-
   int update_every_n_cycles;        //! If greater than 0, this controller will only be updated every n-th cycle
-  ros::Duration min_update_period;  //! A minimum update period. The controller will never be updated faster than this.
 };
 
 }

--- a/controller_manager/include/controller_manager/controller_spec.h
+++ b/controller_manager/include/controller_manager/controller_spec.h
@@ -55,6 +55,9 @@ struct ControllerSpec
 {
   hardware_interface::ControllerInfo info;
   boost::shared_ptr<controller_interface::ControllerBase> c;
+
+  int update_every_n_cycles;        //! If greater than 0, this controller will only be updated every n-th cycle
+  ros::Duration min_update_period;  //! A minimum update period. The controller will never be updated faster than this.
 };
 
 }

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -107,20 +107,6 @@ void ControllerManager::update(const ros::Time& time, const ros::Duration& perio
       }
     }
 
-    // skip cycle if min_update_period is set
-    if (!spec.min_update_period.isZero()) {
-      if (!last_update_time.isZero() && (time >= last_update_time)) {
-        time_since_last_update = time - last_update_time;
-      } else {
-        time_since_last_update = spec.min_update_period;
-      }
-
-      if (time_since_last_update < spec.min_update_period) {
-        spec.c->skipped_update_cycles_++;
-        continue;
-      }
-    }
-
     spec.c->updateRequest(time, time_since_last_update);
   }
 
@@ -256,23 +242,13 @@ bool ControllerManager::loadController(const std::string& name)
     return false;
   }
 
-  // Configure timing parameter
+  // Configure update_every_n_cycles parameter
   int update_every_n_cycles = 0;
-  double min_update_period = 0.0;
-  double max_update_frequency = 0.0;
   if (c_nh.getParam("update_every_n_cycles", update_every_n_cycles))
   {
     if (update_every_n_cycles > 1) {
       ROS_DEBUG("Controller '%s' of type '%s' will only be updated in steps of %d cycles.", name.c_str(), type.c_str(), update_every_n_cycles);
     }
-  }
-  if (c_nh.getParam("min_update_period", min_update_period))
-  {
-    ROS_DEBUG("Controller '%s' of type '%s' will be updated not faster than every %f seconds.", name.c_str(), type.c_str(), min_update_period);
-
-  } else if (c_nh.getParam("max_update_frequency", max_update_frequency) && max_update_frequency > 0.0) {
-    ROS_DEBUG("Controller '%s' of type '%s' will be updated at a maximum rate of %f Hz.", name.c_str(), type.c_str(), max_update_frequency);
-    min_update_period = 1. / max_update_frequency;
   }
 
   // Initializes the controller
@@ -306,7 +282,6 @@ bool ControllerManager::loadController(const std::string& name)
   to[to.size()-1].info.resources = claimed_resources;
   to[to.size()-1].c = c;
   to[to.size()-1].update_every_n_cycles = update_every_n_cycles;
-  to[to.size()-1].min_update_period = ros::Duration(min_update_period);
 
   // Destroys the old controllers list when the realtime thread is finished with it.
   int former_current_controllers_list_ = current_controllers_list_;

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -248,6 +248,10 @@ bool ControllerManager::loadController(const std::string& name)
   {
     if (update_every_n_cycles > 1) {
       ROS_DEBUG("Controller '%s' of type '%s' will only be updated in steps of %d cycles.", name.c_str(), type.c_str(), update_every_n_cycles);
+    } else if (update_every_n_cycles < 0) {
+      ROS_ERROR("Could not load controller '%s' because the 'update_every_n_cycles' parameter cannot be negative.", name.c_str());
+      to.clear();
+      return false;
     }
   }
 


### PR DESCRIPTION
This pull request adds an optional per-controller update period to ros_control.

The default update period for a controller is zero and the controller is updated on each update of the controller manager. This should not break existing code.

If the controller sets an individual update period by calling the new `ControllerInterface::setUpdatePeriod()` method, e.g. in its overridden `init()` method, the controller manager will only invoke update if the desired period has elapsed since the last update and also adapts the period passed to the controller accordingly.

I am using ros_control for a cascaded controller where the outer loops should run slower than the inner loops. Of course it would be possible to implement this throttling in the outer controllers itself, but this solution is more general. Another use case is the JointStateController in ros_controllers, where a similar solution is already implemented for the publish rate.

There are also some checks in `ControllerInterface::updateRequest()` that make sure that the controller (hopefully) handles stops and restarts at a later point of time (or a time reset when running in Gazebo) correctly without passing bogus periods to the controller's `update()` method.
