### PR TITLE
Introduce prepareSwitch

### DIFF
--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -472,7 +472,7 @@ bool ControllerManager::switchController(const std::vector<std::string>& start_c
     return false;
   }
 
-  if (!robot_hw_->canSwitch(start_list, stop_list))
+  if (!robot_hw_->prepareSwitch(start_list, stop_list))
   {
     ROS_ERROR("Could not switch controllers. The hardware interface combination for the requested controllers is unfeasible.");
     stop_request_.clear();

--- a/hardware_interface/include/hardware_interface/robot_hw.h
+++ b/hardware_interface/include/hardware_interface/robot_hw.h
@@ -101,8 +101,16 @@ public:
    * Check (in non-realtime) if given controllers could be started and stopped from the current state of the RobotHW
    * with regard to necessary hardware interface switches. Start and stop list are disjoint.
    * This is just a check, the actual switch is done in doSwitch()
+   * @deprecated: Implement prepareSwitch() instead
    */
   virtual bool canSwitch(const std::list<ControllerInfo>& /*start_list*/, const std::list<ControllerInfo>& /*stop_list*/) const { return true; }
+
+  /**
+   * Check (in non-realtime) if given controllers could be started and stopped from the current state of the RobotHW
+   * with regard to necessary hardware interface switches and prepare the switching. Start and stop list are disjoint.
+   * This handles the check and preparation, the actual switch is commited in doSwitch()
+   */
+  virtual bool prepareSwitch(const std::list<ControllerInfo>& start_list, const std::list<ControllerInfo>& stop_list) { return canSwitch(start_list, stop_list); }
 
   /**
    * Perform (in non-realtime) all necessary hardware interface switches in order to start and stop the given controllers.


### PR DESCRIPTION
This PR introduces `prepareSwitch` as a replacement for `canSwitch`, which will be deprecated.
The reasons behind are discussed in #211.

Summary:
`doSwitch` should be run in the RT-part (#209,#210), so it must not perform blocking tasks.
Thus much more work needs to be done in `canSwitch`. That's why it is preferable to have a non-const equivalent.  A new name was applied to emphasize the extended role.

Existing implementations with `canSwitch` will  still work.
