### PR TITLE
Change language generic in travis.yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@
 # Author: Dave Coleman
 sudo: required
 dist: trusty
-language:
-  - cpp
-  - python
+language: generic
 python:
   - "2.7"
 compiler:
@@ -44,7 +42,6 @@ install: # Use this to install any prerequisites or dependencies necessary to ru
   # Install dependencies for source repos
   - rosdep install --from-paths src --ignore-src --rosdistro $ROS_DISTRO -y
 before_script: # Use this to prepare your build for testing e.g. copy database configurations, environment variables, etc.
-  - export PYTHONPATH=/usr/lib/python2.7/dist-packages:$PYTHONPATH
   - source /opt/ros/$ROS_DISTRO/setup.bash  
 script: # All commands must exit with code 0 on success. Anything else is considered failure.
   - catkin_make -j2


### PR DESCRIPTION
Thanks to @ipa-mdl, it is possible to avoid adding `/usr/lib/python2.7/dist-packages` .
