### PR TITLE
Disable spawner shutdown option

### DIFF
--- a/controller_manager/scripts/spawner
+++ b/controller_manager/scripts/spawner
@@ -89,7 +89,7 @@ def parse_args(args=None):
     parser.add_argument('--timeout', metavar='T', type=float, default=30,
                         help='how long to wait for controller_manager services when starting up [s] (default: 30)')
     parser.add_argument('--shutdown-timeout', metavar='T', type=float, default=30,
-                        help='how long to wait for controller_manager services when shutting down [s] (default: 30)')
+                        help='how long to wait for controller_manager services when shutting down [s] (default: 30). value 0 disables controllers from being unloaded')
     parser.add_argument('controllers', metavar='controller', nargs='+',
                         help='controllers to load')
     return parser.parse_args(args=args)

--- a/controller_manager/scripts/spawner
+++ b/controller_manager/scripts/spawner
@@ -168,8 +168,9 @@ def main():
             if rospy.is_shutdown():
                 return
 
-    # hook for unloading controllers on shutdown
-    rospy.on_shutdown(shutdown)
+    # hook for unloading controllers on shutdown. do not use if shutdown timeout is set to 0
+    if shutdown_timeout:
+        rospy.on_shutdown(shutdown)
 
     # find yaml files to load
     controllers = []


### PR DESCRIPTION
I've identified a problem when using the same launch file for the spawner python script and the controller_manager node. When using Ctrl-C to end the launch file, the controller_manager immediatley shutsdown but the spawner gets stuck because it is attempting to shutdown each controller it previously started, but the shutdown service is already ended with the controller_manager. 

I know for some hardware use cases, by passing the unload/shutdown service could be bad. But when using ros_control for baxter in the same launch file, this is a needed feature so that it doesn't unnecessarily hang.
