### PR TITLE
Add name to anonymous objects to avoid cppcheck error

### DIFF
--- a/hardware_interface/test/actuator_command_interface_test.cpp
+++ b/hardware_interface/test/actuator_command_interface_test.cpp
@@ -40,8 +40,8 @@ TEST(ActuatorCommandHandleTest, HandleConstruction)
   string name = "name1";
   double pos, vel, eff;
   double cmd;
-  EXPECT_NO_THROW(ActuatorHandle(ActuatorStateHandle(name, &pos, &vel, &eff), &cmd));
-  EXPECT_THROW(ActuatorHandle(ActuatorStateHandle(name, &pos, &vel, &eff), 0), HardwareInterfaceException);
+  EXPECT_NO_THROW(ActuatorHandle tmp(ActuatorStateHandle(name, &pos, &vel, &eff), &cmd));
+  EXPECT_THROW(ActuatorHandle tmp(ActuatorStateHandle(name, &pos, &vel, &eff), 0), HardwareInterfaceException);
 
   // Print error messages
   // Requires manual output inspection, but exception message should be descriptive

--- a/hardware_interface/test/force_torque_sensor_interface_test.cpp
+++ b/hardware_interface/test/force_torque_sensor_interface_test.cpp
@@ -52,7 +52,7 @@ TEST(ForceTorqueSensorHandleTest, HandleConstruction)
   {
     double force[3]  = {1.0, 2.0, 3.0};
     double torque[3] = {-1.0, -2.0, -3.0};
-    ForceTorqueSensorHandle("name_1", "frame_1", force, torque);
+    ForceTorqueSensorHandle tmp("name_1", "frame_1", force, torque);
   }
 }
 

--- a/hardware_interface/test/joint_command_interface_test.cpp
+++ b/hardware_interface/test/joint_command_interface_test.cpp
@@ -40,12 +40,12 @@ TEST(JointCommandHandleTest, HandleConstruction)
   string name = "name1";
   double pos, vel, eff;
   double cmd;
-  EXPECT_NO_THROW(JointHandle(JointStateHandle(name, &pos, &vel, &eff), &cmd));
-  EXPECT_THROW(JointHandle(JointStateHandle(name, &pos, &vel, &eff), 0), HardwareInterfaceException);
+  EXPECT_NO_THROW(JointHandle tmp(JointStateHandle(name, &pos, &vel, &eff), &cmd));
+  EXPECT_THROW(JointHandle tmp(JointStateHandle(name, &pos, &vel, &eff), 0), HardwareInterfaceException);
 
   // Print error messages
   // Requires manual output inspection, but exception message should be descriptive
-  try {JointHandle(JointStateHandle(name, &pos, &vel, &eff), 0);}
+  try {JointHandle tmp(JointStateHandle(name, &pos, &vel, &eff), 0);}
   catch(const HardwareInterfaceException& e) {ROS_ERROR_STREAM(e.what());}
 }
 

--- a/hardware_interface/test/joint_state_interface_test.cpp
+++ b/hardware_interface/test/joint_state_interface_test.cpp
@@ -39,7 +39,7 @@ TEST(JointStateHandleTest, HandleConstruction)
 {
   string name = "name1";
   double pos, vel, eff;
-  EXPECT_NO_THROW(JointStateHandle(name, &pos, &vel, &eff));
+  EXPECT_NO_THROW(JointStateHandle tmp(name, &pos, &vel, &eff));
   EXPECT_THROW(JointStateHandle(name, 0, &vel, &eff), HardwareInterfaceException);
   EXPECT_THROW(JointStateHandle(name, &pos, 0, &eff), HardwareInterfaceException);
   EXPECT_THROW(JointStateHandle(name, &pos, &vel, 0), HardwareInterfaceException);


### PR DESCRIPTION
`cppcheck` complains that the objects are destroyed immediately, which is the intended behavior here. Nevertheless, giving them a name silences the warning.
