### PR TITLE
add tests for controller_manager scripts

### DIFF
--- a/controller_manager/scripts/controller_manager
+++ b/controller_manager/scripts/controller_manager
@@ -37,9 +37,7 @@ if __name__ == '__main__':
     elif args[1] == 'lc' or args[1] == 'list':
         controller_manager_interface.list_controllers()
     elif args[1] == 'reload-libraries':
-        print "ARGS", args, args[2:]
         if '--restore' in args[2:]:
-            print "RE1"
             controller_manager_interface.reload_libraries(True, restore = True)
         else:
             controller_manager_interface.reload_libraries(True)

--- a/controller_manager/scripts/unspawner
+++ b/controller_manager/scripts/unspawner
@@ -31,49 +31,42 @@
 #
 # Author: Stuart Glaser
 
-import time
 import sys
-import getopt
-
 import rospy
 from controller_manager_msgs.srv import *
 
-
-switch_controller = rospy.ServiceProxy('controller_manager/switch_controller', SwitchController)
-list_controllers = rospy.ServiceProxy('controller_manager/list_controllers', ListControllers)
-
 def main():
-    inhibited_controllers = []
-    try:
-        rospy.init_node("inhibit", anonymous=True, disable_signals=True)
-        list_controllers.wait_for_service()
-        switch_controller.wait_for_service()
+    rospy.init_node("unspawner", anonymous=True)
 
-        to_inhibit = rospy.myargv()
-        inhibited = set()
+    switch_controller = rospy.ServiceProxy('controller_manager/switch_controller', SwitchController)
+    list_controllers = rospy.ServiceProxy('controller_manager/list_controllers', ListControllers)
+    inhibited = set()
 
-        # Repeatedly check what controllers are up and inhibit the ones that shouldn't be up
-        while True:
-            to_stop = []
-            listed = list_controllers()
-            for controller_state in listed.controller:
-                if controller_state.name in to_inhibit and controller_state.state == 'running':
-                    to_stop.append(controller_state.name)
+    switch_controller.wait_for_service()
+    list_controllers.wait_for_service()
 
-            if to_stop:
-                rospy.logout("Inhibiting controllers: %s" % ', '.join(to_stop))
-                switch_controller(strictness = SwitchControllerRequest.BEST_EFFORT,
-                                  stop_controllers = to_stop)
-                inhibited.update(to_stop)
+    to_inhibit = set(rospy.myargv())
 
-            time.sleep(3.0)
+    def stop_controllers(*argc):
+        to_stop = to_inhibit & set(cs.name for cs in list_controllers().controller if cs.state == 'running')
 
-    finally:
+        if to_stop:
+            rospy.logout("Inhibiting controllers: %s" % ', '.join(to_stop))
+            switch_controller(strictness = SwitchControllerRequest.BEST_EFFORT,
+                              stop_controllers = list(to_stop))
+            inhibited.update(to_stop)
+
+    stop_controllers()
+    timer = rospy.Timer(rospy.Duration(3), stop_controllers)
+
+    def restart_controllers():
+        timer.shutdown()
         # Re-starts inhibited controllers
         switch_controller(strictness = SwitchControllerRequest.BEST_EFFORT,
                           start_controllers = list(inhibited))
 
-
+    rospy.on_shutdown(restart_controllers)
+    rospy.spin()
 
 def print_help():
     print './unspawner name1 name2 name3'
@@ -85,10 +78,4 @@ if __name__ == '__main__':
     if len(sys.argv) == 1 or sys.argv[1] == '-h' or sys.argv[1] == '--help':
         print_help()
         sys.exit(1)
-
-    try:
-        main()
-    except KeyboardInterrupt:
-        pass
-    finally:
-        rospy.signal_shutdown("interrupted")
+    main()

--- a/controller_manager/src/controller_manager/controller_manager_interface.py
+++ b/controller_manager/src/controller_manager/controller_manager_interface.py
@@ -57,7 +57,8 @@ def list_controllers():
         print "No controllers are loaded in mechanism control"
     else:
         for c in resp.controller:
-            print '%s - %s ( %s )'%(c.name, c.hardware_interface, c.state)
+            hwi = list(set(r.hardware_interface for r in  c.claimed_resources))
+            print '%s - %s ( %s )'%(c.name, '+'.join(hwi), c.state)
 
 
 def load_controller(name):

--- a/controller_manager_tests/CMakeLists.txt
+++ b/controller_manager_tests/CMakeLists.txt
@@ -41,6 +41,7 @@ if(CATKIN_ENABLE_TESTING)
   add_rostest(test/cm_test.test)
   catkin_add_nosetests(test)
   add_rostest(test/cm_msgs_utils_rostest.test)
+  add_rostest(test/controller_manager_scripts.test)
 endif()
 
 # Install
@@ -54,4 +55,3 @@ install(TARGETS ${PROJECT_NAME} dummy_app
 
 install(FILES test_controllers_plugin.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
-

--- a/controller_manager_tests/package.xml
+++ b/controller_manager_tests/package.xml
@@ -24,6 +24,8 @@
   <run_depend>controller_manager</run_depend>
   <run_depend>controller_interface</run_depend>
   <test_depend>rosservice</test_depend>
+  <test_depend>rosbash</test_depend>
+  <test_depend>rosnode</test_depend>
 
   <export>
     <controller_interface plugin="${prefix}/test_controllers_plugin.xml"/>

--- a/controller_manager_tests/src/dummy_app.cpp
+++ b/controller_manager_tests/src/dummy_app.cpp
@@ -52,5 +52,6 @@ int main(int argc, char** argv)
     hw.write();
     period.sleep();
   }
+  return 0;
 }
 

