### PR TITLE
Add raw data accessors to actuators interface.

### DIFF
--- a/hardware_interface/include/hardware_interface/actuator_command_interface.h
+++ b/hardware_interface/include/hardware_interface/actuator_command_interface.h
@@ -58,6 +58,8 @@ public:
   void setCommand(double command) {assert(cmd_); *cmd_ = command;}
   double getCommand() const {assert(cmd_); return *cmd_;}
 
+  double* getCommandPtr() {return cmd_;}
+
 private:
   double* cmd_;
 };

--- a/hardware_interface/include/hardware_interface/actuator_state_interface.h
+++ b/hardware_interface/include/hardware_interface/actuator_state_interface.h
@@ -71,6 +71,10 @@ public:
   double getVelocity()  const {assert(vel_); return *vel_;}
   double getEffort()    const {assert(eff_); return *eff_;}
 
+  const double* getPositionPtr() const {return pos_;}
+  const double* getVelocityPtr() const {return vel_;}
+  const double* getEffortPtr()   const {return eff_;}
+
 private:
   std::string name_;
   const double* pos_;

--- a/hardware_interface/test/actuator_command_interface_test.cpp
+++ b/hardware_interface/test/actuator_command_interface_test.cpp
@@ -102,6 +102,11 @@ TEST_F(ActuatorCommandInterfaceTest, ExcerciseApi)
   EXPECT_DOUBLE_EQ(vel1, hc1_tmp.getVelocity());
   EXPECT_DOUBLE_EQ(eff1, hc1_tmp.getEffort());
   EXPECT_DOUBLE_EQ(cmd1, hc1_tmp.getCommand());
+  EXPECT_EQ(&pos1, hc1_tmp.getPositionPtr());
+  EXPECT_EQ(&vel1, hc1_tmp.getVelocityPtr());
+  EXPECT_EQ(&eff1, hc1_tmp.getEffortPtr());
+  EXPECT_EQ(&cmd1, hc1_tmp.getCommandPtr());
+
   const double new_cmd_1 = -1.0;
   hc1_tmp.setCommand(new_cmd_1);
   EXPECT_DOUBLE_EQ(new_cmd_1, hc1_tmp.getCommand());

--- a/hardware_interface/test/actuator_state_interface_test.cpp
+++ b/hardware_interface/test/actuator_state_interface_test.cpp
@@ -103,12 +103,18 @@ TEST_F(ActuatorStateInterfaceTest, ExcerciseApi)
   EXPECT_DOUBLE_EQ(pos1, h1_tmp.getPosition());
   EXPECT_DOUBLE_EQ(vel1, h1_tmp.getVelocity());
   EXPECT_DOUBLE_EQ(eff1, h1_tmp.getEffort());
+  EXPECT_EQ(&pos1, h1_tmp.getPositionPtr());
+  EXPECT_EQ(&vel1, h1_tmp.getVelocityPtr());
+  EXPECT_EQ(&eff1, h1_tmp.getEffortPtr());
 
   ActuatorStateHandle h2_tmp = iface.getHandle(name2);
   EXPECT_EQ(name2, h2_tmp.getName());
   EXPECT_DOUBLE_EQ(pos2, h2_tmp.getPosition());
   EXPECT_DOUBLE_EQ(vel2, h2_tmp.getVelocity());
   EXPECT_DOUBLE_EQ(eff2, h2_tmp.getEffort());
+  EXPECT_EQ(&pos2, h2_tmp.getPositionPtr());
+  EXPECT_EQ(&vel2, h2_tmp.getVelocityPtr());
+  EXPECT_EQ(&eff2, h2_tmp.getEffortPtr());
 
   // This interface does not claim resources
   EXPECT_TRUE(iface.getClaims().empty());


### PR DESCRIPTION
Write access to the raw actuator data will be needed for automatic transmission loading. Refs #133.

We don't need to expose the raw data for the joint interfaces, as the transmission parser owns the raw data and knows about it. However, actuator interfaces are a requisite for transmission parsing and we don't own or know where the raw data is.
