### PR TITLE
Add inverse transmission interfaces to transmission interface loader

### DIFF
--- a/transmission_interface/CMakeLists.txt
+++ b/transmission_interface/CMakeLists.txt
@@ -52,13 +52,16 @@ target_link_libraries(${PROJECT_NAME}_loader
 
 
 add_library(${PROJECT_NAME}_loader_plugins
-  src/simple_transmission_loader.cpp           include/transmission_interface/simple_transmission_loader.h
-  src/differential_transmission_loader.cpp     include/transmission_interface/differential_transmission_loader.h
-  src/four_bar_linkage_transmission_loader.cpp include/transmission_interface/four_bar_linkage_transmission_loader.h
-  src/joint_state_interface_provider.cpp       include/transmission_interface/joint_state_interface_provider.h
-  src/position_joint_interface_provider.cpp    include/transmission_interface/position_joint_interface_provider.h
-  src/velocity_joint_interface_provider.cpp    include/transmission_interface/velocity_joint_interface_provider.h
-  src/effort_joint_interface_provider.cpp      include/transmission_interface/effort_joint_interface_provider.h)
+  src/simple_transmission_loader.cpp                      include/transmission_interface/simple_transmission_loader.h
+  src/differential_transmission_loader.cpp                include/transmission_interface/differential_transmission_loader.h
+  src/four_bar_linkage_transmission_loader.cpp            include/transmission_interface/four_bar_linkage_transmission_loader.h
+  src/joint_state_interface_provider.cpp                  include/transmission_interface/joint_state_interface_provider.h
+  src/position_joint_interface_provider.cpp               include/transmission_interface/position_joint_interface_provider.h
+  src/velocity_joint_interface_provider.cpp               include/transmission_interface/velocity_joint_interface_provider.h
+  src/effort_joint_interface_provider.cpp                 include/transmission_interface/effort_joint_interface_provider.h
+  src/bidirectional_position_joint_interface_provider.cpp include/transmission_interface/bidirectional_position_joint_interface_provider.h
+  src/bidirectional_velocity_joint_interface_provider.cpp include/transmission_interface/bidirectional_velocity_joint_interface_provider.h
+  src/bidirectional_effort_joint_interface_provider.cpp   include/transmission_interface/bidirectional_effort_joint_interface_provider.h)
 target_link_libraries(${PROJECT_NAME}_loader_plugins ${PROJECT_NAME}_loader)
 
 

--- a/transmission_interface/include/transmission_interface/bidirectional_effort_joint_interface_provider.h
+++ b/transmission_interface/include/transmission_interface/bidirectional_effort_joint_interface_provider.h
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////////
-// Copyright (C) 2013, PAL Robotics S.L.
+// Copyright (C) 2017, Houston Mechatronics Inc.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
@@ -8,7 +8,7 @@
 //   * Redistributions in binary form must reproduce the above copyright
 //     notice, this list of conditions and the following disclaimer in the
 //     documentation and/or other materials provided with the distribution.
-//   * Neither the name of PAL Robotics S.L. nor the names of its
+//   * Neither the name of Houston Mechatronics Inc. nor the names of its
 //     contributors may be used to endorse or promote products derived from
 //     this software without specific prior written permission.
 //
@@ -35,15 +35,14 @@
 
 namespace transmission_interface
 {
-    class BiDirectionalEffortJointInterfaceProvider : public EffortJointInterfaceProvider
-    {
-    protected:
-      
-        bool registerTransmission(TransmissionLoaderData& loader_data, 
-                                  TransmissionHandleData& handle_data);
-    };
+class BiDirectionalEffortJointInterfaceProvider : public EffortJointInterfaceProvider
+{
+protected:
+  
+  bool registerTransmission(TransmissionLoaderData& loader_data, 
+                            TransmissionHandleData& handle_data);
+};
 
 } // namespace
-
 
 #endif // header guard

--- a/transmission_interface/include/transmission_interface/bidirectional_effort_joint_interface_provider.h
+++ b/transmission_interface/include/transmission_interface/bidirectional_effort_joint_interface_provider.h
@@ -1,0 +1,49 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2013, PAL Robotics S.L.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of PAL Robotics S.L. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+#ifndef TRANSMISSION_INTERFACE_BIDIRECTIONAL_EFFORT_JOINT_INTERFACE_PROVIDER_H
+#define TRANSMISSION_INTERFACE_BIDIRECTIONAL_EFFORT_JOINT_INTERFACE_PROVIDER_H
+
+// ros_control
+#include <transmission_interface/transmission_info.h>
+#include <transmission_interface/transmission_interface_loader.h>
+#include <transmission_interface/effort_joint_interface_provider.h>
+
+namespace transmission_interface
+{
+    class BiDirectionalEffortJointInterfaceProvider : public EffortJointInterfaceProvider
+    {
+    protected:
+      
+        bool registerTransmission(TransmissionLoaderData& loader_data, 
+                                  TransmissionHandleData& handle_data);
+    };
+
+} // namespace
+
+
+#endif // header guard

--- a/transmission_interface/include/transmission_interface/bidirectional_position_joint_interface_provider.h
+++ b/transmission_interface/include/transmission_interface/bidirectional_position_joint_interface_provider.h
@@ -1,0 +1,48 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2013, PAL Robotics S.L.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of PAL Robotics S.L. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+#ifndef TRANSMISSION_INTERFACE_BIDIRECTIONAL_POSITION_JOINT_INTERFACE_PROVIDER_H
+#define TRANSMISSION_INTERFACE_BIDIRECTIONAL_POSITION_JOINT_INTERFACE_PROVIDER_H
+
+// ros_control
+#include <transmission_interface/transmission_info.h>
+#include <transmission_interface/transmission_interface_loader.h>
+#include <transmission_interface/position_joint_interface_provider.h>
+
+namespace transmission_interface
+{
+    class BiDirectionalPositionJointInterfaceProvider : public PositionJointInterfaceProvider
+    {
+    protected:
+
+        bool registerTransmission(TransmissionLoaderData& loader_data, 
+                                  TransmissionHandleData& handle_data);
+    };
+
+} // namespace
+
+#endif // header guard

--- a/transmission_interface/include/transmission_interface/bidirectional_position_joint_interface_provider.h
+++ b/transmission_interface/include/transmission_interface/bidirectional_position_joint_interface_provider.h
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////////
-// Copyright (C) 2013, PAL Robotics S.L.
+// Copyright (C) 2017, Houston Mechatronics Inc.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
@@ -8,7 +8,7 @@
 //   * Redistributions in binary form must reproduce the above copyright
 //     notice, this list of conditions and the following disclaimer in the
 //     documentation and/or other materials provided with the distribution.
-//   * Neither the name of PAL Robotics S.L. nor the names of its
+//   * Neither the name of Houston Mechatronics Inc. nor the names of its
 //     contributors may be used to endorse or promote products derived from
 //     this software without specific prior written permission.
 //
@@ -35,13 +35,13 @@
 
 namespace transmission_interface
 {
-    class BiDirectionalPositionJointInterfaceProvider : public PositionJointInterfaceProvider
-    {
-    protected:
+class BiDirectionalPositionJointInterfaceProvider : public PositionJointInterfaceProvider
+{
+protected:
 
-        bool registerTransmission(TransmissionLoaderData& loader_data, 
-                                  TransmissionHandleData& handle_data);
-    };
+  bool registerTransmission(TransmissionLoaderData& loader_data, 
+                            TransmissionHandleData& handle_data);
+};
 
 } // namespace
 

--- a/transmission_interface/include/transmission_interface/bidirectional_velocity_joint_interface_provider.h
+++ b/transmission_interface/include/transmission_interface/bidirectional_velocity_joint_interface_provider.h
@@ -1,0 +1,48 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2013, PAL Robotics S.L.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of PAL Robotics S.L. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+#ifndef TRANSMISSION_INTERFACE_BIDIRECTIONAL_VELOCITY_JOINT_INTERFACE_PROVIDER_H
+#define TRANSMISSION_INTERFACE_BIDIRECTIONAL_VELOCITY_JOINT_INTERFACE_PROVIDER_H
+
+// ros_control
+#include <transmission_interface/transmission_info.h>
+#include <transmission_interface/transmission_interface_loader.h>
+#include <transmission_interface/velocity_joint_interface_provider.h>
+
+namespace transmission_interface
+{
+    class BiDirectionalVelocityJointInterfaceProvider : public VelocityJointInterfaceProvider
+    {
+    protected:
+
+        bool registerTransmission(TransmissionLoaderData& loader_data, 
+                                  TransmissionHandleData& handle_data);
+    };
+
+} // namespace
+
+#endif // header guard

