### PR TITLE
Joint limits debug helper functionality

### DIFF
--- a/joint_limits_interface/include/joint_limits_interface/joint_limits.h
+++ b/joint_limits_interface/include/joint_limits_interface/joint_limits.h
@@ -50,6 +50,26 @@ struct JointLimits
       angle_wraparound(false)
   {}
 
+public:
+
+  // Helper function for debuggging, not realtime safe
+  void print()
+  {
+    std::cout << "min_position " << min_position << std::endl;
+    std::cout << "max_position " << max_position << std::endl;
+    std::cout << "max_velocity " << max_velocity << std::endl;
+    std::cout << "max_acceleration " << max_acceleration << std::endl;
+    std::cout << "max_jerk " << max_jerk << std::endl;
+    std::cout << "max_effort " << max_effort << std::endl;
+
+    std::cout << "has_position_limits " << has_position_limits << std::endl;
+    std::cout << "has_velocity_limits " << has_velocity_limits << std::endl;
+    std::cout << "has_acceleration_limits " << has_acceleration_limits << std::endl;
+    std::cout << "has_jerk_limits " << has_jerk_limits << std::endl;
+    std::cout << "has_effort_limits " << has_effort_limits << std::endl;
+    std::cout << "angle_wraparound " << angle_wraparound << std::endl;
+  }
+
   double min_position;
   double max_position;
   double max_velocity;

--- a/joint_limits_interface/include/joint_limits_interface/joint_limits_interface.h
+++ b/joint_limits_interface/include/joint_limits_interface/joint_limits_interface.h
@@ -111,6 +111,27 @@ public:
     }
 
     const double cmd = internal::saturate(jh_.getCommand(), min_pos, max_pos);
+
+    // Optional helper code for debugging, not realtime safe ----------
+#define USE_JOINT_LIMIT_DEBUG 0 // Set to 1 to enable debug output
+#if USE_JOINT_LIMIT_DEBUG
+    if (cmd != jh_.getCommand())
+    {
+      // Determine if velocity or position is what limited us
+      if (min_pos != min_pos_limit_ || max_pos != max_pos_limit_)
+        std::cout << "VELOCITY LIMIT ";
+      else
+        std::cout << "POSITION LIMIT ";
+
+      // Limit violation details
+      std::cout << jh_.getName() << " position - original: " << jh_.getCommand() << " new: " << cmd
+                << " diff: " << jh_.getCommand() - cmd
+                << " vel_pos_delta: " << (limits_.max_velocity * period.toSec())
+                << std::endl;
+    }
+#endif
+    // ----------------------------------------------------
+
     jh_.setCommand(cmd);
     prev_cmd_ = cmd;
   }

--- a/joint_limits_interface/include/joint_limits_interface/joint_limits_interface.h
+++ b/joint_limits_interface/include/joint_limits_interface/joint_limits_interface.h
@@ -113,8 +113,8 @@ public:
     const double cmd = internal::saturate(jh_.getCommand(), min_pos, max_pos);
 
     // Optional helper code for debugging, not realtime safe ----------
-#define USE_JOINT_LIMIT_DEBUG 0 // Set to 1 to enable debug output
-#if USE_JOINT_LIMIT_DEBUG
+#define USE_JOINT_LIMIT_DEBUG // Show warnings when joint limits exceeded
+#ifdef USE_JOINT_LIMIT_DEBUG
     if (cmd != jh_.getCommand())
     {
       // Determine if velocity or position is what limited us


### PR DESCRIPTION
Currently there is no easy way to tell when the joint_limits_interface is limiting joints, but it can be very helpful in debugging why your trajectory isn't moving the way it should to get feedback during testing. This well documented debug code is disabled by default (not even compiled) but allows one to see information about joint limits and usage of them.

If other maintainers like this addition, we can add the debug to all types of joint_limits_interfaces, not just the position joint limit.
