### PR TITLE
Add composite controller interface

### DIFF
--- a/composite_controller_interface/CMakeLists.txt
+++ b/composite_controller_interface/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(composite_controller_interface)
+
+find_package(catkin REQUIRED COMPONENTS roscpp hardware_interface controller_interface)
+
+include_directories(include)
+
+# Declare catkin package
+catkin_package(
+  CATKIN_DEPENDS roscpp hardware_interface controller_interface
+  INCLUDE_DIRS include
+) 
+
+# Install
+install(DIRECTORY include/${PROJECT_NAME}/
+DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
+

--- a/composite_controller_interface/include/composite_controller_interface/composite_controller.h
+++ b/composite_controller_interface/include/composite_controller_interface/composite_controller.h
@@ -1,0 +1,90 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ * Copyright (c) 2014, Igor Kalevatykh, Bauman Moscow State Technical University
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *      * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *      * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *      * Neither the name of the Bauman Moscow State Technical University,
+ *      nor the names of its contributors may be used to endorse or promote
+ *      products derived from this software without specific prior written
+ *      permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/// \author Igor Kalevatykh <kalevatykhia@gmail.com>
+
+#ifndef COMPOSITE_CONTROLLER_INTERFACE__COMPOSITE_CONTROLLER_H
+#define COMPOSITE_CONTROLLER_INTERFACE__COMPOSITE_CONTROLLER_H
+
+
+#include <ros/ros.h>
+#include <ros/console.h>
+#include <controller_interface/controller.h>
+#include <composite_controller_interface/internal/composite_controller_base.h>
+#include <boost/preprocessor/repetition.hpp>
+
+
+namespace composite_controller_interface
+{
+
+//TODO: Use variadic template when C++11 will be available
+#define COMPOSITE_CONTROLLER_INTERFACE__COMPOSITE_CONTROLLER(z, n, _)                                                     \
+  template<BOOST_PP_ENUM_PARAMS(n, class T)>                                                                              \
+    class CompositeController##n :                                                                                        \
+        public internal::CompositeControllerBase<internal::HardwareInterface##n <BOOST_PP_ENUM_PARAMS(n, T)> >            \
+    {                                                                                                                     \
+    public:                                                                                                               \
+      virtual ~CompositeController##n() { }                                                                               \
+                                                                                                                          \
+      virtual bool init(BOOST_PP_ENUM_BINARY_PARAMS(n, T, *hw), ros::NodeHandle &controller_nh)                           \
+      { return true; }                                                                                                    \
+                                                                                                                          \
+      virtual bool init(BOOST_PP_ENUM_BINARY_PARAMS(n, T, *hw), ros::NodeHandle& root_nh, ros::NodeHandle &controller_nh) \
+      { return true; }                                                                                                    \
+                                                                                                                          \
+    private:                                                                                                              \
+      typedef internal::HardwareInterface##n <BOOST_PP_ENUM_PARAMS(n, T)> TypeHW;                                         \
+                                                                                                                          \
+      bool init(TypeHW* hw, ros::NodeHandle &controller_nh)                                                               \
+      {                                                                                                                   \
+        return init(BOOST_PP_REPEAT(n,COMPOSITE_CONTROLLER_INTERFACE__GET_HW_MACRO,~) controller_nh);                     \
+      }                                                                                                                   \
+                                                                                                                          \
+      bool init(TypeHW* hw, ros::NodeHandle& root_nh, ros::NodeHandle &controller_nh)                                     \
+      {                                                                                                                   \
+        return init(BOOST_PP_REPEAT(n,COMPOSITE_CONTROLLER_INTERFACE__GET_HW_MACRO,~) root_nh, controller_nh);            \
+      }                                                                                                                   \
+    };
+
+#define COMPOSITE_CONTROLLER_INTERFACE__GET_HW_MACRO(z, i, _)  hw->get##i(),
+
+/** \brief Controller class with a composite hardware interface
+ *
+ * \tparam T1 - Tn The composite hardware interfaces types used by this controller.
+ * This enforces semantic compatibility between the controller and the hardware it's
+ * meant to control.
+ */
+BOOST_PP_REPEAT_FROM_TO(2, 7, COMPOSITE_CONTROLLER_INTERFACE__COMPOSITE_CONTROLLER, ~)
+
+}
+
+#endif

--- a/composite_controller_interface/include/composite_controller_interface/internal/composite_controller_base.h
+++ b/composite_controller_interface/include/composite_controller_interface/internal/composite_controller_base.h
@@ -1,0 +1,95 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ * Copyright (c) 2014, Igor Kalevatykh, Bauman Moscow State Technical University
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *      * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *      * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *      * Neither the name of the Bauman Moscow State Technical University,
+ *      nor the names of its contributors may be used to endorse or promote
+ *      products derived from this software without specific prior written
+ *      permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/// \author Igor Kalevatykh <kalevatykhia@gmail.com>
+
+#ifndef COMPOSITE_CONTROLLER_INTERFACE__INTERNAL__COMPOSITE_CONTROLLER_BASE_H
+#define COMPOSITE_CONTROLLER_INTERFACE__INTERNAL__COMPOSITE_CONTROLLER_BASE_H
+
+#include <ros/ros.h>
+#include <ros/console.h>
+#include <controller_interface/controller.h>
+#include <composite_controller_interface/internal/composite_hardware_interface.h>
+
+namespace composite_controller_interface
+{
+
+namespace internal
+{
+
+/** \brief Controller base class with a composite hardware interface
+ *
+ * \tparam T The COMPOSITE hardware interface type used by this controller. This
+ * enforces semantic compatibility between the controller and the hardware it's
+ * meant to control.
+ */
+template<class T>
+  class CompositeControllerBase : public controller_interface::Controller<T>
+  {
+  public:
+
+    virtual ~CompositeControllerBase()
+    {
+    }
+
+    /** \brief Initialize the controller from a RobotHW pointer
+     *
+     * This try extract from \c robot_hw all interfaces that composing \ref T.
+     *
+     */
+    virtual bool initRequest(hardware_interface::RobotHW* robot_hw, ros::NodeHandle& root_nh,
+                             ros::NodeHandle &controller_nh, std::set<std::string> &claimed_resources)
+    {
+      if (!composite_hw_.init(robot_hw))
+      {
+        ROS_ERROR("This controller requires a hardware interface of type '%s'."
+                  " Make sure all sub interfaces is registered in the hardware_interface::RobotHW class.",
+                  controller_interface::Controller<T>::getHardwareInterfaceType().c_str());
+        return false;
+      }
+
+      hardware_interface::RobotHW robot_hw_tmp;
+      robot_hw_tmp.registerInterface(&composite_hw_);
+
+      return controller_interface::Controller<T>::initRequest(&robot_hw_tmp, root_nh, controller_nh, claimed_resources);
+    }
+
+  private:
+    T composite_hw_;
+  };
+
+}
+
+}
+
+#endif
+

--- a/composite_controller_interface/include/composite_controller_interface/internal/composite_hardware_interface.h
+++ b/composite_controller_interface/include/composite_controller_interface/internal/composite_hardware_interface.h
@@ -1,0 +1,121 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ * Copyright (c) 2014, Igor Kalevatykh, Bauman Moscow State Technical University
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *      * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *      * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *      * Neither the name of the Bauman Moscow State Technical University,
+ *      nor the names of its contributors may be used to endorse or promote
+ *      products derived from this software without specific prior written
+ *      permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/// \author Igor Kalevatykh <kalevatykhia@gmail.com>
+
+#ifndef COMPOSITE_CONTROLLER_INTERFACE__INTERNAL__COMPOSITE_HARDWARE_INTERFACE_H
+#define COMPOSITE_CONTROLLER_INTERFACE__INTERNAL__COMPOSITE_HARDWARE_INTERFACE_H
+
+#include <controller_interface/controller.h>
+#include <boost/preprocessor/repetition.hpp>
+#include <boost/range/algorithm.hpp>
+
+namespace composite_controller_interface
+{
+
+namespace internal
+{
+
+/** \brief Abstract Composite Hardware Interface
+ *
+ */
+class CompositeHardwareInterface
+{
+public:
+
+  virtual ~CompositeHardwareInterface() { }
+
+  /// Clear the resources this interface is claiming
+  void clearClaims()
+  {
+    boost::range::for_each(sub_ifaces_, std::mem_fun(&hardware_interface::HardwareInterface::clearClaims));
+  }
+
+  /// Get the list of resources this interface is currently claiming
+  std::set<std::string> getClaims() const
+  {
+    std::set<std::string> claims;
+    for (InterfaceVector::const_iterator it = sub_ifaces_.begin(); it != sub_ifaces_.end(); ++it)
+    {
+      boost::range::copy((*it)->getClaims(), std::inserter(claims, claims.end()));
+    }
+    return claims;
+  }
+
+protected:
+
+  /** \brief Add hardware interface pointer with type \ref T to sub interfaces cash.
+   *
+   * \param ifaces Source interface manager
+   * \returns True if \ref ifaces contains interface with a type \ref T
+   *
+   */
+  template<class T>
+    bool registerSubInterface(hardware_interface::InterfaceManager* ifaces)
+    {
+      T* hw = ifaces->get<T>();
+      return hw ? sub_ifaces_.push_back(hw), true : false;
+    }
+
+  typedef std::vector<hardware_interface::HardwareInterface*> InterfaceVector;
+  InterfaceVector sub_ifaces_;
+};
+
+//TODO: Use variadic template when C++11 will be available
+#define COMPOSITE_CONTROLLER_INTERFACE__COMPOSITE_HW(z, n, _)                   \
+  template<BOOST_PP_ENUM_PARAMS(n, class T)>                                    \
+    class HardwareInterface##n : public CompositeHardwareInterface              \
+    {                                                                           \
+    public:                                                                     \
+      bool init(hardware_interface::RobotHW* robot_hw)                          \
+      {                                                                         \
+        sub_ifaces_.clear();                                                    \
+        BOOST_PP_REPEAT(n, COMPOSITE_CONTROLLER_INTERFACE__HW_REG_MACRO, ~)     \
+        return true;                                                            \
+      }                                                                         \
+                                                                                \
+      BOOST_PP_REPEAT(n, COMPOSITE_CONTROLLER_INTERFACE__HW_GET_FUNC_MACRO, ~)  \
+    };
+
+#define COMPOSITE_CONTROLLER_INTERFACE__HW_REG_MACRO(z, i, _) \
+  if(!registerSubInterface<T##i>(robot_hw)) return false;
+
+#define COMPOSITE_CONTROLLER_INTERFACE__HW_GET_FUNC_MACRO(z, i, _) \
+  T##i* get##i() { return static_cast<T##i *>(sub_ifaces_[i]); }
+
+BOOST_PP_REPEAT_FROM_TO(2, 7, COMPOSITE_CONTROLLER_INTERFACE__COMPOSITE_HW, ~)
+
+}
+}
+
+#endif
+

--- a/composite_controller_interface/package.xml
+++ b/composite_controller_interface/package.xml
@@ -1,0 +1,27 @@
+<package>
+  <name>composite_controller_interface</name>
+  <version>0.1.0</version>
+  <description>Composite Hardware Interface class.</description>
+  <maintainer email="kalevatykhia@gmail.com">Igor Kalevatykh</maintainer>
+
+  <license>BSD</license>
+
+  <url type="website">https://github.com/ros-controls/ros_control/wiki</url>
+  <url type="bugtracker">https://github.com/ros-controls/ros_control/issues</url>
+  <url type="repository">https://github.com/ros-controls/ros_control</url>
+
+  <author>Igor Kalevatykh</author>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  
+  <build_depend>roscpp</build_depend> 
+  <build_depend>hardware_interface</build_depend>
+  <build_depend>controller_interface</build_depend>  
+    
+  <run_depend>roscpp</run_depend>
+  <run_depend>hardware_interface</run_depend> 
+  <run_depend>controller_interface</run_depend>    
+
+  <export>
+  </export>
+</package>


### PR DESCRIPTION
Composite controller allow use several hardware interfaces in one controller. This commit is not change existing code, only adds new functionality.

Example:

``` c++
class MyController: public composite_controller_interface::CompositeController3<
                             hardware_interface::PositionJointInterface,
                             hardware_interface::ImuSensorInterface,
                             hardware_interface::ForceTorqueSensorInterface>

{
public:
  bool init( hardware_interface::PositionJointInterface *pos_hw;
             hardware_interface::ImuSensorInterface *imu_hw;
             hardware_interface::ForceTorqueSensorInterface *ft_hw,
             ros::NodeHandle &n)
  {
    // Use interfaces
  }
 ...
};

```