--- a/transmission_interface/include/transmission_interface/bidirectional_velocity_joint_interface_provider.h
+++ b/transmission_interface/include/transmission_interface/bidirectional_velocity_joint_interface_provider.h
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////////
-// Copyright (C) 2013, PAL Robotics S.L.
+// Copyright (C) 2017, Houston Mechatronics Inc.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
@@ -8,7 +8,7 @@
 //   * Redistributions in binary form must reproduce the above copyright
 //     notice, this list of conditions and the following disclaimer in the
 //     documentation and/or other materials provided with the distribution.
-//   * Neither the name of PAL Robotics S.L. nor the names of its
+//   * Neither the name of Houston Mechatronics nor the names of its
 //     contributors may be used to endorse or promote products derived from
 //     this software without specific prior written permission.
 //
@@ -35,13 +35,13 @@
 
 namespace transmission_interface
 {
-    class BiDirectionalVelocityJointInterfaceProvider : public VelocityJointInterfaceProvider
-    {
-    protected:
+class BiDirectionalVelocityJointInterfaceProvider : public VelocityJointInterfaceProvider
+{
+protected:
 
-        bool registerTransmission(TransmissionLoaderData& loader_data, 
-                                  TransmissionHandleData& handle_data);
-    };
+  bool registerTransmission(TransmissionLoaderData& loader_data, 
+                            TransmissionHandleData& handle_data);
+};
 
 } // namespace
 

--- a/transmission_interface/include/transmission_interface/transmission_interface_loader.h
+++ b/transmission_interface/include/transmission_interface/transmission_interface_loader.h
@@ -145,6 +145,14 @@ struct ForwardTransmissionInterfaces
   JointToActuatorEffortInterface   jnt_to_act_eff_cmd;
 };
 
+struct InverseTransmissionInterfaces
+{
+  JointToActuatorStateInterface    jnt_to_act_state;
+  ActuatorToJointPositionInterface act_to_jnt_pos_cmd;
+  ActuatorToJointVelocityInterface act_to_jnt_vel_cmd;
+  ActuatorToJointEffortInterface   act_to_jnt_eff_cmd;
+};
+
 struct TransmissionLoaderData
 {
   typedef boost::shared_ptr<Transmission> TransmissionPtr;
@@ -159,6 +167,7 @@ struct TransmissionLoaderData
   JointInterfaces               joint_interfaces;
   RawJointDataMap               raw_joint_data_map;
   ForwardTransmissionInterfaces transmission_interfaces;
+  InverseTransmissionInterfaces inverse_transmission_interfaces;
   std::vector<TransmissionPtr>  transmission_data;
 };
 

--- a/transmission_interface/ros_control_plugins.xml
+++ b/transmission_interface/ros_control_plugins.xml
@@ -62,4 +62,31 @@
     </description>
   </class>
 
+  <class name="hardware_interface/BiDirectionalPositionJointInterface"
+         type="transmission_interface::BiDirectionalPositionJointInterfaceProvider"
+         base_class_type="transmission_interface::RequisiteProvider">
+    <description>
+      Deal with hardware interface specifics when loading a transmission interface from URDF.
+      BiDirectionalPositionJointInterface specialization.
+    </description>
+  </class>
+
+  <class name="hardware_interface/BiDirectionalVelocityJointInterface"
+         type="transmission_interface::BiDirectionalVelocityJointInterfaceProvider"
+         base_class_type="transmission_interface::RequisiteProvider">
+    <description>
+      Deal with hardware interface specifics when loading a transmission interface from URDF.
+      BiDirectionalVelocityJointInterface specialization.
+    </description>
+  </class>
+
+  <class name="hardware_interface/BiDirectionalEffortJointInterface"
+         type="transmission_interface::BiDirectionalEffortJointInterfaceProvider"
+         base_class_type="transmission_interface::RequisiteProvider">
+    <description>
+      Deal with hardware interface specifics when loading a transmission interface from URDF.
+      BiDirectionalEffortJointInterface specialization.
+    </description>
+  </class>
+
 </library>

--- a/transmission_interface/src/bidirectional_effort_joint_interface_provider.cpp
+++ b/transmission_interface/src/bidirectional_effort_joint_interface_provider.cpp
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////////
-// Copyright (C) 2013, PAL Robotics S.L.
+// Copyright (C) 2017, Houston Mechatronics Inc.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
@@ -8,7 +8,7 @@
 //   * Redistributions in binary form must reproduce the above copyright
 //     notice, this list of conditions and the following disclaimer in the
 //     documentation and/or other materials provided with the distribution.
-//   * Neither the name of PAL Robotics S.L. nor the names of its
+//   * Neither the name of Houston Mechatronics Inc. nor the names of its
 //     contributors may be used to endorse or promote products derived from
 //     this software without specific prior written permission.
 //
@@ -33,55 +33,48 @@
 
 namespace transmission_interface
 {
-    bool BiDirectionalEffortJointInterfaceProvider::registerTransmission(TransmissionLoaderData &loader_data,
-            TransmissionHandleData &handle_data)
+
+bool BiDirectionalEffortJointInterfaceProvider::registerTransmission(TransmissionLoaderData &loader_data,
+                                                                     TransmissionHandleData &handle_data)
+{
+  if(!EffortJointInterfaceProvider::registerTransmission(loader_data, handle_data))
+  {
+    return false;
+  }
+
+  if(!hasResource(handle_data.name, loader_data.inverse_transmission_interfaces.jnt_to_act_state))
+  {
+    if(!loader_data.robot_transmissions->get<JointToActuatorStateInterface>())
     {
-        // Setup joint state interface first (if not yet done)
-        if(!hasResource(handle_data.name, loader_data.transmission_interfaces.act_to_jnt_state))
-        {
-            if(!JointStateInterfaceProvider::registerTransmission(loader_data, handle_data))
-            {
-                return false;
-            }
-        }
-
-        if(!hasResource(handle_data.name, loader_data.inverse_transmission_interfaces.jnt_to_act_state))
-        {
-            if(!loader_data.robot_transmissions->get<transmission_interface::JointToActuatorStateInterface>())
-            {
-                loader_data.robot_transmissions->registerInterface(&loader_data.inverse_transmission_interfaces.jnt_to_act_state);
-            }
-
-            transmission_interface::JointToActuatorStateInterface &interface = *(loader_data.robot_transmissions->get<transmission_interface::JointToActuatorStateInterface>());
-
-            // Update transmission interface
-            transmission_interface::JointToActuatorStateHandle handle(handle_data.name, handle_data.transmission.get(), handle_data.act_state_data, handle_data.jnt_state_data);
-            interface.registerHandle(handle);
-        }
-
-        // If command interface does not yet exist in the robot transmissions, add it and use internal data structures
-        if(!loader_data.robot_transmissions->get<transmission_interface::JointToActuatorEffortInterface>())
-        {
-            loader_data.robot_transmissions->registerInterface(&loader_data.transmission_interfaces.jnt_to_act_eff_cmd);
-        }
-
-        if(!loader_data.robot_transmissions->get<transmission_interface::ActuatorToJointEffortInterface>())
-        {
-            loader_data.robot_transmissions->registerInterface(&loader_data.inverse_transmission_interfaces.act_to_jnt_eff_cmd);
-        }
-
-        transmission_interface::JointToActuatorEffortInterface &interface = *(loader_data.robot_transmissions->get<transmission_interface::JointToActuatorEffortInterface>());
-        transmission_interface::ActuatorToJointEffortInterface &reverse_interface = *(loader_data.robot_transmissions->get<transmission_interface::ActuatorToJointEffortInterface>());
-
-        // Setup command interface
-        transmission_interface::JointToActuatorEffortHandle handle(handle_data.name, handle_data.transmission.get(), handle_data.act_cmd_data, handle_data.jnt_cmd_data);
-        interface.registerHandle(handle);
-
-        transmission_interface::ActuatorToJointEffortHandle reverse_handle = transmission_interface::ActuatorToJointEffortHandle(handle_data.name, handle_data.transmission.get(), handle_data.act_cmd_data, handle_data.jnt_cmd_data);
-        reverse_interface.registerHandle(reverse_handle);
-        return true;
+      loader_data.robot_transmissions->registerInterface(&loader_data.inverse_transmission_interfaces.jnt_to_act_state);
     }
+
+    JointToActuatorStateInterface &interface = *(loader_data.robot_transmissions->get<JointToActuatorStateInterface>());
+
+    // Update transmission interface
+    JointToActuatorStateHandle handle(handle_data.name, 
+                                      handle_data.transmission.get(), 
+                                      handle_data.act_state_data, 
+                                      handle_data.jnt_state_data);
+    interface.registerHandle(handle);
+  }
+
+  if(!loader_data.robot_transmissions->get<ActuatorToJointEffortInterface>())
+  {
+    loader_data.robot_transmissions->registerInterface(&loader_data.inverse_transmission_interfaces.act_to_jnt_eff_cmd);
+  }
+
+  ActuatorToJointEffortInterface &interface = *(loader_data.robot_transmissions->get<ActuatorToJointEffortInterface>());
+
+  ActuatorToJointEffortHandle handle(handle_data.name, 
+                                     handle_data.transmission.get(),
+                                     handle_data.act_cmd_data, 
+                                     handle_data.jnt_cmd_data);
+  interface.registerHandle(handle);
+  return true;
+}
 
 } // namespace
 
