### PR TITLE
Clarify that hardwareInterface element is optional for actuators

### DIFF
--- a/transmission_interface/src/transmission_parser.cpp
+++ b/transmission_interface/src/transmission_parser.cpp
@@ -229,7 +229,7 @@ bool TransmissionParser::parseActuators(TiXmlElement *trans_it, std::vector<Actu
     }
     if (actuator.hardware_interfaces_.empty())
     {
-      ROS_DEBUG_STREAM_NAMED("parser","No valid hardware interface element found in actuator '"
+      ROS_DEBUG_STREAM_NAMED("parser","Optional: No valid hardware interface element found in actuator '"
         << actuator.name_ << "'.");
       // continue; // NOTE: Hardware interface is optional, so we keep on going
     }


### PR DESCRIPTION
This confused me for a long time today. I also updated the transmission XML documentation to explain the existence of this optional element: 

http://wiki.ros.org/action/info/urdf/XML/Transmission?action=diff&rev2=18&rev1=17
