### PR TITLE
Address -Wunused-parameter warnings

### DIFF
--- a/controller_interface/include/controller_interface/controller.h
+++ b/controller_interface/include/controller_interface/controller.h
@@ -68,7 +68,7 @@ public:
    * \returns True if initialization was successful and the controller
    * is ready to be started.
    */
-  virtual bool init(T* hw, ros::NodeHandle &controller_nh) {return true;};
+  virtual bool init(T* /*hw*/, ros::NodeHandle& /*controller_nh*/) {return true;};
 
   /** \brief The init function is called to initialize the controller from a
    * non-realtime thread with a pointer to the hardware interface, itself,
@@ -85,7 +85,7 @@ public:
    * \returns True if initialization was successful and the controller
    * is ready to be started.
    */
-  virtual bool init(T* hw, ros::NodeHandle& root_nh, ros::NodeHandle &controller_nh) {return true;};
+  virtual bool init(T* /*hw*/, ros::NodeHandle& /*root_nh*/, ros::NodeHandle& /*controller_nh*/) {return true;};
 
 
 protected:

--- a/controller_interface/include/controller_interface/controller_base.h
+++ b/controller_interface/include/controller_interface/controller_base.h
@@ -60,7 +60,7 @@ public:
    *
    * \param time The current time
    */
-  virtual void starting(const ros::Time& time) {};
+  virtual void starting(const ros::Time& /*time*/) {};
 
   /** \brief This is called periodically by the realtime thread when the controller is running
    *
@@ -74,7 +74,7 @@ public:
    *
    * \param time The current time
    */
-  virtual void stopping(const ros::Time& time) {};
+  virtual void stopping(const ros::Time& /*time*/) {};
 
   /** \brief Check if the controller is running
    * \returns true if the controller is running

--- a/controller_manager/test/hwi_switch_test.cpp
+++ b/controller_manager/test/hwi_switch_test.cpp
@@ -223,8 +223,10 @@ class DummyControllerLoader: public controller_manager::ControllerLoaderInterfac
         const std::string type_name;
     public:
         DummyController(const std::string &name) : type_name(name) {}
-        virtual void update(const ros::Time& time, const ros::Duration& period) {}
-        virtual bool initRequest(hardware_interface::RobotHW* hw, ros::NodeHandle& root_nh, ros::NodeHandle &controller_nh,
+        virtual void update(const ros::Time& /*time*/, const ros::Duration& /*period*/) {}
+        virtual bool initRequest(hardware_interface::RobotHW* /*hw*/,
+                                 ros::NodeHandle& /*root_nh*/,
+                                 ros::NodeHandle &controller_nh,
                                  std::set<std::string>& claimed_resources)
         {
             std::vector<std::string> joints;

--- a/controller_manager_tests/include/controller_manager_tests/effort_test_controller.h
+++ b/controller_manager_tests/include/controller_manager_tests/effort_test_controller.h
@@ -43,10 +43,11 @@ class EffortTestController: public controller_interface::Controller<hardware_int
 public:
   EffortTestController(){}
 
-  bool init(hardware_interface::EffortJointInterface* hw, ros::NodeHandle &n);
-  void starting(const ros::Time& time);
-  void update(const ros::Time& time, const ros::Duration& period);
-  void stopping(const ros::Time& time);
+  using controller_interface::Controller<hardware_interface::EffortJointInterface>::init;
+  bool init(hardware_interface::EffortJointInterface* hw, ros::NodeHandle& /*n*/);
+  void starting(const ros::Time& /*time*/);
+  void update(const ros::Time& /*time*/, const ros::Duration& /*period*/);
+  void stopping(const ros::Time& /*time*/);
 
 private:
   std::vector<hardware_interface::JointHandle> joint_effort_commands_;

--- a/controller_manager_tests/include/controller_manager_tests/my_dummy_controller.h
+++ b/controller_manager_tests/include/controller_manager_tests/my_dummy_controller.h
@@ -51,10 +51,11 @@ class MyDummyController : public controller_interface::Controller<MyDummyInterfa
 public:
   MyDummyController() { }
 
-  bool init(MyDummyInterface* hw, ros::NodeHandle &n) { return true; }
-  void starting(const ros::Time& time) { }
-  void update(const ros::Time& time, const ros::Duration& period) { }
-  void stopping(const ros::Time& time) { }
+  using controller_interface::Controller<MyDummyInterface>::init;
+  bool init(MyDummyInterface* /*hw*/, ros::NodeHandle& /*n*/) { return true; }
+  void starting(const ros::Time& /*time*/) { }
+  void update(const ros::Time& /*time*/, const ros::Duration& /*period*/) { }
+  void stopping(const ros::Time& /*time*/) { }
 };
 
 }

