### PR TITLE
Interface composition revised

### DIFF
--- a/hardware_interface/include/hardware_interface/internal/interface_manager.h
+++ b/hardware_interface/include/hardware_interface/internal/interface_manager.h
@@ -43,6 +43,10 @@
 
 namespace hardware_interface
 {
+
+namespace internal
+{
+
 // SFINAE workaround, so that we have reflection inside the template functions
 template <typename T>
 struct CheckIsResourceManager {
@@ -107,6 +111,8 @@ struct CheckIsResourceManager {
 
 };
 
+} // namespace internal
+
 class InterfaceManager
 {
 public:
@@ -128,7 +134,7 @@ public:
       ROS_WARN_STREAM("Replacing previously registered interface '" << iface_name << "'.");
     }
     interfaces_[iface_name] = iface;
-    CheckIsResourceManager<T>::callGetResources(resources_[iface_name], iface);
+    internal::CheckIsResourceManager<T>::callGetResources(resources_[iface_name], iface);
   }
 
   void registerInterfaceManager(InterfaceManager* iface_man)
@@ -190,10 +196,10 @@ public:
       iface_combo = static_cast<T*>(it_combo->second);
     } else {
       // no existing combined interface
-      iface_combo = CheckIsResourceManager<T>::newCombinedInterface(interface_destruction_list_);
+      iface_combo = internal::CheckIsResourceManager<T>::newCombinedInterface(interface_destruction_list_);
       if(iface_combo) {
         // concat all of the resource managers together
-        CheckIsResourceManager<T>::callConcatManagers(iface_list, iface_combo);
+        internal::CheckIsResourceManager<T>::callConcatManagers(iface_list, iface_combo);
         // save the combined interface for if this is called again
         interfaces_combo_[type_name] = iface_combo;
         num_ifaces_registered_[type_name] = iface_list.size();

--- a/hardware_interface/include/hardware_interface/internal/interface_manager.h
+++ b/hardware_interface/include/hardware_interface/internal/interface_manager.h
@@ -46,21 +46,6 @@ namespace hardware_interface
 // SFINAE workaround, so that we have reflection inside the template functions
 template <typename T>
 struct CheckIsResourceManager {
-  // variable definitions for compiler-time logic
-  typedef char yes[1];
-  typedef char no[2];
-
-  // method called if C is a ResourceManager
-  template <typename C>
-  static yes& testRM(typename C::resource_manager_type*);
-
-  // method called if C is not a ResourceManager
-  template <typename>
-  static no& testRM(...);
-
-  // CheckIsResourceManager<T>::value == true when T is a ResourceManager
-  static const bool value = (sizeof(testRM<T>(0)) == sizeof(yes));
-
   // method called if C is a ResourceManager
   template <typename C>
   static void callCM(typename std::vector<C*>& managers, C* result, typename C::resource_manager_type*)

--- a/hardware_interface/test/interface_manager_test.cpp
+++ b/hardware_interface/test/interface_manager_test.cpp
@@ -34,6 +34,7 @@ using namespace hardware_interface;
 
 struct FooInterface
 {
+  FooInterface(int foo): foo(foo) {}
   int foo;
 };
 
@@ -50,7 +51,7 @@ struct BazInterface
 TEST(InterfaceManagerTest, InterfaceRegistration)
 {
   // Register interfaces
-  FooInterface foo_iface;
+  FooInterface foo_iface(0);
   BarInterface bar_iface;
 
   InterfaceManager iface_mgr;
@@ -66,11 +67,8 @@ TEST(InterfaceManagerTest, InterfaceRegistration)
 TEST(InterfaceManagerTest, InterfaceRewriting)
 {
   // Two instances of the same interface
-  FooInterface foo_iface_1;
-  foo_iface_1.foo = 1;
-
-  FooInterface foo_iface_2;
-  foo_iface_2.foo = 2;
+  FooInterface foo_iface_1(1);
+  FooInterface foo_iface_2(2);
 
   // Register first interface and validate it
   InterfaceManager iface_mgr;
@@ -91,4 +89,3 @@ int main(int argc, char** argv)
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-


### PR DESCRIPTION
As reported  in https://github.com/PR2/pr2_mechanism/issues/330 the changes introduced in #235 break hardware interfaces without default contructors.

This PR relaxes this by requiring the default constructor only for interfaces derived from `hardware_interface::HardwareResourceManager`.

In addition I have cleaned-up the code a little bit and got rid of some warnings.
This breaks the API of `CheckIsResourceManager`.