-PLUGINLIB_EXPORT_CLASS(transmission_interface::BiDirectionalEffortJointInterfaceProvider, transmission_interface::RequisiteProvider);
+PLUGINLIB_EXPORT_CLASS(transmission_interface::BiDirectionalEffortJointInterfaceProvider, 
+                       transmission_interface::RequisiteProvider);

--- a/transmission_interface/src/bidirectional_effort_joint_interface_provider.cpp
+++ b/transmission_interface/src/bidirectional_effort_joint_interface_provider.cpp
@@ -1,0 +1,87 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2013, PAL Robotics S.L.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of PAL Robotics S.L. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+// Pluginlib
+#include <pluginlib/class_list_macros.h>
+
+// ros_control
+#include <transmission_interface/bidirectional_effort_joint_interface_provider.h>
+
+namespace transmission_interface
+{
+    bool BiDirectionalEffortJointInterfaceProvider::registerTransmission(TransmissionLoaderData &loader_data,
+            TransmissionHandleData &handle_data)
+    {
+        // Setup joint state interface first (if not yet done)
+        if(!hasResource(handle_data.name, loader_data.transmission_interfaces.act_to_jnt_state))
+        {
+            if(!JointStateInterfaceProvider::registerTransmission(loader_data, handle_data))
+            {
+                return false;
+            }
+        }
+
+        if(!hasResource(handle_data.name, loader_data.inverse_transmission_interfaces.jnt_to_act_state))
+        {
+            if(!loader_data.robot_transmissions->get<transmission_interface::JointToActuatorStateInterface>())
+            {
+                loader_data.robot_transmissions->registerInterface(&loader_data.inverse_transmission_interfaces.jnt_to_act_state);
+            }
+
+            transmission_interface::JointToActuatorStateInterface &interface = *(loader_data.robot_transmissions->get<transmission_interface::JointToActuatorStateInterface>());
+
+            // Update transmission interface
+            transmission_interface::JointToActuatorStateHandle handle(handle_data.name, handle_data.transmission.get(), handle_data.act_state_data, handle_data.jnt_state_data);
+            interface.registerHandle(handle);
+        }
+
+        // If command interface does not yet exist in the robot transmissions, add it and use internal data structures
+        if(!loader_data.robot_transmissions->get<transmission_interface::JointToActuatorEffortInterface>())
+        {
+            loader_data.robot_transmissions->registerInterface(&loader_data.transmission_interfaces.jnt_to_act_eff_cmd);
+        }
+
+        if(!loader_data.robot_transmissions->get<transmission_interface::ActuatorToJointEffortInterface>())
+        {
+            loader_data.robot_transmissions->registerInterface(&loader_data.inverse_transmission_interfaces.act_to_jnt_eff_cmd);
+        }
+
+        transmission_interface::JointToActuatorEffortInterface &interface = *(loader_data.robot_transmissions->get<transmission_interface::JointToActuatorEffortInterface>());
+        transmission_interface::ActuatorToJointEffortInterface &reverse_interface = *(loader_data.robot_transmissions->get<transmission_interface::ActuatorToJointEffortInterface>());
+
+        // Setup command interface
+        transmission_interface::JointToActuatorEffortHandle handle(handle_data.name, handle_data.transmission.get(), handle_data.act_cmd_data, handle_data.jnt_cmd_data);
+        interface.registerHandle(handle);
+
+        transmission_interface::ActuatorToJointEffortHandle reverse_handle = transmission_interface::ActuatorToJointEffortHandle(handle_data.name, handle_data.transmission.get(), handle_data.act_cmd_data, handle_data.jnt_cmd_data);
+        reverse_interface.registerHandle(reverse_handle);
+        return true;
+    }
+
+} // namespace
+
+PLUGINLIB_EXPORT_CLASS(transmission_interface::BiDirectionalEffortJointInterfaceProvider, transmission_interface::RequisiteProvider);

--- a/transmission_interface/src/bidirectional_position_joint_interface_provider.cpp
+++ b/transmission_interface/src/bidirectional_position_joint_interface_provider.cpp
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////////
-// Copyright (C) 2013, PAL Robotics S.L.
+// Copyright (C) 2017, Houston Mechatronics Inc.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
@@ -8,7 +8,7 @@
 //   * Redistributions in binary form must reproduce the above copyright
 //     notice, this list of conditions and the following disclaimer in the
 //     documentation and/or other materials provided with the distribution.
-//   * Neither the name of PAL Robotics S.L. nor the names of its
+//   * Neither the name of Houston Mechatronics nor the names of its
 //     contributors may be used to endorse or promote products derived from
 //     this software without specific prior written permission.
 //
