### PR TITLE
Remove boost from depends declaration to fix cmake warning

### DIFF
--- a/controller_interface/CMakeLists.txt
+++ b/controller_interface/CMakeLists.txt
@@ -6,7 +6,6 @@ find_package(catkin REQUIRED COMPONENTS roscpp hardware_interface pluginlib)
 
 # Declare catkin package
 catkin_package(
-  DEPENDS boost
   CATKIN_DEPENDS roscpp hardware_interface pluginlib
   INCLUDE_DIRS include
   )

--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -4,11 +4,13 @@ project(controller_manager)
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS controller_interface controller_manager_msgs hardware_interface realtime_tools pluginlib)
 
+find_package(Boost REQUIRED COMPONENTS thread)
+
 include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
 
 # Declare catkin package
 catkin_package(
-  DEPENDS boost
+  DEPENDS Boost
   CATKIN_DEPENDS controller_interface controller_manager_msgs hardware_interface realtime_tools pluginlib
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}


### PR DESCRIPTION
This is to remove 2 cmake warnings for said packages.

`catkin_package() DEPENDS on 'boost' but neither 'boost_INCLUDE_DIRS' nor 'boost_LIBRARIES' is defined.`
