### PR TITLE
Add notifier function to allow hwinterface switching

### DIFF
--- a/controller_manager/include/controller_manager/controller_manager.h
+++ b/controller_manager/include/controller_manager/controller_manager.h
@@ -142,6 +142,12 @@ public:
                         const std::vector<std::string>& stop_controllers,
                         const int strictness);
 
+  /** \brief Notification for switching HW-Interfaces.
+   *
+   * \param info_list A list containing ControlInfo about the controllers to be started (containing the HW-Interfaces requested by the resources)
+   */
+  virtual bool notifyHardwareInterface(const std::list<hardware_interface::ControllerInfo> &info_list) {return true;}
+
   /** \brief Get a controller by name.
    *
    * \param name The name of a controller

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -439,6 +439,14 @@ bool ControllerManager::switchController(const std::vector<std::string>& start_c
     start_request_.clear();
     return false;
   }
+  
+  if(!notifyHardwareInterface(info_list))
+  {
+    ROS_ERROR("Could not switch controllers, because switching the HWInterface failed");
+    stop_request_.clear();
+    start_request_.clear();
+    return false;
+  }
 
   // start the atomic controller switching
   switch_strictness_ = strictness;
@@ -457,8 +465,6 @@ bool ControllerManager::switchController(const std::vector<std::string>& start_c
   ROS_DEBUG("Successfully switched controllers");
   return true;
 }
-
-
 
 
 


### PR DESCRIPTION
This PR is motivated by the feature proposed in [gazebo_ros_pkgs#256](https://github.com/ros-simulation/gazebo_ros_pkgs/pull/256)
For more details see [gazebo_ros_pkgs#256](https://github.com/ros-simulation/gazebo_ros_pkgs/pull/256)
#184 adds a notification function that is called in `ControllerManager::switchController`. This function can be used to switch the HardwareInterface for the resources of the controller that is meant to be started, i.e. **"Switch HardwareInterfaces on Switching Controllers.**

Default behaviour is simply `return true` - no effect.