--- a/controller_manager_tests/src/effort_test_controller.cpp
+++ b/controller_manager_tests/src/effort_test_controller.cpp
@@ -30,7 +30,7 @@
 
 using namespace controller_manager_tests;
 
-bool EffortTestController::init(hardware_interface::EffortJointInterface* hw, ros::NodeHandle &n)
+bool EffortTestController::init(hardware_interface::EffortJointInterface* hw, ros::NodeHandle& /*n*/)
 {
   // get all joint states from the hardware interface
   // const std::vector<std::string>& joint_names = hw->getJointNames();
@@ -46,12 +46,12 @@ bool EffortTestController::init(hardware_interface::EffortJointInterface* hw, ro
   return true;
 }
 
-void EffortTestController::starting(const ros::Time& time)
+void EffortTestController::starting(const ros::Time& /*time*/)
 {
   ROS_INFO("Starting JointState Controller");
 }
 
-void EffortTestController::update(const ros::Time& time, const ros::Duration& period)
+void EffortTestController::update(const ros::Time& /*time*/, const ros::Duration& /*period*/)
 {
   for (unsigned int i=0; i < joint_effort_commands_.size(); i++)
   {
@@ -59,7 +59,7 @@ void EffortTestController::update(const ros::Time& time, const ros::Duration& pe
   }
 }
 
-void EffortTestController::stopping(const ros::Time& time)
+void EffortTestController::stopping(const ros::Time& /*time*/)
 {
   ROS_INFO("Stopping JointState Controller");
 }

--- a/hardware_interface/include/hardware_interface/internal/hardware_resource_manager.h
+++ b/hardware_interface/include/hardware_interface/internal/hardware_resource_manager.h
@@ -121,7 +121,7 @@ struct ClaimResources
 
 struct DontClaimResources
 {
-  static void claim(HardwareInterface* hw, const std::string& name) {}
+  static void claim(HardwareInterface* /*hw*/, const std::string& /*name*/) {}
 };
 /** \endcond */
 

--- a/hardware_interface/include/hardware_interface/robot_hw.h
+++ b/hardware_interface/include/hardware_interface/robot_hw.h
@@ -102,13 +102,13 @@ public:
    * with regard to necessary hardware interface switches. Start and stop list are disjoint.
    * This is just a check, the actual switch is done in doSwitch()
    */
-  virtual bool canSwitch(const std::list<ControllerInfo> &start_list, const std::list<ControllerInfo> &stop_list) const { return true; }
+  virtual bool canSwitch(const std::list<ControllerInfo>& /*start_list*/, const std::list<ControllerInfo>& /*stop_list*/) const { return true; }
 
   /**
    * Perform (in non-realtime) all necessary hardware interface switches in order to start and stop the given controllers.
    * Start and stop list are disjoint. The feasability was checked in canSwitch() beforehand.
    */
-  virtual void doSwitch(const std::list<ControllerInfo> &start_list, const std::list<ControllerInfo> &stop_list) {}
+  virtual void doSwitch(const std::list<ControllerInfo>& /*start_list*/, const std::list<ControllerInfo>& /*stop_list*/) {}
 };
 
 }

--- a/transmission_interface/include/transmission_interface/joint_state_interface_provider.h
+++ b/transmission_interface/include/transmission_interface/joint_state_interface_provider.h
@@ -50,17 +50,17 @@ protected:
                          const RawJointDataMap&  raw_joint_data_map,
                          JointData&              jnt_state_data);
 
-  bool getJointCommandData(const TransmissionInfo& transmission_info,
-                           const RawJointDataMap&  raw_joint_data_map,
-                           JointData&              jnt_cmd_data) {return true;}
+  bool getJointCommandData(const TransmissionInfo& /*transmission_info*/,
+                           const RawJointDataMap&  /*raw_joint_data_map*/,
+                           JointData&              /*jnt_cmd_data*/) {return true;}
 
   bool getActuatorStateData(const TransmissionInfo&      transmission_info,
                             hardware_interface::RobotHW* robot_hw,
                             ActuatorData&                act_state_data);
 
-  bool getActuatorCommandData(const TransmissionInfo&      transmission_info,
-                              hardware_interface::RobotHW* robot_hw,
-                              ActuatorData&                act_cmd_data) {return true;}
+  bool getActuatorCommandData(const TransmissionInfo&      /*transmission_info*/,
+                              hardware_interface::RobotHW* /*robot_hw*/,
+                              ActuatorData&                /*act_cmd_data*/) {return true;}
 
   bool registerTransmission(TransmissionLoaderData& loader_data,
                             TransmissionHandleData& handle_data);


### PR DESCRIPTION
Building with stricter gcc flags produces many warnings. This PR addresses an important part of those.
