### PR TITLE
Propagate urdfdom changes to CMakeLists.txt

### DIFF
--- a/joint_limits_interface/CMakeLists.txt
+++ b/joint_limits_interface/CMakeLists.txt
@@ -1,41 +1,56 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(joint_limits_interface)
 
+find_package(urdfdom REQUIRED)
+
 find_package(catkin REQUIRED
   roscpp
   rostest
   hardware_interface
-  urdfdom
 )
 
 include_directories(
   SYSTEM
   include
   ${catkin_INCLUDE_DIRS}
+  ${urdfdom_INCLUDE_DIRS}
 )
 
 # Declare catkin package
 catkin_package(
   CATKIN_DEPENDS
     roscpp
+    hardware_interface
   INCLUDE_DIRS
     include
     ${catkin_INCLUDE_DIRS}
+    ${urdfdom_INCLUDE_DIRS}
   LIBRARIES
     ${catkin_LIBRARIES}
+    ${urdfdom_LIBRARIES}
 )
 
 if(CATKIN_ENABLE_TESTING)
   catkin_add_gtest(joint_limits_interface_test test/joint_limits_interface_test.cpp)
-  target_link_libraries(joint_limits_interface_test ${catkin_LIBRARIES})
+  target_link_libraries(joint_limits_interface_test
+    ${catkin_LIBRARIES}
+    ${urdfdom_LIBRARIES}
+  )
 
-  catkin_add_gtest(joint_limits_urdf_test      test/joint_limits_urdf_test.cpp)
-  target_link_libraries(joint_limits_urdf_test ${catkin_LIBRARIES})
+  catkin_add_gtest(joint_limits_urdf_test test/joint_limits_urdf_test.cpp)
+  target_link_libraries(joint_limits_urdf_test
+    ${catkin_LIBRARIES}
+    ${urdfdom_LIBRARIES}
+  )
 
-  catkin_add_gtest(joint_limits_rosparam_test  test/joint_limits_urdf_test.cpp)
-  target_link_libraries(joint_limits_rosparam_test ${catkin_LIBRARIES})
-
-  add_rostest(test/joint_limits_rosparam.test)
+  add_rostest_gtest(joint_limits_rosparam_test
+    test/joint_limits_rosparam.test
+    test/joint_limits_rosparam_test.cpp
+  )
+  target_link_libraries(joint_limits_rosparam_test
+    ${catkin_LIBRARIES}
+    ${urdfdom_LIBRARIES}
+  )
 endif()
 
 # Install


### PR DESCRIPTION
urdfdom is now standalone, so it must be find_package'd independently.
Also, the rosparam rostest was not being built correctly.