@@ -34,62 +34,47 @@
 namespace transmission_interface
 {
 
-    bool BiDirectionalPositionJointInterfaceProvider::registerTransmission(TransmissionLoaderData& loader_data,
-            TransmissionHandleData& handle_data)
+bool BiDirectionalPositionJointInterfaceProvider::registerTransmission(TransmissionLoaderData& loader_data,
+                                                                       TransmissionHandleData& handle_data)
+{
+  if(!PositionJointInterfaceProvider::registerTransmission(loader_data,handle_data))
+  {
+    return false;
+  }
+
+  if(!hasResource(handle_data.name, loader_data.inverse_transmission_interfaces.jnt_to_act_state))
+  {
+    if(!loader_data.robot_transmissions->get<JointToActuatorStateInterface>())
     {
-        // Setup joint state interface first (if not yet done)
-        if (!hasResource(handle_data.name, loader_data.transmission_interfaces.act_to_jnt_state))
-        {
-            if (!JointStateInterfaceProvider::registerTransmission(loader_data, handle_data)) {return false;}
-        }
-
-        if(!hasResource(handle_data.name, loader_data.inverse_transmission_interfaces.jnt_to_act_state))
-        {
-            if(!loader_data.robot_transmissions->get<transmission_interface::JointToActuatorStateInterface>())
-            {
-                loader_data.robot_transmissions->registerInterface(&loader_data.inverse_transmission_interfaces.jnt_to_act_state);
-            }
-
-            transmission_interface::JointToActuatorStateInterface &interface = *(loader_data.robot_transmissions->get<transmission_interface::JointToActuatorStateInterface>());
-
-            // Update transmission interface
-            transmission_interface::JointToActuatorStateHandle handle(handle_data.name, handle_data.transmission.get(), handle_data.act_state_data, handle_data.jnt_state_data);
-            interface.registerHandle(handle);
-        }
-
-        // If command interface does not yet exist in the robot transmissions, add it and use internal data structures
-        if (!loader_data.robot_transmissions->get<transmission_interface::JointToActuatorPositionInterface>())
-        {
-            loader_data.robot_transmissions->registerInterface(&loader_data.transmission_interfaces.jnt_to_act_pos_cmd);
-        }
-
-        if(!loader_data.robot_transmissions->get<transmission_interface::ActuatorToJointPositionInterface>())
-        {
-            loader_data.robot_transmissions->registerInterface(&loader_data.inverse_transmission_interfaces.act_to_jnt_pos_cmd);
-        }
-
-        transmission_interface::JointToActuatorPositionInterface& interface = *(loader_data.robot_transmissions->get<transmission_interface::JointToActuatorPositionInterface>());
-
-        transmission_interface::ActuatorToJointPositionInterface& reverse_interface = *(loader_data.robot_transmissions->get<transmission_interface::ActuatorToJointPositionInterface>());
-
-        // Setup command interface
-        transmission_interface::JointToActuatorPositionHandle handle(handle_data.name,
-                handle_data.transmission.get(),
-                handle_data.act_cmd_data,
-                handle_data.jnt_cmd_data);
-
-        transmission_interface::ActuatorToJointPositionHandle reverse_handle(handle_data.name,
-                handle_data.transmission.get(),
-                handle_data.act_cmd_data,
-                handle_data.jnt_cmd_data);
-
-        interface.registerHandle(handle);
-
-        reverse_interface.registerHandle(reverse_handle);
-
-        return true;
+      loader_data.robot_transmissions->registerInterface(&loader_data.inverse_transmission_interfaces.jnt_to_act_state);
     }
+
+    JointToActuatorStateInterface &interface = *(loader_data.robot_transmissions->get<JointToActuatorStateInterface>());
+
+    // Update transmission interface
+    JointToActuatorStateHandle handle(handle_data.name, 
+                                      handle_data.transmission.get(), 
+                                      handle_data.act_state_data, 
+                                      handle_data.jnt_state_data);
+    interface.registerHandle(handle);
+  }
+
+  if(!loader_data.robot_transmissions->get<ActuatorToJointPositionInterface>())
+  {
+    loader_data.robot_transmissions->registerInterface(&loader_data.inverse_transmission_interfaces.act_to_jnt_pos_cmd);
+  }
+
+  ActuatorToJointPositionInterface& interface = *(loader_data.robot_transmissions->get<ActuatorToJointPositionInterface>());
+
+  ActuatorToJointPositionHandle handle(handle_data.name,
+                                       handle_data.transmission.get(),
+                                       handle_data.act_cmd_data,
+                                       handle_data.jnt_cmd_data);
+  interface.registerHandle(handle);
+  return true;
+}
 
 }
 
-PLUGINLIB_EXPORT_CLASS(transmission_interface::BiDirectionalPositionJointInterfaceProvider, transmission_interface::RequisiteProvider);
+PLUGINLIB_EXPORT_CLASS(transmission_interface::BiDirectionalPositionJointInterfaceProvider, 
+                       transmission_interface::RequisiteProvider);

--- a/transmission_interface/src/bidirectional_position_joint_interface_provider.cpp
+++ b/transmission_interface/src/bidirectional_position_joint_interface_provider.cpp
@@ -1,0 +1,95 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2013, PAL Robotics S.L.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of PAL Robotics S.L. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+// Pluginlib
+#include <pluginlib/class_list_macros.h>
+
+// ros_control
+#include <transmission_interface/bidirectional_position_joint_interface_provider.h>
+
+namespace transmission_interface
+{
+
+    bool BiDirectionalPositionJointInterfaceProvider::registerTransmission(TransmissionLoaderData& loader_data,
+            TransmissionHandleData& handle_data)
+    {
+        // Setup joint state interface first (if not yet done)
+        if (!hasResource(handle_data.name, loader_data.transmission_interfaces.act_to_jnt_state))
+        {
+            if (!JointStateInterfaceProvider::registerTransmission(loader_data, handle_data)) {return false;}
+        }
+
+        if(!hasResource(handle_data.name, loader_data.inverse_transmission_interfaces.jnt_to_act_state))
+        {
+            if(!loader_data.robot_transmissions->get<transmission_interface::JointToActuatorStateInterface>())
+            {
+                loader_data.robot_transmissions->registerInterface(&loader_data.inverse_transmission_interfaces.jnt_to_act_state);
+            }
+
+            transmission_interface::JointToActuatorStateInterface &interface = *(loader_data.robot_transmissions->get<transmission_interface::JointToActuatorStateInterface>());
+
+            // Update transmission interface
+            transmission_interface::JointToActuatorStateHandle handle(handle_data.name, handle_data.transmission.get(), handle_data.act_state_data, handle_data.jnt_state_data);
+            interface.registerHandle(handle);
+        }
+
+        // If command interface does not yet exist in the robot transmissions, add it and use internal data structures
+        if (!loader_data.robot_transmissions->get<transmission_interface::JointToActuatorPositionInterface>())
+        {
+            loader_data.robot_transmissions->registerInterface(&loader_data.transmission_interfaces.jnt_to_act_pos_cmd);
+        }
+
+        if(!loader_data.robot_transmissions->get<transmission_interface::ActuatorToJointPositionInterface>())
+        {
+            loader_data.robot_transmissions->registerInterface(&loader_data.inverse_transmission_interfaces.act_to_jnt_pos_cmd);
+        }
+
+        transmission_interface::JointToActuatorPositionInterface& interface = *(loader_data.robot_transmissions->get<transmission_interface::JointToActuatorPositionInterface>());
+
+        transmission_interface::ActuatorToJointPositionInterface& reverse_interface = *(loader_data.robot_transmissions->get<transmission_interface::ActuatorToJointPositionInterface>());
+
+        // Setup command interface
+        transmission_interface::JointToActuatorPositionHandle handle(handle_data.name,
+                handle_data.transmission.get(),
+                handle_data.act_cmd_data,
+                handle_data.jnt_cmd_data);
+
+        transmission_interface::ActuatorToJointPositionHandle reverse_handle(handle_data.name,
+                handle_data.transmission.get(),
+                handle_data.act_cmd_data,
+                handle_data.jnt_cmd_data);
+
+        interface.registerHandle(handle);
+
+        reverse_interface.registerHandle(reverse_handle);
+
+        return true;
+    }
+
+}
+
+PLUGINLIB_EXPORT_CLASS(transmission_interface::BiDirectionalPositionJointInterfaceProvider, transmission_interface::RequisiteProvider);

