### PR TITLE
Prepare switch jade

### DIFF
--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -471,7 +471,7 @@ bool ControllerManager::switchController(const std::vector<std::string>& start_c
     return false;
   }
 
-  if (!robot_hw_->canSwitch(start_list, stop_list))
+  if (!robot_hw_->prepareSwitch(start_list, stop_list))
   {
     ROS_ERROR("Could not switch controllers. The hardware interface combination for the requested controllers is unfeasible.");
     stop_request_.clear();

--- a/controller_manager/test/hwi_switch_test.cpp
+++ b/controller_manager/test/hwi_switch_test.cpp
@@ -86,7 +86,7 @@ class SwitchBot : public hardware_interface::RobotHW
             if(can_switch) interfaces_.insert(hardware_interface::internal::demangledTypeName<Interface>() );
             iface.registerHandle(typename Interface::ResourceHandleType(jsh_, &dummy_));
         }
-        bool canSwitch(const std::string &n) const
+        bool prepareSwitch(const std::string &n)
         {
             if(interfaces_.find(n) == interfaces_.end()) return false;
             return n >= current_;
@@ -135,11 +135,11 @@ public:
 
     }
 
-    virtual bool canSwitch(const std::list<hardware_interface::ControllerInfo>& start_list,
-                           const std::list<hardware_interface::ControllerInfo>& stop_list) const
+    virtual bool prepareSwitch(const std::list<hardware_interface::ControllerInfo>& start_list,
+                               const std::list<hardware_interface::ControllerInfo>& stop_list)
     {
 
-        if(!RobotHW::canSwitch(start_list, stop_list))
+        if(!RobotHW::prepareSwitch(start_list, stop_list))
         {
             ROS_ERROR("Something is wrong with RobotHW");
             return false;
@@ -171,7 +171,7 @@ public:
                 // per joint check
                 try
                 {
-                    if(!joints_.at(*res_it)->canSwitch(iface_res.hardware_interface))
+                    if(!joints_.at(*res_it)->prepareSwitch(iface_res.hardware_interface))
                     {
                         ROS_ERROR_STREAM("Cannot switch " << *res_it << " to " << iface_res.hardware_interface);
                         return false;

--- a/hardware_interface/include/hardware_interface/robot_hw.h
+++ b/hardware_interface/include/hardware_interface/robot_hw.h
@@ -116,24 +116,15 @@ public:
 
   /**
    * Check (in non-realtime) if given controllers could be started and stopped from the current state of the RobotHW
-   * with regard to necessary hardware interface switches. Start and stop list are disjoint.
-   * This is just a check, the actual switch is done in doSwitch()
-   * @deprecated: Implement prepareSwitch() instead
-   */
-  virtual bool canSwitch(const std::list<ControllerInfo>& /*start_list*/,
-                         const std::list<ControllerInfo>& /*stop_list*/) const { return true; }
-
-  /**
-   * Check (in non-realtime) if given controllers could be started and stopped from the current state of the RobotHW
    * with regard to necessary hardware interface switches and prepare the switching. Start and stop list are disjoint.
    * This handles the check and preparation, the actual switch is commited in doSwitch()
    */
   virtual bool prepareSwitch(const std::list<ControllerInfo>& start_list,
-                             const std::list<ControllerInfo>& stop_list) { return canSwitch(start_list, stop_list); }
+                             const std::list<ControllerInfo>& stop_list) { return true; }
 
   /**
    * Perform (in non-realtime) all necessary hardware interface switches in order to start and stop the given controllers.
-   * Start and stop list are disjoint. The feasability was checked in canSwitch() beforehand.
+   * Start and stop list are disjoint. The feasability was checked in prepareSwitch() beforehand.
    */
   virtual void doSwitch(const std::list<ControllerInfo>& /*start_list*/,
                         const std::list<ControllerInfo>& /*stop_list*/) {}

--- a/hardware_interface/include/hardware_interface/robot_hw.h
+++ b/hardware_interface/include/hardware_interface/robot_hw.h
@@ -120,20 +120,23 @@ public:
    * This is just a check, the actual switch is done in doSwitch()
    * @deprecated: Implement prepareSwitch() instead
    */
-  virtual bool canSwitch(const std::list<ControllerInfo>& /*start_list*/, const std::list<ControllerInfo>& /*stop_list*/) const { return true; }
+  virtual bool canSwitch(const std::list<ControllerInfo>& /*start_list*/,
+                         const std::list<ControllerInfo>& /*stop_list*/) const { return true; }
 
   /**
    * Check (in non-realtime) if given controllers could be started and stopped from the current state of the RobotHW
    * with regard to necessary hardware interface switches and prepare the switching. Start and stop list are disjoint.
    * This handles the check and preparation, the actual switch is commited in doSwitch()
    */
-  virtual bool prepareSwitch(const std::list<ControllerInfo>& start_list, const std::list<ControllerInfo>& stop_list) { return canSwitch(start_list, stop_list); }
+  virtual bool prepareSwitch(const std::list<ControllerInfo>& start_list,
+                             const std::list<ControllerInfo>& stop_list) { return canSwitch(start_list, stop_list); }
 
   /**
    * Perform (in non-realtime) all necessary hardware interface switches in order to start and stop the given controllers.
    * Start and stop list are disjoint. The feasability was checked in canSwitch() beforehand.
    */
-  virtual void doSwitch(const std::list<ControllerInfo>& /*start_list*/, const std::list<ControllerInfo>& /*stop_list*/) {}
+  virtual void doSwitch(const std::list<ControllerInfo>& /*start_list*/,
+                        const std::list<ControllerInfo>& /*stop_list*/) {}
 };
 
 }

--- a/hardware_interface/include/hardware_interface/robot_hw.h
+++ b/hardware_interface/include/hardware_interface/robot_hw.h
@@ -118,8 +118,16 @@ public:
    * Check (in non-realtime) if given controllers could be started and stopped from the current state of the RobotHW
    * with regard to necessary hardware interface switches. Start and stop list are disjoint.
    * This is just a check, the actual switch is done in doSwitch()
+   * @deprecated: Implement prepareSwitch() instead
    */
   virtual bool canSwitch(const std::list<ControllerInfo>& /*start_list*/, const std::list<ControllerInfo>& /*stop_list*/) const { return true; }
+
+  /**
+   * Check (in non-realtime) if given controllers could be started and stopped from the current state of the RobotHW
+   * with regard to necessary hardware interface switches and prepare the switching. Start and stop list are disjoint.
+   * This handles the check and preparation, the actual switch is commited in doSwitch()
+   */
+  virtual bool prepareSwitch(const std::list<ControllerInfo>& start_list, const std::list<ControllerInfo>& stop_list) { return canSwitch(start_list, stop_list); }
 
   /**
    * Perform (in non-realtime) all necessary hardware interface switches in order to start and stop the given controllers.


### PR DESCRIPTION
- Forward port of #217.
- Deprecation of `RobotHW::canSwitch`.
