### PR TITLE
[WIP] HW interface switching revisited

### DIFF
--- a/hardware_interface/include/hardware_interface/robot_hw.h
+++ b/hardware_interface/include/hardware_interface/robot_hw.h
@@ -94,6 +94,18 @@ public:
 
     return in_conflict;
   }
+/** \name Mode Switching
+   *\{*/
+
+  /**
+   * Check (in non-realtime) if given controller to be started can be switched from the current state of the RobotHW
+   */
+  virtual bool canStart(const ControllerInfo &info) const {return true;}
+
+  /**
+   * actually start and stop internal command handling (in non-realtime)
+   */
+  virtual void doSwitch(const std::list<ControllerInfo> &start_list, const std::list<ControllerInfo> &stop_list) {}
 };
 
 }


### PR DESCRIPTION
Based on the discussions in #184 we have prepared a new version of the interface switching.

**Interface rationals:**
- Conflicts between controllers (and their interfaces) can be checked in checkForConflict
- New member canStart checks if the given controller can be started (including HW interface switches) from the current state. For strict checking the switch fails if one controller cannot be started, otherwise it is filtered out.
- We assume that controllers can be stopped at any time
- After all checks are passed  new member doSwitch is called with filtered lists of controllers that start or stop, but not restart
- All controller information needed for switching is contained in ControllerInfo

**Alternative implementations:**
- canStart was chosen in favour of the discussed canSwitch, because this simplifies the filtering and handling in general
- doSwitch only gets updates, not the the full list, this should simplify the handling of stopped interfaces
- doSwitch runs in the non-RT part, do you see any pros or cons for running it in the real-time part?

**Example usage:**
@ipa-fxm has prepared a gazebo plugin that uses this interface, you can find it here: https://github.com/ipa-fxm/cob_gazebo_plugins/tree/hwi_switch/cob_gazebo_ros_control (source+documentation)

_What do you think?_