--- a/transmission_interface/src/bidirectional_velocity_joint_interface_provider.cpp
+++ b/transmission_interface/src/bidirectional_velocity_joint_interface_provider.cpp
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////////
-// Copyright (C) 2013, PAL Robotics S.L.
+// Copyright (C) 2017, PAL Robotics S.L.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
@@ -34,56 +34,46 @@
 namespace transmission_interface
 {
 
-    bool BiDirectionalVelocityJointInterfaceProvider::registerTransmission(TransmissionLoaderData &loader_data, TransmissionHandleData &handle_data)
+bool BiDirectionalVelocityJointInterfaceProvider::registerTransmission(TransmissionLoaderData &loader_data,
+                                                                       TransmissionHandleData &handle_data)
+{
+  if(!VelocityJointInterfaceProvider::registerTransmission(loader_data,handle_data))
+  {
+    return false;
+  }
+
+  if(!hasResource(handle_data.name, loader_data.inverse_transmission_interfaces.jnt_to_act_state))
+  {
+    if(!loader_data.robot_transmissions->get<JointToActuatorStateInterface>())
     {
-        // Setup joint state interface first (if not yet done)
-        if(!hasResource(handle_data.name, loader_data.transmission_interfaces.act_to_jnt_state))
-        {
-            if(!JointStateInterfaceProvider::registerTransmission(loader_data, handle_data))
-            {
-                return false;
-            }
-        }
-
-        if(!hasResource(handle_data.name, loader_data.inverse_transmission_interfaces.jnt_to_act_state))
-        {
-            if(!loader_data.robot_transmissions->get<transmission_interface::JointToActuatorStateInterface>())
-            {
-                loader_data.robot_transmissions->registerInterface(&loader_data.inverse_transmission_interfaces.jnt_to_act_state);
-            }
-
-            transmission_interface::JointToActuatorStateInterface &interface = *(loader_data.robot_transmissions->get<transmission_interface::JointToActuatorStateInterface>());
-
-            // Update transmission interface
-            transmission_interface::JointToActuatorStateHandle handle(handle_data.name, handle_data.transmission.get(), handle_data.act_state_data, handle_data.jnt_state_data);
-            interface.registerHandle(handle);
-        }
-
-        // If command interface does not yet exist in the robot transmissions, add it and use internal data structures
-        if(!loader_data.robot_transmissions->get<transmission_interface::JointToActuatorVelocityInterface>())
-        {
-            loader_data.robot_transmissions->registerInterface(&loader_data.transmission_interfaces.jnt_to_act_vel_cmd);
-        }
-
-        if(!loader_data.robot_transmissions->get<transmission_interface::ActuatorToJointVelocityInterface>())
-        {
-            loader_data.robot_transmissions->registerInterface(&loader_data.inverse_transmission_interfaces.act_to_jnt_vel_cmd);
-        }
-
-        transmission_interface::JointToActuatorVelocityInterface &interface = *(loader_data.robot_transmissions->get<transmission_interface::JointToActuatorVelocityInterface>());
-
-        transmission_interface::ActuatorToJointVelocityInterface &reverse_interface = *(loader_data.robot_transmissions->get<transmission_interface::ActuatorToJointVelocityInterface>());
-
-        // Setup command interface
-        transmission_interface::JointToActuatorVelocityHandle handle(handle_data.name, handle_data.transmission.get(), handle_data.act_cmd_data, handle_data.jnt_cmd_data);
-        interface.registerHandle(handle);
-
-        transmission_interface::ActuatorToJointVelocityHandle reverse_handle(handle_data.name, handle_data.transmission.get(), handle_data.act_cmd_data, handle_data.jnt_cmd_data);
-        reverse_interface.registerHandle(reverse_handle);
-
-        return true;
+      loader_data.robot_transmissions->registerInterface(&loader_data.inverse_transmission_interfaces.jnt_to_act_state);
     }
+
+    JointToActuatorStateInterface &interface = *(loader_data.robot_transmissions->get<JointToActuatorStateInterface>());
+
+    // Update transmission interface
+    JointToActuatorStateHandle handle(handle_data.name, 
+                                      handle_data.transmission.get(), 
+                                      handle_data.act_state_data, 
+                                      handle_data.jnt_state_data);
+    interface.registerHandle(handle);
+  }
+
+  if(!loader_data.robot_transmissions->get<ActuatorToJointVelocityInterface>())
+  {
+    loader_data.robot_transmissions->registerInterface(&loader_data.inverse_transmission_interfaces.act_to_jnt_vel_cmd);
+  }
+
+  ActuatorToJointVelocityInterface &interface = *(loader_data.robot_transmissions->get<ActuatorToJointVelocityInterface>());
+
+  ActuatorToJointVelocityHandle handle(handle_data.name, 
+                                       handle_data.transmission.get(), 
+                                       handle_data.act_cmd_data, 
+                                       handle_data.jnt_cmd_data);
+  interface.registerHandle(handle);
+  return true;
+}
 } // namespace
 
-PLUGINLIB_EXPORT_CLASS(transmission_interface::BiDirectionalVelocityJointInterfaceProvider, transmission_interface::RequisiteProvider
-)
+PLUGINLIB_EXPORT_CLASS(transmission_interface::BiDirectionalVelocityJointInterfaceProvider, 
+                       transmission_interface::RequisiteProvider)

--- a/transmission_interface/src/bidirectional_velocity_joint_interface_provider.cpp
+++ b/transmission_interface/src/bidirectional_velocity_joint_interface_provider.cpp
@@ -1,0 +1,89 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2013, PAL Robotics S.L.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of PAL Robotics S.L. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+// Pluginlib
+#include <pluginlib/class_list_macros.h>
+
+// ros_control
+#include <transmission_interface/bidirectional_velocity_joint_interface_provider.h>
+
+namespace transmission_interface
+{
+
+    bool BiDirectionalVelocityJointInterfaceProvider::registerTransmission(TransmissionLoaderData &loader_data, TransmissionHandleData &handle_data)
+    {
+        // Setup joint state interface first (if not yet done)
+        if(!hasResource(handle_data.name, loader_data.transmission_interfaces.act_to_jnt_state))
+        {
+            if(!JointStateInterfaceProvider::registerTransmission(loader_data, handle_data))
+            {
+                return false;
+            }
+        }
+
+        if(!hasResource(handle_data.name, loader_data.inverse_transmission_interfaces.jnt_to_act_state))
+        {
+            if(!loader_data.robot_transmissions->get<transmission_interface::JointToActuatorStateInterface>())
+            {
+                loader_data.robot_transmissions->registerInterface(&loader_data.inverse_transmission_interfaces.jnt_to_act_state);
+            }
+
+            transmission_interface::JointToActuatorStateInterface &interface = *(loader_data.robot_transmissions->get<transmission_interface::JointToActuatorStateInterface>());
+
+            // Update transmission interface
+            transmission_interface::JointToActuatorStateHandle handle(handle_data.name, handle_data.transmission.get(), handle_data.act_state_data, handle_data.jnt_state_data);
+            interface.registerHandle(handle);
+        }
+
+        // If command interface does not yet exist in the robot transmissions, add it and use internal data structures
+        if(!loader_data.robot_transmissions->get<transmission_interface::JointToActuatorVelocityInterface>())
+        {
+            loader_data.robot_transmissions->registerInterface(&loader_data.transmission_interfaces.jnt_to_act_vel_cmd);
+        }
+
+        if(!loader_data.robot_transmissions->get<transmission_interface::ActuatorToJointVelocityInterface>())
+        {
+            loader_data.robot_transmissions->registerInterface(&loader_data.inverse_transmission_interfaces.act_to_jnt_vel_cmd);
+        }
+
+        transmission_interface::JointToActuatorVelocityInterface &interface = *(loader_data.robot_transmissions->get<transmission_interface::JointToActuatorVelocityInterface>());
+
+        transmission_interface::ActuatorToJointVelocityInterface &reverse_interface = *(loader_data.robot_transmissions->get<transmission_interface::ActuatorToJointVelocityInterface>());
+
+        // Setup command interface
+        transmission_interface::JointToActuatorVelocityHandle handle(handle_data.name, handle_data.transmission.get(), handle_data.act_cmd_data, handle_data.jnt_cmd_data);
+        interface.registerHandle(handle);
+
+        transmission_interface::ActuatorToJointVelocityHandle reverse_handle(handle_data.name, handle_data.transmission.get(), handle_data.act_cmd_data, handle_data.jnt_cmd_data);
+        reverse_interface.registerHandle(reverse_handle);
+
+        return true;
+    }
+} // namespace
+
+PLUGINLIB_EXPORT_CLASS(transmission_interface::BiDirectionalVelocityJointInterfaceProvider, transmission_interface::RequisiteProvider
+)

--- a/transmission_interface/test/transmission_interface_loader_test.cpp
+++ b/transmission_interface/test/transmission_interface_loader_test.cpp
@@ -390,6 +390,239 @@ TEST_F(TransmissionInterfaceLoaderTest, SuccessfulLoad)
   EXPECT_NEAR(1.0, act_eff_cmd_handle_diff2.getEffort(), EPS);
 }
 
