### PR TITLE
transmission_interface: Add new loading method

### DIFF
--- a/transmission_interface/include/transmission_interface/transmission_interface_loader.h
+++ b/transmission_interface/include/transmission_interface/transmission_interface_loader.h
@@ -374,6 +374,16 @@ public:
   bool load(const std::string& urdf);
 
   /**
+   * \brief Load all transmissions contained in a vector of \c TransmissionInfo instances.
+   *
+   * This method adds new joint and transmission interfaces to the \c RobotHW and \c RobotTransmissions instances
+   * passed in the constructor, respectively.
+   * \param transmission_info_vec Vector of \c TransmissionInfo instances.
+   * \return True if successful.
+   */
+  bool load(const std::vector<TransmissionInfo>& transmission_info_vec);
+
+  /**
    * \brief Load a single transmission.
    *
    * This method adds new joint and transmission interfaces to the \c RobotHW and \c RobotTransmissions instances

--- a/transmission_interface/src/transmission_interface_loader.cpp
+++ b/transmission_interface/src/transmission_interface_loader.cpp
@@ -118,7 +118,12 @@ bool TransmissionInterfaceLoader::load(const std::string& urdf)
     return false;
   }
 
-  BOOST_FOREACH(const TransmissionInfo& info, infos)
+  return load(infos);
+}
+
+bool TransmissionInterfaceLoader::load(const std::vector<TransmissionInfo>& transmission_info_vec)
+{
+  BOOST_FOREACH(const TransmissionInfo& info, transmission_info_vec)
   {
     if (!load(info)) {return false;}
   }


### PR DESCRIPTION
Allow loading transmissions from a vector of TransmissionInfo instances.

**Motivation**
This is irrelevant to the PR itself, but describes why we considered the proposed addition useful.

We have added support in our robots to change joint control modes at runtime (leveraging #200), and for that to work, we needed to reason about which actuators are associated to each joint requesting a control mode switch. Note that sometimes multiple actuators are coupled to a single joint, or the other way around.

All the information required to perform this reasoning is contained in the `vector<TransmissionInfo>`  that results from parsing a URDF. Before this PR, this vector was a implementation detail of the `TransmissionInterfaceLoader` class, and was not accessible to the outside. The proposed overload allows a user to generate the `vector<TransmissionInfo>`, and then:
- On initialization: Pass it to the `TransmissionInterfaceLoader`, for populating transmission and joint interfaces.
- When the robot is running: Keep it for reasoning about joint control mode switching.
