### PR TITLE
Per controller update period

### DIFF
--- a/controller_interface/include/controller_interface/controller_base.h
+++ b/controller_interface/include/controller_interface/controller_base.h
@@ -108,7 +108,7 @@ public:
       starting(time);
       state_ = RUNNING;
       skipped_update_cycles_ = 0;
-      total_update_period_ = ros::Duration();
+      time_since_last_update_ = ros::Duration();
       return true;
     }
     else
@@ -167,11 +167,11 @@ private:
 
   friend class controller_manager::ControllerManager;
 
-  /// The number of cycles skipped since the last update
+  /// The number of controller manager cycles skipped since the last controller update
   int skipped_update_cycles_;
 
-  /// The total period since the last update
-  ros::Duration total_update_period_;
+  /// The duration since the last controller update
+  ros::Duration time_since_last_update_;
 
 };
 

--- a/controller_interface/include/controller_interface/controller_base.h
+++ b/controller_interface/include/controller_interface/controller_base.h
@@ -41,6 +41,11 @@ namespace hardware_interface
   class InterfaceResources;
 }
 
+namespace controller_manager
+{
+  class ControllerManager;
+}
+
 namespace controller_interface
 {
 
@@ -102,6 +107,8 @@ public:
     if (state_ == RUNNING || state_ == INITIALIZED){
       starting(time);
       state_ = RUNNING;
+      skipped_update_cycles_ = 0;
+      total_update_period_ = ros::Duration();
       return true;
     }
     else
@@ -154,10 +161,17 @@ public:
   /// The current execution state of the controller
   enum {CONSTRUCTED, INITIALIZED, RUNNING} state_;
 
-
 private:
   ControllerBase(const ControllerBase &c);
   ControllerBase& operator =(const ControllerBase &c);
+
+  friend class controller_manager::ControllerManager;
+
+  /// The number of cycles skipped since the last update
+  int skipped_update_cycles_;
+
+  /// The total period since the last update
+  ros::Duration total_update_period_;
 
 };
 

--- a/controller_manager/include/controller_manager/controller_spec.h
+++ b/controller_manager/include/controller_manager/controller_spec.h
@@ -55,7 +55,7 @@ struct ControllerSpec
 {
   hardware_interface::ControllerInfo info;
   boost::shared_ptr<controller_interface::ControllerBase> c;
-  int update_every_n_cycles;        //! If greater than 0, this controller will only be updated every n-th cycle
+  int update_freq_divider; ///< If > 0, this controller will only be updated every n-th cycle
 };
 
 }

--- a/controller_manager/include/controller_manager/controller_spec.h
+++ b/controller_manager/include/controller_manager/controller_spec.h
@@ -55,6 +55,7 @@ struct ControllerSpec
 {
   hardware_interface::ControllerInfo info;
   boost::shared_ptr<controller_interface::ControllerBase> c;
+  int update_every_n_cycles;        //! If greater than 0, this controller will only be updated every n-th cycle
 };
 
 }

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -88,8 +88,26 @@ void ControllerManager::update(const ros::Time& time, const ros::Duration& perio
 
 
   // Update all controllers
-  for (size_t i=0; i<controllers.size(); i++)
-    controllers[i].c->updateRequest(time, period);
+  for (size_t i=0; i<controllers.size(); i++) {
+    const ControllerSpec& spec = controllers[i];
+
+    // update period accumulator and skipped_update_cycles counter
+    spec.c->total_update_period_ += period;
+    spec.c->skipped_update_cycles_++;
+
+    // skip cycle if skipped_update_cycles < update_every_n_cycles
+    //    (always update if update_every_n_cycles <= 1)
+    if (spec.c->skipped_update_cycles_ < spec.update_every_n_cycles) {
+      continue;
+    }
+
+    spec.c->updateRequest(time, spec.c->total_update_period_);
+
+    // reset period accumulator and skipped_update_cycles counter
+    spec.c->total_update_period_ = ros::Duration();
+    spec.c->skipped_update_cycles_ = 0;
+  }
+
 
   // there are controllers to start/stop
   if (please_switch_)
@@ -222,6 +240,19 @@ bool ControllerManager::loadController(const std::string& name)
     return false;
   }
 
