### PR TITLE
Replace boost::shared_ptr<urdf::XY> with urdf::XYConstSharedPtr

### DIFF
--- a/joint_limits_interface/include/joint_limits_interface/joint_limits_interface.h
+++ b/joint_limits_interface/include/joint_limits_interface/joint_limits_interface.h
@@ -36,8 +36,6 @@
 #include <cmath>
 #include <limits>
 
-#include <boost/shared_ptr.hpp>
-
 #include <ros/duration.h>
 
 #include <hardware_interface/internal/resource_manager.h>

--- a/joint_limits_interface/include/joint_limits_interface/joint_limits_urdf.h
+++ b/joint_limits_interface/include/joint_limits_interface/joint_limits_urdf.h
@@ -48,7 +48,7 @@ namespace joint_limits_interface
  * values. Values in \e limits not present in \e urdf_joint remain unchanged.
  * \return True if \e urdf_joint has a valid limits specification, false otherwise.
  */
-inline bool getJointLimits(boost::shared_ptr<const urdf::Joint> urdf_joint, JointLimits& limits)
+inline bool getJointLimits(urdf::JointConstSharedPtr urdf_joint, JointLimits& limits)
 {
   if (!urdf_joint || !urdf_joint->limits)
   {
@@ -84,7 +84,7 @@ inline bool getJointLimits(boost::shared_ptr<const urdf::Joint> urdf_joint, Join
  * \param[out] soft_limits Where URDF soft joint limit data gets written into.
  * \return True if \e urdf_joint has a valid soft limits specification, false otherwise.
  */
-inline bool getSoftJointLimits(boost::shared_ptr<const urdf::Joint> urdf_joint, SoftJointLimits& soft_limits)
+inline bool getSoftJointLimits(urdf::JointConstSharedPtr urdf_joint, SoftJointLimits& soft_limits)
 {
   if (!urdf_joint || !urdf_joint->safety)
   {

--- a/joint_limits_interface/mainpage.dox
+++ b/joint_limits_interface/mainpage.dox
@@ -64,7 +64,7 @@ int main(int argc, char** argv)
   // Populate (soft) joint limits from URDF
   // Limits specified in URDF overwrite existing values in 'limits' and 'soft_limits'
   // Limits not specified in URDF preserve their existing values
-  boost::shared_ptr<const urdf::Joint> urdf_joint = urdf->getJoint("foo_joint");
+  urdf::JointConstSharedPtr urdf_joint = urdf->getJoint("foo_joint");
   const bool urdf_limits_ok = getJointLimits(urdf_joint, limits);
   const bool urdf_soft_limits_ok = getSoftJointLimits(urdf_joint, soft_limits);
 

--- a/joint_limits_interface/test/joint_limits_urdf_test.cpp
+++ b/joint_limits_interface/test/joint_limits_urdf_test.cpp
@@ -58,9 +58,9 @@ public:
   }
 
 protected:
-  boost::shared_ptr<urdf::JointLimits> urdf_limits;
-  boost::shared_ptr<urdf::JointSafety> urdf_safety;
-  boost::shared_ptr<urdf::Joint> urdf_joint;
+  urdf::JointLimitsSharedPtr urdf_limits;
+  urdf::JointSafetySharedPtr urdf_safety;
+  urdf::JointSharedPtr urdf_joint;
 };
 
 TEST_F(JointLimitsUrdfTest, GetJointLimits)
@@ -68,14 +68,14 @@ TEST_F(JointLimitsUrdfTest, GetJointLimits)
   // Unset URDF joint
   {
     JointLimits limits;
-    boost::shared_ptr<urdf::Joint> urdf_joint_bad;
+    urdf::JointSharedPtr urdf_joint_bad;
     EXPECT_FALSE(getJointLimits(urdf_joint_bad, limits));
   }
 
   // Unset URDF limits
   {
     JointLimits limits;
-    boost::shared_ptr<urdf::Joint> urdf_joint_bad(new urdf::Joint);
+    urdf::JointSharedPtr urdf_joint_bad(new urdf::Joint);
     EXPECT_FALSE(getJointLimits(urdf_joint_bad, limits));
   }
 
@@ -160,14 +160,14 @@ TEST_F(JointLimitsUrdfTest, GetSoftJointLimits)
   // Unset URDF joint
   {
     SoftJointLimits soft_limits;
-    boost::shared_ptr<urdf::Joint> urdf_joint_bad;
+    urdf::JointSharedPtr urdf_joint_bad;
     EXPECT_FALSE(getSoftJointLimits(urdf_joint_bad, soft_limits));
   }
 
   // Unset URDF limits
   {
     SoftJointLimits soft_limits;
-    boost::shared_ptr<urdf::Joint> urdf_joint_bad(new urdf::Joint);
+    urdf::JointSharedPtr urdf_joint_bad(new urdf::Joint);
     EXPECT_FALSE(getSoftJointLimits(urdf_joint_bad, soft_limits));
   }
 


### PR DESCRIPTION
To ease "unboosting" efforts from URDF