--- a/controller_manager_tests/test/controller_manager_scripts.py
+++ b/controller_manager_tests/test/controller_manager_scripts.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+import unittest
+import rospy
+import subprocess
+
+# output of controller_manager list, will by combined dynamically
+myc1_running='my_controller1 - hardware_interface::EffortJointInterface ( running )\n'
+myc1_stopped='my_controller1 - hardware_interface::EffortJointInterface ( stopped )\n'
+myc2_running='my_controller2 - hardware_interface::EffortJointInterface ( running )\n'
+myc2_stopped='my_controller2 - hardware_interface::EffortJointInterface ( stopped )\n'
+
+
+# output of other commands
+loaded_fmt = 'Loaded %s\n'
+unloaded_fmt = 'Unloaded %s successfully\n'
+stopped_fmt = "Stopped ['%s'] successfully\n"
+started_fmt = "Started ['%s'] successfully\n"
+
+no_controllers = 'No controllers are loaded in mechanism control\n'
+reload_response = 'Restore: False\nSuccessfully reloaded libraries\n'
+
+# run controller_manager in process
+def run_cm(*args):
+    return subprocess.check_output('rosrun controller_manager controller_manager ' + ' '.join(args), shell=True)
+
+# helper function that return the actual and expected response
+def load_c(name):
+    return run_cm('load', name), loaded_fmt % name
+
+def unload_c(name):
+    return run_cm('unload', name), unloaded_fmt % name
+
+def stop_c(name):
+    return run_cm('stop', name), stopped_fmt % name
+
+def start_c(name):
+    return run_cm('start', name), started_fmt % name
+
+def spawn_c(name):
+    return run_cm('spawn', name), loaded_fmt % name + started_fmt % name
+
+def kill_c(name):
+    return run_cm('kill', name), stopped_fmt % name + unloaded_fmt % name
+
+class TestUtils(unittest.TestCase):
+    def test_scripts(self):
+        rospy.wait_for_service("/controller_manager/list_controllers", 2.0)
+
+        # ensure that test controller is available
+        listed_types = run_cm('list-types').split()
+        self.assertIn('controller_manager_tests/EffortTestController', listed_types)
+
+        # ensure that no controllers are loaded
+        self.assertEqual(run_cm('list'), no_controllers)
+
+        # spawn (load+start) my_controller1 externally
+        s1 = subprocess.Popen('rosrun controller_manager spawner my_controller1 __name:=myspawner', shell=True)
+        rospy.sleep(1.0)
+        self.assertEqual(run_cm('list'), myc1_running)
+
+        # load my_controller2
+        self.assertEqual(*load_c('my_controller2'))
+        self.assertEqual(run_cm('list'), myc1_running + myc2_stopped)
+
+        # stop my_controller1
+        self.assertEqual(*stop_c('my_controller1'))
+        self.assertEqual(run_cm('list'), myc1_stopped + myc2_stopped)
+
+        # start my_controller2
+        self.assertEqual(*start_c('my_controller2'))
+        self.assertEqual(run_cm('list'), myc1_stopped + myc2_running)
+
+        # stop my_controller2
+        self.assertEqual(*stop_c('my_controller2'))
+        self.assertEqual(run_cm('list'), myc1_stopped + myc2_stopped)
+
+        # start my_controller1
+        self.assertEqual(*start_c('my_controller1'))
+        self.assertEqual(run_cm('list'), myc1_running + myc2_stopped)
+
+        # stop my_controller1 externally
+        u1 = subprocess.Popen('rosrun controller_manager unspawner my_controller1 __name:=myunspawner', shell=True)
+        rospy.sleep(1.0)
+        self.assertEqual(run_cm('list'), myc1_stopped + myc2_stopped)
+
+        # kill unspawner -> restart my_controller1
+        subprocess.check_call('rosnode kill /myunspawner', shell=True)
+        self.assertEqual(u1.wait(), 0)
+        self.assertEqual(run_cm('list'), myc1_running + myc2_stopped)
+
+        # kill spawner -> stop+unload my_controller1
+        subprocess.check_call('rosnode kill /myspawner', shell=True)
+        self.assertEqual(0, s1.wait())
+        self.assertEqual(run_cm('list'), myc2_stopped)
+
+        # spawn (load+start) my_controller1
+        self.assertEqual(*spawn_c('my_controller1'))
+        self.assertEqual(run_cm('list'), myc2_stopped + myc1_running)
+
+        # kill (stop+unload) my_controller1
+        self.assertEqual(*kill_c('my_controller1'))
+        self.assertEqual(run_cm('list'), myc2_stopped)
+
+        # unload my_controller2
+        self.assertEqual(*unload_c('my_controller2'))
+        self.assertEqual(run_cm('list'), no_controllers)
+
+        self.assertEqual(run_cm('reload-libraries'), reload_response)
+
+if __name__ == '__main__':
+    import rostest
+    rostest.rosrun('controller_manager_msgs',
+                   'controller_manager_scripts_rostest',
+                   TestUtils)

--- a/controller_manager_tests/test/controller_manager_scripts.test
+++ b/controller_manager_tests/test/controller_manager_scripts.test
@@ -1,0 +1,11 @@
+<launch>
+  <rosparam>
+    my_controller1:
+      type: controller_manager_tests/EffortTestController
+    my_controller2:
+      type: controller_manager_tests/EffortTestController
+  </rosparam>
+
+  <node pkg="controller_manager_tests" type="dummy_app" name="dummy_app"/>
+  <test test-name="controller_manager_scripts_test" pkg="controller_manager_tests" type="controller_manager_scripts.py"/>
+</launch>


### PR DESCRIPTION
addresses #287 

I have added some basic tests without argument tests.
To make the tests work I had to fix a bug in controller_manager list.

In addtion I have refactored the `unspawner` script.
This alters the behavior a little bit, but prevents any infinite blocking.