+  // Configure update_every_n_cycles parameter
+  int update_every_n_cycles = 1;
+  if (c_nh.getParam("update_every_n_cycles", update_every_n_cycles))
+  {
+    if (update_every_n_cycles > 1) {
+      ROS_DEBUG("Controller '%s' of type '%s' will only be updated in steps of %d cycles.", name.c_str(), type.c_str(), update_every_n_cycles);
+    } else if (update_every_n_cycles < 1) {
+      ROS_ERROR("Could not load controller '%s' because the 'update_every_n_cycles' parameter cannot be zero or negative.", name.c_str());
+      to.clear();
+      return false;
+    }
+  }
+
   // Initializes the controller
   ROS_DEBUG("Initializing controller '%s'", name.c_str());
   bool initialized;
@@ -251,6 +282,7 @@ bool ControllerManager::loadController(const std::string& name)
   to[to.size()-1].info.name = name;
   to[to.size()-1].info.claimed_resources = claimed_resources;
   to[to.size()-1].c = c;
+  to[to.size()-1].update_every_n_cycles = update_every_n_cycles;
 
   // Destroys the old controllers list when the realtime thread is finished with it.
   int former_current_controllers_list_ = current_controllers_list_;

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -242,14 +242,24 @@ bool ControllerManager::loadController(const std::string& name)
 
   // Configure controller update frequency divider parameter
   int update_freq_divider = 1;