+TEST_F(TransmissionInterfaceLoaderTest, SuccessfulLoadReversible)
+{
+  // Parse transmission info
+  const std::string urdf_filename = "test/urdf/transmission_interface_loader_bidirectional_valid.urdf";
+  std::string urdf;
+  ASSERT_TRUE(readFile(urdf_filename, urdf));
+
+  std::vector<TransmissionInfo> infos = parseUrdf(urdf_filename);
+  ASSERT_EQ(2, infos.size());
+
+  // Get info for each transmission
+  const TransmissionInfo& info_red = infos.front();
+  ASSERT_EQ(1, info_red.actuators_.size());
+  ASSERT_EQ(1, info_red.joints_.size());
+
+  const TransmissionInfo& info_diff = infos.back();
+  ASSERT_EQ(2, info_diff.actuators_.size());
+  ASSERT_EQ(2, info_diff.joints_.size());
+
+  // Load transmissions
+  TransmissionInterfaceLoader trans_iface_loader(&robot_hw, &robot_transmissions);
+  ASSERT_TRUE(trans_iface_loader.load(urdf)); // NOTE: Using URDF loader
+
+  using namespace hardware_interface;
+
+  // Actuator interfaces
+  PositionActuatorInterface* act_pos_cmd_iface = robot_hw.get<PositionActuatorInterface>();
+  VelocityActuatorInterface* act_vel_cmd_iface = robot_hw.get<VelocityActuatorInterface>();
+  EffortActuatorInterface*   act_eff_cmd_iface = robot_hw.get<EffortActuatorInterface>();
+  ActuatorStateInterface*    act_state_iface   = robot_hw.get<ActuatorStateInterface>();
+  ASSERT_TRUE(0 != act_pos_cmd_iface);
+  ASSERT_TRUE(0 != act_vel_cmd_iface);
+  ASSERT_TRUE(0 != act_eff_cmd_iface);
+  ASSERT_TRUE(0 != act_state_iface);
+
+  // Joint interfaces
+  PositionJointInterface* pos_jnt_iface = robot_hw.get<PositionJointInterface>();
+  VelocityJointInterface* vel_jnt_iface = robot_hw.get<VelocityJointInterface>();
+  EffortJointInterface*   eff_jnt_iface = robot_hw.get<EffortJointInterface>();
+  JointStateInterface*    state_jnt_iface = robot_hw.get<JointStateInterface>();
+  ASSERT_TRUE(0 != pos_jnt_iface);
+  ASSERT_TRUE(0 != vel_jnt_iface);
+  ASSERT_TRUE(0 != eff_jnt_iface);
+
+  // Forward Transmission interfaces
+  ActuatorToJointStateInterface*    act_to_jnt_state   = robot_transmissions.get<ActuatorToJointStateInterface>();
+  JointToActuatorPositionInterface* jnt_to_act_pos_cmd = robot_transmissions.get<JointToActuatorPositionInterface>();
+  JointToActuatorVelocityInterface* jnt_to_act_vel_cmd = robot_transmissions.get<JointToActuatorVelocityInterface>();
+  JointToActuatorEffortInterface*   jnt_to_act_eff_cmd = robot_transmissions.get<JointToActuatorEffortInterface>();
+
+  // Inverse Transmission interfaces
+  JointToActuatorStateInterface*    jnt_to_act_state   = robot_transmissions.get<JointToActuatorStateInterface>();
+  ActuatorToJointPositionInterface* act_to_jnt_pos_cmd = robot_transmissions.get<ActuatorToJointPositionInterface>();
+  ActuatorToJointVelocityInterface* act_to_jnt_vel_cmd = robot_transmissions.get<ActuatorToJointVelocityInterface>();
+  ActuatorToJointEffortInterface*   act_to_jnt_eff_cmd = robot_transmissions.get<ActuatorToJointEffortInterface>();
+
+  ASSERT_TRUE(0 != act_to_jnt_state);
+  ASSERT_TRUE(0 != jnt_to_act_pos_cmd);
+  ASSERT_TRUE(0 != jnt_to_act_vel_cmd);
+  ASSERT_TRUE(0 != jnt_to_act_eff_cmd);
+
+  ASSERT_TRUE(0 != jnt_to_act_state);
+  ASSERT_TRUE(0 != act_to_jnt_pos_cmd);
+  ASSERT_TRUE(0 != act_to_jnt_vel_cmd);
+  ASSERT_TRUE(0 != act_to_jnt_eff_cmd);
+
+  // Actuator handles
+  ASSERT_NO_THROW(act_pos_cmd_iface->getHandle(info_red.actuators_.front().name_));
+  ASSERT_NO_THROW(act_vel_cmd_iface->getHandle(info_red.actuators_.front().name_));
+  ASSERT_NO_THROW(act_eff_cmd_iface->getHandle(info_red.actuators_.front().name_));
+  ASSERT_NO_THROW(act_state_iface->getHandle(info_red.actuators_.front().name_));
+  ActuatorHandle act_pos_cmd_handle_red = act_pos_cmd_iface->getHandle(info_red.actuators_.front().name_);
+  ActuatorHandle act_vel_cmd_handle_red = act_vel_cmd_iface->getHandle(info_red.actuators_.front().name_);
+  ActuatorHandle act_eff_cmd_handle_red = act_eff_cmd_iface->getHandle(info_red.actuators_.front().name_);
+
+  ActuatorStateHandle act_state_handle_red = act_state_iface->getHandle(info_red.actuators_.front().name_);
+
+  ASSERT_NO_THROW(act_pos_cmd_iface->getHandle(info_diff.actuators_.front().name_));
+  ASSERT_NO_THROW(act_vel_cmd_iface->getHandle(info_diff.actuators_.front().name_));
+  ASSERT_NO_THROW(act_eff_cmd_iface->getHandle(info_diff.actuators_.front().name_));
+  ASSERT_NO_THROW(act_state_iface->getHandle(info_diff.actuators_.front().name_));
+  ASSERT_NO_THROW(act_pos_cmd_iface->getHandle(info_diff.actuators_.back().name_));
+  ASSERT_NO_THROW(act_vel_cmd_iface->getHandle(info_diff.actuators_.back().name_));
+  ASSERT_NO_THROW(act_eff_cmd_iface->getHandle(info_diff.actuators_.back().name_));
+  ASSERT_NO_THROW(act_state_iface->getHandle(info_diff.actuators_.front().name_));
+  ActuatorHandle act_pos_cmd_handle_diff1 = act_pos_cmd_iface->getHandle(info_diff.actuators_.front().name_);
+  ActuatorHandle act_vel_cmd_handle_diff1 = act_vel_cmd_iface->getHandle(info_diff.actuators_.front().name_);
+  ActuatorHandle act_eff_cmd_handle_diff1 = act_eff_cmd_iface->getHandle(info_diff.actuators_.front().name_);
+  ActuatorHandle act_pos_cmd_handle_diff2 = act_pos_cmd_iface->getHandle(info_diff.actuators_.back().name_);
+  ActuatorHandle act_vel_cmd_handle_diff2 = act_vel_cmd_iface->getHandle(info_diff.actuators_.back().name_);
+  ActuatorHandle act_eff_cmd_handle_diff2 = act_eff_cmd_iface->getHandle(info_diff.actuators_.back().name_);
+
+  ActuatorStateHandle act_state_handle_diff1 = act_state_iface->getHandle(info_diff.actuators_.front().name_);
+  ActuatorStateHandle act_state_handle_diff2 = act_state_iface->getHandle(info_diff.actuators_.back().name_);
+
+  // Joint handles
+  ASSERT_NO_THROW(pos_jnt_iface->getHandle(info_red.joints_.front().name_));
+  ASSERT_NO_THROW(vel_jnt_iface->getHandle(info_red.joints_.front().name_));
+  ASSERT_NO_THROW(eff_jnt_iface->getHandle(info_red.joints_.front().name_));
+  ASSERT_NO_THROW(state_jnt_iface->getHandle(info_red.joints_.front().name_));
+  JointHandle pos_jnt_handle_red = pos_jnt_iface->getHandle(info_red.joints_.front().name_);
+  JointHandle vel_jnt_handle_red = vel_jnt_iface->getHandle(info_red.joints_.front().name_);
+  JointHandle eff_jnt_handle_red = eff_jnt_iface->getHandle(info_red.joints_.front().name_);
+
+  JointStateHandle state_jnt_handle_red = state_jnt_iface->getHandle(info_red.joints_.front().name_);
+
+  ASSERT_NO_THROW(pos_jnt_iface->getHandle(info_diff.joints_.front().name_));
+  ASSERT_NO_THROW(vel_jnt_iface->getHandle(info_diff.joints_.front().name_));
+  ASSERT_NO_THROW(eff_jnt_iface->getHandle(info_diff.joints_.front().name_));
+  ASSERT_NO_THROW(pos_jnt_iface->getHandle(info_diff.joints_.back().name_));
+  ASSERT_NO_THROW(vel_jnt_iface->getHandle(info_diff.joints_.back().name_));
+  ASSERT_NO_THROW(eff_jnt_iface->getHandle(info_diff.joints_.back().name_));
+  JointHandle pos_jnt_handle_diff1 = pos_jnt_iface->getHandle(info_diff.joints_.front().name_);
+  JointHandle vel_jnt_handle_diff1 = vel_jnt_iface->getHandle(info_diff.joints_.front().name_);
+  JointHandle eff_jnt_handle_diff1 = eff_jnt_iface->getHandle(info_diff.joints_.front().name_);
+  JointHandle pos_jnt_handle_diff2 = pos_jnt_iface->getHandle(info_diff.joints_.back().name_);
+  JointHandle vel_jnt_handle_diff2 = vel_jnt_iface->getHandle(info_diff.joints_.back().name_);
+  JointHandle eff_jnt_handle_diff2 = eff_jnt_iface->getHandle(info_diff.joints_.back().name_);
+
+  // Propagate state forward
+  act_pos.assign(3,  50.0);
+  act_vel.assign(3, -50.0);
+  act_eff.assign(3,   1.0);
+
+  act_to_jnt_state->propagate();
+
+  EXPECT_NEAR( 1.5, pos_jnt_handle_red.getPosition(),   EPS);
+  EXPECT_NEAR( 1.5, pos_jnt_handle_diff1.getPosition(), EPS);
+  EXPECT_NEAR( 0.5, pos_jnt_handle_diff2.getPosition(), EPS);
+
+  EXPECT_NEAR(-1.0, pos_jnt_handle_red.getVelocity(),   EPS);
+  EXPECT_NEAR(-1.0, pos_jnt_handle_diff1.getVelocity(), EPS);
+  EXPECT_NEAR( 0.0, pos_jnt_handle_diff2.getVelocity(), EPS);
+
+  EXPECT_NEAR( 50.0, pos_jnt_handle_red.getEffort(),     EPS);
+  EXPECT_NEAR(100.0, pos_jnt_handle_diff1.getEffort(),  EPS);
+  EXPECT_NEAR(  0.0, pos_jnt_handle_diff2.getEffort(),   EPS);
+
+  // Propagate position commands forward
+  pos_jnt_handle_red.setCommand(1.5);
+  pos_jnt_handle_diff1.setCommand(1.5);
+  pos_jnt_handle_diff2.setCommand(0.5);
+
+  jnt_to_act_pos_cmd->propagate();
+
+  EXPECT_NEAR(50.0, act_pos_cmd_handle_red.getPosition(),   EPS);
+  EXPECT_NEAR(50.0, act_pos_cmd_handle_diff1.getPosition(), EPS);
+  EXPECT_NEAR(50.0, act_pos_cmd_handle_diff2.getPosition(), EPS);
+
+  // Propagate velocity commands forward
+  vel_jnt_handle_red.setCommand(1.0);
+  vel_jnt_handle_diff1.setCommand(1.0);
+  vel_jnt_handle_diff2.setCommand(0.0);
+
+  jnt_to_act_vel_cmd->propagate();
+
+  EXPECT_NEAR(-50.0, act_vel_cmd_handle_red.getVelocity(),   EPS);
+  EXPECT_NEAR(-50.0, act_vel_cmd_handle_diff1.getVelocity(), EPS);
+  EXPECT_NEAR(-50.0, act_vel_cmd_handle_diff2.getVelocity(), EPS);
+
+  // Propagate effort commands forward
+  eff_jnt_handle_red.setCommand(50.0);
+  eff_jnt_handle_diff1.setCommand(100.0);
+  eff_jnt_handle_diff2.setCommand( 0.0);
+
+  jnt_to_act_eff_cmd->propagate();
+
+  EXPECT_NEAR(1.0, act_eff_cmd_handle_red.getEffort(), EPS);
+  EXPECT_NEAR(1.0, act_eff_cmd_handle_diff1.getEffort(), EPS);
+  EXPECT_NEAR(1.0, act_eff_cmd_handle_diff2.getEffort(), EPS);
+
+  // Now propegate things in the reverse direction
+  RawJointDataMap* joint_data_map = &trans_iface_loader.getData()->raw_joint_data_map;
+  joint_data_map->operator[]("foo_joint").position = 1.5;
+  joint_data_map->operator[]("bar_joint").position = 1.5;
+  joint_data_map->operator[]("baz_joint").position = 0.5;
+
+  joint_data_map->operator[]("foo_joint").velocity = -1.;
+  joint_data_map->operator[]("bar_joint").velocity = -1.;
+  joint_data_map->operator[]("baz_joint").velocity = -2.;
+
+  joint_data_map->operator[]("foo_joint").effort = 5.;
+  joint_data_map->operator[]("bar_joint").effort = 10.;
+  joint_data_map->operator[]("baz_joint").effort = -5.;
+
+  jnt_to_act_state->propagate();
+
+  EXPECT_NEAR(50., act_state_handle_red.getPosition(),   EPS);
+  EXPECT_NEAR(50., act_state_handle_diff1.getPosition(), EPS);
+  EXPECT_NEAR(50., act_state_handle_diff2.getPosition(), EPS);
+
+  EXPECT_NEAR(-50.,  act_state_handle_red.getVelocity(),   EPS);
+  EXPECT_NEAR(-150., act_state_handle_diff1.getVelocity(), EPS);
+  EXPECT_NEAR( 50.,  act_state_handle_diff2.getVelocity(), EPS);
+
+  EXPECT_NEAR(0.1,  act_state_handle_red.getEffort(),   EPS);
+  EXPECT_NEAR(0.05, act_state_handle_diff1.getEffort(), EPS);
+  EXPECT_NEAR(0.15, act_state_handle_diff2.getEffort(), EPS);
+
+  act_pos_cmd_handle_red.setCommand(3.);
+  act_pos_cmd_handle_diff1.setCommand(3.);
+  act_pos_cmd_handle_diff2.setCommand(3.);
+
+    // reverse propegate position commands
+  act_to_jnt_pos_cmd->propagate();
+
+  EXPECT_NEAR(0.56, joint_data_map->operator[]("foo_joint").position_cmd, EPS);
+  EXPECT_NEAR(0.56, joint_data_map->operator[]("bar_joint").position_cmd, EPS);
+  EXPECT_NEAR(0.5,  joint_data_map->operator[]("baz_joint").position_cmd, EPS);
+
+  // Propagate velocity commands forward
+  act_vel_cmd_handle_red.setCommand(1.0);
+  act_vel_cmd_handle_diff1.setCommand(1.0);
+  act_vel_cmd_handle_diff2.setCommand(0.0);
+
+  act_to_jnt_vel_cmd->propagate();
+
+  EXPECT_NEAR(0.02, joint_data_map->operator[]("foo_joint").velocity_cmd, EPS);
+  EXPECT_NEAR(0.01, joint_data_map->operator[]("bar_joint").velocity_cmd, EPS);
+  EXPECT_NEAR(0.01, joint_data_map->operator[]("baz_joint").velocity_cmd, EPS);
+
+   // Propagate effort commands forward
+  act_eff_cmd_handle_red.setCommand(50.0);
+  act_eff_cmd_handle_diff1.setCommand(1.0);
+  act_eff_cmd_handle_diff2.setCommand( 0.0);
+
+  act_to_jnt_eff_cmd->propagate();
+
+  EXPECT_NEAR(2500., joint_data_map->operator[]("foo_joint").effort_cmd, EPS);
+  EXPECT_NEAR(50.,  joint_data_map->operator[]("bar_joint").effort_cmd, EPS);
+  EXPECT_NEAR(50.,  joint_data_map->operator[]("baz_joint").effort_cmd, EPS);
+}
+
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);

