### PR TITLE
Throw error if EffortJointSaturationHandle is missing effort or velocity limits

### DIFF
--- a/joint_limits_interface/include/joint_limits_interface/joint_limits_interface.h
+++ b/joint_limits_interface/include/joint_limits_interface/joint_limits_interface.h
@@ -267,9 +267,19 @@ class EffortJointSaturationHandle
 {
 public:
   EffortJointSaturationHandle(const hardware_interface::JointHandle& jh, const JointLimits& limits)
+    : jh_(jh)
+    , limits_(limits)
   {
-    jh_ = jh;
-    limits_ = limits;
+    if (!limits.has_velocity_limits)
+    {
+      throw JointLimitsInterfaceException("Cannot enforce limits for joint '" + getName() +
+                                           "'. It has no velocity limits specification.");
+    }
+    if (!limits.has_effort_limits)
+    {
+      throw JointLimitsInterfaceException("Cannot enforce limits for joint '" + getName() +
+                                          "'. It has no efforts limits specification.");
+    }
   }
 
   /** \return Joint name. */
@@ -280,17 +290,8 @@ public:
    */
   void enforceLimits(const ros::Duration& /* period */)
   {
-    double min_eff, max_eff;
-    if (limits_.has_effort_limits)
-    {
-      min_eff = -limits_.max_effort;
-      max_eff = limits_.max_effort;
-    }
-    else
-    {
-      min_eff = -std::numeric_limits<double>::max();
-      max_eff = std::numeric_limits<double>::max();
-    }
+    double min_eff = -limits_.max_effort;
+    double max_eff = limits_.max_effort;
 
     if (limits_.has_position_limits)
     {
@@ -301,14 +302,11 @@ public:
         max_eff = 0;
     }
 
-    if (limits_.has_velocity_limits)
-    {
-      const double vel = jh_.getVelocity();
-      if (vel < -limits_.max_velocity)
-        min_eff = 0;
-      else if (vel > limits_.max_velocity)
-        max_eff = 0;
-    }
+    const double vel = jh_.getVelocity();
+    if (vel < -limits_.max_velocity)
+      min_eff = 0;
+    else if (vel > limits_.max_velocity)
+      max_eff = 0;
 
     jh_.setCommand(internal::saturate(jh_.getCommand(), min_eff, max_eff));
   }


### PR DESCRIPTION
This makes the EffortJointSaturationHandle have uniform behavior with all the other SaturationHandles.  It also makes it behave the same as the EffortJointSoftLimitsHandle, where it has:

```
   EffortJointSoftLimitsHandle(const hardware_interface::JointHandle& jh,
                               const JointLimits&                     limits,
                               const SoftJointLimits&                 soft_limits)
   : jh_(jh),
     limits_(limits),
     soft_limits_(soft_limits)
   {
     if (!limits.has_velocity_limits)
     {
       throw JointLimitsInterfaceException("Cannot enforce limits for joint '" + getName() +
                                            "'. It has no velocity limits specification.");
     }
     if (!limits.has_effort_limits)
     {
       throw JointLimitsInterfaceException("Cannot enforce limits for joint '" + getName() +
                                            "'. It has no effort limits specification.");
     }
   }
```

See this discussion for more details https://github.com/ros-controls/ros_control/issues/213