-  if (c_nh.getParam("update_freq_divider", update_freq_divider))
+  if (c_nh.hasParam("update_freq_divider"))
   {
-    if (update_freq_divider > 1) {
-      ROS_DEBUG("Controller '%s' of type '%s' will only be updated every %d cycles.",
-                name.c_str(), type.c_str(), update_freq_divider);
+    if (c_nh.getParam("update_freq_divider", update_freq_divider))
+    {
+      if (update_freq_divider > 1) {
+        ROS_DEBUG("Controller '%s' of type '%s' will only be updated every %d cycles.",
+                  name.c_str(), type.c_str(), update_freq_divider);
+      }
+      else if (update_freq_divider < 1) {
+        ROS_ERROR("Could not load controller '%s' because the 'update_freq_divider' parameter cannot be zero or negative.",
+                  name.c_str());
+        to.clear();
+        return false;
+      }
     }
-    else if (update_freq_divider < 1) {
-      ROS_ERROR("Could not load controller '%s' because the 'update_freq_divider' parameter cannot be zero or negative.",
+    else
+    {
+      ROS_ERROR("Could not load controller '%s' because the 'update_freq_divider' parameter is not an integer.",
                 name.c_str());
       to.clear();
       return false;

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -92,7 +92,7 @@ void ControllerManager::update(const ros::Time& time, const ros::Duration& perio
     const ControllerSpec& spec = controllers[i];
 
     // update period accumulator and skipped_update_cycles counter
-    spec.c->total_update_period_ += period;
+    spec.c->time_since_last_update_ += period;
     spec.c->skipped_update_cycles_++;
 
     // skip cycle if skipped_update_cycles < update_freq_divider
@@ -101,10 +101,10 @@ void ControllerManager::update(const ros::Time& time, const ros::Duration& perio
       continue;
     }
 
-    spec.c->updateRequest(time, spec.c->total_update_period_);
+    spec.c->updateRequest(time, spec.c->time_since_last_update_);
 
     // reset period accumulator and skipped_update_cycles counter
-    spec.c->total_update_period_ = ros::Duration();
+    spec.c->time_since_last_update_ = ros::Duration();
     spec.c->skipped_update_cycles_ = 0;
   }
 

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -95,9 +95,9 @@ void ControllerManager::update(const ros::Time& time, const ros::Duration& perio
     spec.c->total_update_period_ += period;
     spec.c->skipped_update_cycles_++;
 
-    // skip cycle if skipped_update_cycles < update_every_n_cycles
-    //    (always update if update_every_n_cycles <= 1)
-    if (spec.c->skipped_update_cycles_ < spec.update_every_n_cycles) {
+    // skip cycle if skipped_update_cycles < update_freq_divider
+    //    (always update if update_freq_divider <= 1)
+    if (spec.c->skipped_update_cycles_ < spec.update_freq_divider) {
       continue;
     }
 
@@ -240,14 +240,14 @@ bool ControllerManager::loadController(const std::string& name)
     return false;
   }
 
-  // Configure update_every_n_cycles parameter
-  int update_every_n_cycles = 1;
-  if (c_nh.getParam("update_every_n_cycles", update_every_n_cycles))
+  // Configure update_freq_divider parameter
+  int update_freq_divider = 1;
+  if (c_nh.getParam("update_freq_divider", update_freq_divider))
   {
-    if (update_every_n_cycles > 1) {
-      ROS_DEBUG("Controller '%s' of type '%s' will only be updated in steps of %d cycles.", name.c_str(), type.c_str(), update_every_n_cycles);
-    } else if (update_every_n_cycles < 1) {
-      ROS_ERROR("Could not load controller '%s' because the 'update_every_n_cycles' parameter cannot be zero or negative.", name.c_str());
+    if (update_freq_divider > 1) {
+      ROS_DEBUG("Controller '%s' of type '%s' will only be updated in steps of %d cycles.", name.c_str(), type.c_str(), update_freq_divider);
+    } else if (update_freq_divider < 1) {
+      ROS_ERROR("Could not load controller '%s' because the 'update_freq_divider' parameter cannot be zero or negative.", name.c_str());
       to.clear();
       return false;
     }
@@ -282,7 +282,7 @@ bool ControllerManager::loadController(const std::string& name)
   to[to.size()-1].info.name = name;
   to[to.size()-1].info.claimed_resources = claimed_resources;
   to[to.size()-1].c = c;
-  to[to.size()-1].update_every_n_cycles = update_every_n_cycles;
+  to[to.size()-1].update_freq_divider = update_freq_divider;
 
   // Destroys the old controllers list when the realtime thread is finished with it.
   int former_current_controllers_list_ = current_controllers_list_;

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -240,14 +240,17 @@ bool ControllerManager::loadController(const std::string& name)
     return false;
   }
 
-  // Configure update_freq_divider parameter
+  // Configure controller update frequency divider parameter
   int update_freq_divider = 1;
   if (c_nh.getParam("update_freq_divider", update_freq_divider))
   {
     if (update_freq_divider > 1) {
-      ROS_DEBUG("Controller '%s' of type '%s' will only be updated in steps of %d cycles.", name.c_str(), type.c_str(), update_freq_divider);
-    } else if (update_freq_divider < 1) {
-      ROS_ERROR("Could not load controller '%s' because the 'update_freq_divider' parameter cannot be zero or negative.", name.c_str());
+      ROS_DEBUG("Controller '%s' of type '%s' will only be updated every %d cycles.",
+                name.c_str(), type.c_str(), update_freq_divider);
+    }
+    else if (update_freq_divider < 1) {
+      ROS_ERROR("Could not load controller '%s' because the 'update_freq_divider' parameter cannot be zero or negative.",
+                name.c_str());
       to.clear();
       return false;
     }

--- a/controller_manager_tests/CMakeLists.txt
+++ b/controller_manager_tests/CMakeLists.txt
@@ -27,6 +27,8 @@ add_library(${PROJECT_NAME}
   include/controller_manager_tests/pos_eff_opt_controller.h
   src/my_dummy_controller.cpp
   include/controller_manager_tests/my_dummy_controller.h
+  src/pub_period_controller.cpp
+  include/controller_manager_tests/pub_period_controller.h
   )
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 

--- a/controller_manager_tests/include/controller_manager_tests/pub_period_controller.h
+++ b/controller_manager_tests/include/controller_manager_tests/pub_period_controller.h
@@ -1,0 +1,59 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2015, PAL Robotics S.L.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the names of PAL Robotics S.L. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+#ifndef CONTROLLER_MANAGER_TESTS_PUB_PERIOD_CONTROLLER_H
+#define CONTROLLER_MANAGER_TESTS_PUB_PERIOD_CONTROLLER_H
+
+#include <ros/publisher.h>
+#include <controller_interface/controller.h>
+#include <hardware_interface/joint_command_interface.h>
+#include <pluginlib/class_list_macros.h>
+
+
+namespace controller_manager_tests
+{
+
+
+class PubPeriodController: public controller_interface::Controller<hardware_interface::JointStateInterface>
+{
+public:
+  PubPeriodController(){}
+
+  using controller_interface::Controller<hardware_interface::JointStateInterface>::init;
+  bool init(hardware_interface::JointStateInterface* /*hw*/, ros::NodeHandle& n);
+  void starting(const ros::Time& /*time*/);
+  void update(const ros::Time& /*time*/, const ros::Duration& period);
+  void stopping(const ros::Time& /*time*/);
+
+private:
+  ros::Publisher period_pub_; // NOTE: Non real-time, for testing only
+
+};
+
+}
+
+#endif

--- a/controller_manager_tests/src/pub_period_controller.cpp
+++ b/controller_manager_tests/src/pub_period_controller.cpp
@@ -1,0 +1,56 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2012, hiDOF INC.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of hiDOF Inc nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+#include <std_msgs/Duration.h>
+#include <controller_manager_tests/pub_period_controller.h>
+
+using namespace controller_manager_tests;
+
+bool PubPeriodController::init(hardware_interface::JointStateInterface* /*hw*/, ros::NodeHandle& n)
+{
+  period_pub_ = n.advertise<std_msgs::Duration>("period", 1);
+  return true;
+}
+
+void PubPeriodController::starting(const ros::Time& /*time*/)
+{
+  ROS_INFO("Starting JointState Controller");
+}
+
+void PubPeriodController::update(const ros::Time& /*time*/, const ros::Duration& period)
+{
+  std_msgs::Duration msg;
+  msg.data = period;
+  period_pub_.publish(msg);
+}
+
+void PubPeriodController::stopping(const ros::Time& /*time*/)
+{
+  ROS_INFO("Stopping JointState Controller");
+}
+
+PLUGINLIB_EXPORT_CLASS( controller_manager_tests::PubPeriodController, controller_interface::ControllerBase)

--- a/controller_manager_tests/test/cm_test.test
+++ b/controller_manager_tests/test/cm_test.test
@@ -6,6 +6,7 @@
       type: controller_manager_tests/EffortTestController
     non_existent_interface_controller:
       type: controller_manager_tests/MyDummyController
+
     vel_eff_controller:
       type: controller_manager_tests/VelEffController
       velocity_joints:
@@ -41,6 +42,16 @@
       - hiDOF_joint2
       effort_joints:
       - hiDOF_joint1
+
+    half_freq_controller:
+      type: controller_manager_tests/PubPeriodController
+      update_freq_divider: 2
+    invalid_value_freq_controller:
+      type: controller_manager_tests/PubPeriodController
+      update_freq_divider: 0
+    invalid_type_freq_controller:
+      type: controller_manager_tests/PubPeriodController
+      update_freq_divider: two
   </rosparam>
 
   <node pkg="controller_manager_tests" type="dummy_app" name="dummy_app" />

--- a/controller_manager_tests/test_controllers_plugin.xml
+++ b/controller_manager_tests/test_controllers_plugin.xml
@@ -31,4 +31,10 @@
   </description>
   </class>
 
+  <class name="controller_manager_tests/PubPeriodController" type="controller_manager_tests::PubPeriodController" base_class_type="controller_interface::ControllerBase">
+  <description>
+    Controller that publishes its update period to a ROS topic.
+  </description>
+  </class>
+
 </library>


### PR DESCRIPTION
Superceeds #127.

I'm proposing the feature in jade first, as the tests leverage the testing infrastructure I put in place for #204. ~~Because of that, please ignore all commits until 5c3f066, which is when this feature actually starts~~.

The changes are basically what @meyerj initially proposed, with some variable rename proposals, minor code refactoring and tests. I'd like some feedback especially on the renaming done in c0c38fd and 3ddb2f0. Once we have an agreement on that, I'll squash the changesets and backport to indigo.