--- a/transmission_interface/test/transmission_interface_loader_test.cpp
+++ b/transmission_interface/test/transmission_interface_loader_test.cpp
@@ -516,17 +516,17 @@ TEST_F(TransmissionInterfaceLoaderTest, SuccessfulLoadReversible)
 
   act_to_jnt_state->propagate();
 
-  EXPECT_NEAR( 1.5, pos_jnt_handle_red.getPosition(),   EPS);
-  EXPECT_NEAR( 1.5, pos_jnt_handle_diff1.getPosition(), EPS);
-  EXPECT_NEAR( 0.5, pos_jnt_handle_diff2.getPosition(), EPS);
+  EXPECT_NEAR(1.5, pos_jnt_handle_red.getPosition(),   EPS);
+  EXPECT_NEAR(1.5, pos_jnt_handle_diff1.getPosition(), EPS);
+  EXPECT_NEAR(0.5, pos_jnt_handle_diff2.getPosition(), EPS);
 
   EXPECT_NEAR(-1.0, pos_jnt_handle_red.getVelocity(),   EPS);
   EXPECT_NEAR(-1.0, pos_jnt_handle_diff1.getVelocity(), EPS);
   EXPECT_NEAR( 0.0, pos_jnt_handle_diff2.getVelocity(), EPS);
 
