### PR TITLE
Switch TravisCI to run on Trusty and Indigo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 # Travis Continuous Integration Configuration File For ROS Control Projects
 # Author: Dave Coleman
+sudo: required
+dist: trusty
 language:
   - cpp
   - python
@@ -16,11 +18,11 @@ notifications:
     on_failure: change #[always|never|change] # default: always
 before_install: # Use this to prepare the system to install prerequisites or dependencies
   # Define some config vars
-  - export ROS_DISTRO=hydro
+  - export ROS_DISTRO=indigo
   - export CI_SOURCE_PATH=$(pwd)
   - export REPOSITORY_NAME=${PWD##*/}
   - echo "Testing branch $TRAVIS_BRANCH of $REPOSITORY_NAME"
-  - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu precise main" > /etc/apt/sources.list.d/ros-latest.list'
+  - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list'
   - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
   - sudo apt-get update -qq
   - sudo apt-get install -qq -y python-catkin-pkg python-rosdep python-wstool ros-$ROS_DISTRO-catkin ros-$ROS_DISTRO-ros
@@ -42,7 +44,7 @@ install: # Use this to install any prerequisites or dependencies necessary to ru
   # Install dependencies for source repos
   - rosdep install --from-paths src --ignore-src --rosdistro $ROS_DISTRO -y
 before_script: # Use this to prepare your build for testing e.g. copy database configurations, environment variables, etc.
+  - export PYTHONPATH=/usr/lib/python2.7/dist-packages:$PYTHONPATH
   - source /opt/ros/$ROS_DISTRO/setup.bash  
 script: # All commands must exit with code 0 on success. Anything else is considered failure.
-  - catkin_make -j2
-
+  - catkin_make -j2 --cmake-args -Wno-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,4 +47,4 @@ before_script: # Use this to prepare your build for testing e.g. copy database c
   - export PYTHONPATH=/usr/lib/python2.7/dist-packages:$PYTHONPATH
   - source /opt/ros/$ROS_DISTRO/setup.bash  
 script: # All commands must exit with code 0 on success. Anything else is considered failure.
-  - catkin_make -j2 --cmake-args -Wno-dev
+  - catkin_make -j2


### PR DESCRIPTION
Travis supports Trusty now(https://docs.travis-ci.com/user/trusty-ci-environment/).
Switched Travis CI to use on Trusty and Indigo.

This seems to fix CI build. https://travis-ci.org/otamachan/ros_control/builds/95798345