-  EXPECT_NEAR( 50.0, pos_jnt_handle_red.getEffort(),     EPS);
+  EXPECT_NEAR(50.0, pos_jnt_handle_red.getEffort(),     EPS);
   EXPECT_NEAR(100.0, pos_jnt_handle_diff1.getEffort(),  EPS);
-  EXPECT_NEAR(  0.0, pos_jnt_handle_diff2.getEffort(),   EPS);
+  EXPECT_NEAR(0.0, pos_jnt_handle_diff2.getEffort(),    EPS);
 
   // Propagate position commands forward
   pos_jnt_handle_red.setCommand(1.5);
@@ -557,7 +557,7 @@ TEST_F(TransmissionInterfaceLoaderTest, SuccessfulLoadReversible)
 
   jnt_to_act_eff_cmd->propagate();
 
-  EXPECT_NEAR(1.0, act_eff_cmd_handle_red.getEffort(), EPS);
+  EXPECT_NEAR(1.0, act_eff_cmd_handle_red.getEffort(),   EPS);
   EXPECT_NEAR(1.0, act_eff_cmd_handle_diff1.getEffort(), EPS);
   EXPECT_NEAR(1.0, act_eff_cmd_handle_diff2.getEffort(), EPS);
 
@@ -567,31 +567,31 @@ TEST_F(TransmissionInterfaceLoaderTest, SuccessfulLoadReversible)
   joint_data_map->operator[]("bar_joint").position = 1.5;
   joint_data_map->operator[]("baz_joint").position = 0.5;
 
-  joint_data_map->operator[]("foo_joint").velocity = -1.;
-  joint_data_map->operator[]("bar_joint").velocity = -1.;
-  joint_data_map->operator[]("baz_joint").velocity = -2.;
+  joint_data_map->operator[]("foo_joint").velocity = -1.0;
+  joint_data_map->operator[]("bar_joint").velocity = -1.0;
+  joint_data_map->operator[]("baz_joint").velocity = -2.0;
 
-  joint_data_map->operator[]("foo_joint").effort = 5.;
-  joint_data_map->operator[]("bar_joint").effort = 10.;
-  joint_data_map->operator[]("baz_joint").effort = -5.;
+  joint_data_map->operator[]("foo_joint").effort = 5.0;
+  joint_data_map->operator[]("bar_joint").effort = 10.0;
+  joint_data_map->operator[]("baz_joint").effort = -5.0;
 
   jnt_to_act_state->propagate();
 
-  EXPECT_NEAR(50., act_state_handle_red.getPosition(),   EPS);
-  EXPECT_NEAR(50., act_state_handle_diff1.getPosition(), EPS);
-  EXPECT_NEAR(50., act_state_handle_diff2.getPosition(), EPS);
+  EXPECT_NEAR(50.0, act_state_handle_red.getPosition(),   EPS);
+  EXPECT_NEAR(50.0, act_state_handle_diff1.getPosition(), EPS);
+  EXPECT_NEAR(50.0, act_state_handle_diff2.getPosition(), EPS);
 
-  EXPECT_NEAR(-50.,  act_state_handle_red.getVelocity(),   EPS);
-  EXPECT_NEAR(-150., act_state_handle_diff1.getVelocity(), EPS);
-  EXPECT_NEAR( 50.,  act_state_handle_diff2.getVelocity(), EPS);
+  EXPECT_NEAR(-50.0,  act_state_handle_red.getVelocity(),   EPS);
+  EXPECT_NEAR(-150.0, act_state_handle_diff1.getVelocity(), EPS);
+  EXPECT_NEAR( 50.0,  act_state_handle_diff2.getVelocity(), EPS);
 
   EXPECT_NEAR(0.1,  act_state_handle_red.getEffort(),   EPS);
   EXPECT_NEAR(0.05, act_state_handle_diff1.getEffort(), EPS);
   EXPECT_NEAR(0.15, act_state_handle_diff2.getEffort(), EPS);
 
-  act_pos_cmd_handle_red.setCommand(3.);
-  act_pos_cmd_handle_diff1.setCommand(3.);
-  act_pos_cmd_handle_diff2.setCommand(3.);
+  act_pos_cmd_handle_red.setCommand(3.0);
+  act_pos_cmd_handle_diff1.setCommand(3.0);
+  act_pos_cmd_handle_diff2.setCommand(3.0);
 
     // reverse propegate position commands
   act_to_jnt_pos_cmd->propagate();
@@ -618,9 +618,9 @@ TEST_F(TransmissionInterfaceLoaderTest, SuccessfulLoadReversible)
 
   act_to_jnt_eff_cmd->propagate();
 
-  EXPECT_NEAR(2500., joint_data_map->operator[]("foo_joint").effort_cmd, EPS);
-  EXPECT_NEAR(50.,  joint_data_map->operator[]("bar_joint").effort_cmd, EPS);
-  EXPECT_NEAR(50.,  joint_data_map->operator[]("baz_joint").effort_cmd, EPS);
+  EXPECT_NEAR(2500.0, joint_data_map->operator[]("foo_joint").effort_cmd, EPS);
+  EXPECT_NEAR(50.0, joint_data_map->operator[]("bar_joint").effort_cmd,   EPS);
+  EXPECT_NEAR(50.0, joint_data_map->operator[]("baz_joint").effort_cmd,   EPS);
 }
 
 int main(int argc, char** argv)

--- a/transmission_interface/test/urdf/transmission_interface_loader_bidirectional_valid.urdf
+++ b/transmission_interface/test/urdf/transmission_interface_loader_bidirectional_valid.urdf
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+
+<robot name="robot" xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+  <transmission name="simple_trans">
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="foo_joint">
+      <offset>0.5</offset> <!--optional-->
+      <hardwareInterface>hardware_interface/BiDirectionalPositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/BiDirectionalVelocityJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/BiDirectionalEffortJointInterface</hardwareInterface>
+    </joint>
+    <actuator name="foo_actuator">
+      <mechanicalReduction>50</mechanicalReduction>
+    </actuator>
+  </transmission>
+
+  <transmission name="differential_trans">
+    <type>transmission_interface/DifferentialTransmission</type>
+    <joint name="bar_joint">
+      <role>joint1</role>
+      <offset>0.5</offset> <!--optional-->
+      <hardwareInterface>hardware_interface/BiDirectionalPositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/BiDirectionalVelocityJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/BiDirectionalEffortJointInterface</hardwareInterface>
+    </joint>
+    <joint name="baz_joint">
+      <role>joint2</role>
+      <offset>0.5</offset> <!--optional-->
+      <hardwareInterface>hardware_interface/BiDirectionalPositionJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/BiDirectionalVelocityJointInterface</hardwareInterface>
+      <hardwareInterface>hardware_interface/BiDirectionalEffortJointInterface</hardwareInterface>
+    </joint>
+    <actuator name="bar_actuator">
+      <role>actuator1</role>
+      <mechanicalReduction>50</mechanicalReduction>
+    </actuator>
+    <actuator name="baz_actuator">
+      <role>actuator2</role>
+      <mechanicalReduction>50</mechanicalReduction>
+    </actuator>
+  </transmission>
+
+</robot>


### PR DESCRIPTION
The purpose of this is to help me with [this issue](https://github.com/ros-controls/ros_control/issues/275) in which I would like to propegate transmissions in the opposite direction. In my own code I have created a `BiDirectionalEffortJointInterfaceProvider` plugin which is similar to the `EffortJointInterfaceProvider` plugin that registers the additional `ActuatorToJointEffortInterface`. The problem i'm running into now is the `TransmissionLoaderData` doesn't have these as members, so they aren't constructed and I can't register them as you all have done with the `ForwardTransmissionInterfaces`.

I could of course copy/paste what you all have done with the `TransmissionInterfaceLoader` and reimplement it myself, but i'd much rather add this slight modification which should not effect anything else and gives folks the opportunity to implement their own `RequisiteProvider` to register the reverse interfaces while still leveraging all the automatic transmission registration you all have done with the `TransmissionInterfaceLoader`. Let me know what you think.