### PR TITLE
Single controller template

### DIFF
--- a/controller_interface/CMakeLists.txt
+++ b/controller_interface/CMakeLists.txt
@@ -4,10 +4,13 @@ project(controller_interface)
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS roscpp hardware_interface pluginlib)
 
+find_package(Boost REQUIRED)
+
 # Declare catkin package
 catkin_package(
   CATKIN_DEPENDS roscpp hardware_interface pluginlib
   INCLUDE_DIRS include
+  DEPENDS BOOST
   )
 
 # Install

--- a/controller_interface/include/controller_interface/controller.h
+++ b/controller_interface/include/controller_interface/controller.h
@@ -49,7 +49,7 @@ namespace controller_interface
  * control.
  */
 template <class T>
-class Controller: public ControllerBase
+class Controller: public virtual ControllerBase
 {
 public:
   Controller()  {state_ = CONSTRUCTED;}

--- a/controller_interface/include/controller_interface/controller.h
+++ b/controller_interface/include/controller_interface/controller.h
@@ -135,7 +135,7 @@ namespace controller_interface
  * \tparam T... Hardware interface types.
  * This parameter is \e required.
  */
-template <typename... T>
+template <class... Interfaces>
 class Controller: public virtual ControllerBase
 {
 public:
@@ -175,7 +175,7 @@ public:
    * \returns True if initialization was successful and the controller
    * is ready to be started.
    */
-  virtual bool init(T*... /*interfaces*/,
+  virtual bool init(Interfaces*... /*interfaces*/,
                     ros::NodeHandle& /*controller_nh*/)
   {
     return true;
@@ -205,7 +205,7 @@ public:
    * \returns True if initialization was successful and the controller
    * is ready to be started.
    */
-  virtual bool init(T*... /*interfaces*/,
+  virtual bool init(Interfaces*... /*interfaces*/,
                     ros::NodeHandle& /*root_nh*/,
                     ros::NodeHandle& /*controller_nh*/)
   {
@@ -248,15 +248,15 @@ protected:
     }
 
     // Check for required hardware interfaces.
-    if (!allow_optional_interfaces_ && !internal::hasInterfaces<T...>(robot_hw))
+    if (!allow_optional_interfaces_ && !internal::hasInterfaces<Interfaces...>(robot_hw))
     {
       // Error message has already been sent by the checking function.
       return false;
     }
 
     // Custom controller initialization.
-    if (!init(robot_hw->get<T>()..., controller_nh) ||
-        !init(robot_hw->get<T>()..., root_nh, controller_nh))
+    if (!init(robot_hw->get<Interfaces>()..., controller_nh) ||
+        !init(robot_hw->get<Interfaces>()..., root_nh, controller_nh))
     {
       ROS_ERROR("Failed to initialize the controller.");
       return false;
@@ -264,8 +264,8 @@ protected:
 
     // Populate claimed resources.
     claimed_resources.clear();
-    internal::populateClaimedResources<T...>(robot_hw, claimed_resources);
-    internal::clearClaims<T...>(robot_hw);
+    internal::populateClaimedResources<Interfaces...>(robot_hw, claimed_resources);
+    internal::clearClaims<Interfaces...>(robot_hw);
     // NOTE: Above, claims are cleared since we only want to know what they are and report them back
     // as an output parameter. Actual resource claiming by the controller is done when the controller
     // is start()ed
@@ -281,7 +281,7 @@ protected:
    */
   ROS_DEPRECATED std::string getHardwareInterfaceType() const
   {
-    return hardware_interface::internal::demangledTypeName<T...>();
+    return hardware_interface::internal::demangledTypeName<Interfaces...>();
   }
 
   /*\}*/
@@ -300,7 +300,7 @@ private:
    */
   Controller& operator =(const Controller& c);
 
-  static_assert(sizeof...(T) >= 1, "Controller must have at least one hardware interface.");
+  static_assert(sizeof...(Interfaces) >= 1, "Controller must have at least one hardware interface.");
 };
 
 } // namespace

--- a/controller_interface/include/controller_interface/controller.h
+++ b/controller_interface/include/controller_interface/controller.h
@@ -299,6 +299,8 @@ private:
    * Construction by assignment prohibited. Controllers are not copyable.
    */
   Controller& operator =(const Controller& c);
+
+  static_assert(sizeof...(T) >= 1, "Controller must have at least one hardware interface.");
 };
 
 } // namespace

--- a/controller_interface/include/controller_interface/controller.h
+++ b/controller_interface/include/controller_interface/controller.h
@@ -32,6 +32,7 @@
 #ifndef CONTROLLER_INTERFACE_CONTROLLER_H
 #define CONTROLLER_INTERFACE_CONTROLLER_H
 
+#include <boost/config.hpp>
 #include <controller_interface/controller_base.h>
 #include <controller_interface/internal/robothw_interfaces.h>
 #include <hardware_interface/robot_hw.h>
@@ -300,7 +301,9 @@ private:
    */
   Controller& operator =(const Controller& c);
 
+#ifndef BOOST_NO_VARIADIC_TEMPLATES
   static_assert(sizeof...(Interfaces) >= 1, "Controller must have at least one hardware interface.");
+#endif  // BOOST_NO_VARIADIC_TEMPLATES
 };
 
 } // namespace

--- a/controller_interface/include/controller_interface/controller.h
+++ b/controller_interface/include/controller_interface/controller.h
@@ -243,7 +243,7 @@ protected:
   {
     // Check if construction finished cleanly.
     if (state_ != CONSTRUCTED){
-      ROS_ERROR("Cannot initialize this controller because it failed to be constructed");
+      ROS_ERROR("Cannot initialize this controller because it failed to be constructed.");
       return false;
     }
 
@@ -258,7 +258,7 @@ protected:
     if (!init(robot_hw->get<T>()..., controller_nh) ||
         !init(robot_hw->get<T>()..., root_nh, controller_nh))
     {
-      ROS_ERROR("Failed to initialize the controller");
+      ROS_ERROR("Failed to initialize the controller.");
       return false;
     }
 
@@ -273,6 +273,15 @@ protected:
     // Initialization has succeeded.
     state_ = INITIALIZED;
     return true;
+  }
+
+  /**
+   * This is provided for compatibility with Controller from when it only took a single hardware
+   * interface. It can't be used when Controller has more than on interface type.
+   */
+  ROS_DEPRECATED std::string getHardwareInterfaceType() const
+  {
+    return hardware_interface::internal::demangledTypeName<T...>();
   }
 
   /*\}*/

--- a/controller_interface/include/controller_interface/controller.h
+++ b/controller_interface/include/controller_interface/controller.h
@@ -27,7 +27,11 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //////////////////////////////////////////////////////////////////////////////
 
-/** \author Adolfo Rodríguez Tsouroukdissian */
+/**
+ * \author Wim Meeussen
+ * \author Adolfo Rodríguez Tsouroukdissian
+ * \author Mike Purvis
+ * */
 
 #ifndef CONTROLLER_INTERFACE_CONTROLLER_H
 #define CONTROLLER_INTERFACE_CONTROLLER_H
@@ -45,8 +49,8 @@ namespace controller_interface
 /**
  * \brief %Controller is able to claim resources from multiple hardware interfaces.
  *
- * This particular controller implementation allows to claim resources from one
- * or more different hardware interfaces. The types of these hardware interfaces
+ * This controller implementation allows to claim resources from one or
+ * more different hardware interfaces. The types of these hardware interfaces
  * are specified as template parameters.
  *
  * An example multi-interface controller could claim, for instance, resources
@@ -218,10 +222,9 @@ protected:
   /**
    * \brief Initialize the controller from a RobotHW pointer.
    *
-   * This calls \ref init with a RobotHW that is a subset of the input
-   * \c robot_hw parameter, containing only the requested hardware interfaces
-   * (all or some, depending on the value of \c allow_optional_interfaces passed
-   * to the constructor).
+   * This calls the user-supplied \ref init method with the hardware interfaces
+   * from the \c robot_hw pointer, some or all of which may be NULL, depending
+   * on the value of \c allow_optional_interfaces passed to the constructor.
    *
    * \param robot_hw The robot hardware abstraction.
    *
@@ -302,6 +305,9 @@ private:
   Controller& operator =(const Controller& c);
 
 #ifndef BOOST_NO_VARIADIC_TEMPLATES
+  // Everything other than this line actually compiles just fine under gcc without -std=c++11,
+  // barring warnings about varidic templates being unsupported. This guard can be removed in Melodic
+  // when the compiler is c++14 by default.
   static_assert(sizeof...(Interfaces) >= 1, "Controller must have at least one hardware interface.");
 #endif  // BOOST_NO_VARIADIC_TEMPLATES
 };

--- a/controller_interface/include/controller_interface/controller.h
+++ b/controller_interface/include/controller_interface/controller.h
@@ -1,5 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // Copyright (C) 2012, hiDOF INC.
+// Copyright (C) 2015, PAL Robotics S.L.
+// Copyright (C) 2018, Clearpath Robotics.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
@@ -8,7 +10,7 @@
 //   * Redistributions in binary form must reproduce the above copyright
 //     notice, this list of conditions and the following disclaimer in the
 //     documentation and/or other materials provided with the distribution.
-//   * Neither the name of hiDOF, Inc. nor the names of its
+//   * Neither the names of the copyright holders or the names of their
 //     contributors may be used to endorse or promote products derived from
 //     this software without specific prior written permission.
 //
@@ -25,41 +27,146 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //////////////////////////////////////////////////////////////////////////////
 
-/*
- * Author: Wim Meeussen
- */
+/** \author Adolfo Rodríguez Tsouroukdissian */
 
 #ifndef CONTROLLER_INTERFACE_CONTROLLER_H
 #define CONTROLLER_INTERFACE_CONTROLLER_H
 
 #include <controller_interface/controller_base.h>
-#include <hardware_interface/internal/demangle_symbol.h>
+#include <controller_interface/internal/robothw_interfaces.h>
 #include <hardware_interface/robot_hw.h>
 #include <hardware_interface/hardware_interface.h>
-#include <ros/ros.h>
-
+#include <ros/node_handle.h>
 
 namespace controller_interface
 {
 
-/** \brief %Controller with a specific hardware interface
+/**
+ * \brief %Controller is able to claim resources from multiple hardware interfaces.
  *
- * \tparam T The hardware interface type used by this controller. This enforces
- * semantic compatibility between the controller and the hardware it's meant to
- * control.
+ * This particular controller implementation allows to claim resources from one
+ * or more different hardware interfaces. The types of these hardware interfaces
+ * are specified as template parameters.
+ *
+ * An example multi-interface controller could claim, for instance, resources
+ * from a position-controlled arm and velocity-controlled wheels. Another
+ * example would be a controller claiming both position and effort interfaces
+ * for the same robot resources, but this would require a robot with a custom
+ * (non-exclusive) resource handling policy.
+ *
+ * By default, all specified hardware interfaces are required, and their
+ * existence will be enforced by \ref initRequest. It is possible to make hardware
+ * interfaces optional by means of the \c allow_optional_interfaces
+ * \ref Controller::Controller "constructor" parameter.
+ * This allows to write controllers where some interfaces are mandatory, and
+ * others, if present, improve controller performance, but whose absence does not
+ * prevent the controller from running.
+ *
+ * The following is an example of a controller claiming resources from velocity-
+ * and effort-controlled joints.
+ *
+ * \code
+ * #include <controller_interface/controller.h>
+ * #include <hardware_interface/joint_command_interface.h>
+ *
+ * using namespace hardware_interface;
+ * class VelEffController : public
+ *       controller_interface::Controller<VelocityJointInterface,
+ *                                        EffortJointInterface>
+ * {
+ * public:
+ *   VelEffController() {}
+ *
+ *   bool init(VelocityJointInterface* v, EffortJointInterface* e, ros::NodeHandle &n)
+ *     // v and e are guaranteed to be valid. Fetch resources from them,
+ *     // perform rest of initialization
+ *
+ *     return true;
+ *   }
+ *   void starting(const ros::Time& time);
+ *   void update(const ros::Time& time, const ros::Duration& period);
+ *   void stopping(const ros::Time& time);
+ * };
+ * \endcode
+ *
+ * The following fragment is a modified version of the above example, where
+ * controller interfaces are not required. It is left to the controller
+ * implementer to verify interface validity. Only the initialization code is
+ * shown.
+ *
+ * \code
+ * class VelEffController : public
+ *       controller_interface::Controller<VelocityJointInterface,
+                                          EffortJointInterface>
+ * {
+ * public:
+ *   // Note true flag passed to parent class, allowing requested hardware
+ *   // interfaces to be optional
+ *   VelEffController()
+ *    : controller_interface::Controller<VelocityJointInterface,
+                                         EffortJointInterface> (true)
+ *   {}
+ *
+ *   bool init(VelocityJointInterface* v, EffortJointInterface* e, ros::NodeHandle &n)
+ *   {
+ *     // v is a required interface
+ *     if (!v)
+ *     {
+ *       return false;
+ *     }
+ *
+ *     // e is an optional interface. If present, additional features are enabled.
+ *     // Controller can still function if interface or some of its resources are
+ *     // absent
+ *     if (e)
+ *     {
+ *       // ...
+ *     }
+ *
+ *     // Fetch resources from interfaces, perform rest of initialization
+ *     // ...
+ *
+ *     return true;
+ *   }
+ *   ...
+ * };
+ * \endcode
+ *
+ * \tparam T... Hardware interface types.
+ * This parameter is \e required.
  */
-template <class T>
+template <typename... T>
 class Controller: public virtual ControllerBase
 {
 public:
-  Controller()  {state_ = CONSTRUCTED;}
-  virtual ~Controller<T>(){}
+  /**
+   * \param allow_optional_interfaces If set to true, \ref initRequest will
+   * not fail if one or more of the requested interfaces is not present.
+   * If set to false (the default), all requested interfaces are required.
+   */
+  Controller(bool allow_optional_interfaces = false)
+    : allow_optional_interfaces_(allow_optional_interfaces)
+  {state_ = CONSTRUCTED;}
 
-  /** \brief The init function is called to initialize the controller from a
-   * non-realtime thread with a pointer to the hardware interface, itself,
-   * instead of a pointer to a RobotHW.
+  virtual ~Controller() {}
+
+  /** \name Non Real-Time Safe Functions
+   *\{*/
+
+  /**
+   * \brief Custom controller initialization logic.
    *
-   * \param hw The specific hardware interface used by this controller.
+   * In this method resources from different interfaces are claimed, and other
+   * non real-time initialization is performed, such as setup of ROS interfaces
+   * and resource pre-allocation.
+   *
+   * \param interfaces Pointers to the hardware interfaces used by this
+   * controller, as specified in the template parameter pack.
+   * If \ref Controller::Controller was called with \c allow_optional_interfaces
+   * set to \c false (the default), all pointers will be valid and non-NULL.
+   * If \c allow_optional_interfaces was set to \c true, some or all of the
+   * interface pointers may be NULL, and must be individually checked.
+   * Please refer to the code examples in the \ref Controller class description.
    *
    * \param controller_nh A NodeHandle in the namespace from which the controller
    * should read its configuration, and where it should set up its ROS
@@ -68,13 +175,26 @@ public:
    * \returns True if initialization was successful and the controller
    * is ready to be started.
    */
-  virtual bool init(T* /*hw*/, ros::NodeHandle& /*controller_nh*/) {return true;};
+  virtual bool init(T*... /*interfaces*/,
+                    ros::NodeHandle& /*controller_nh*/)
+  {
+    return true;
+  }
 
-  /** \brief The init function is called to initialize the controller from a
-   * non-realtime thread with a pointer to the hardware interface, itself,
-   * instead of a pointer to a RobotHW.
+  /**
+   * \brief Custom controller initialization logic.
    *
-   * \param hw The specific hardware interface used by this controller.
+   * In this method resources from different interfaces are claimed, and other
+   * non real-time initialization is performed, such as setup of ROS interfaces
+   * and resource pre-allocation.
+   *
+   * \param interfaces Pointers to the hardware interfaces used by this
+   * controller, as specified in the template parameter pack.
+   * If \ref Controller::Controller was called with \c allow_optional_interfaces
+   * set to \c false (the default), all pointers will be valid and non-NULL.
+   * If \c allow_optional_interfaces was set to \c true, some or all of the
+   * interface pointers may be NULL, and must be individually checked.
+   * Please refer to the code examples in the \ref Controller class description.
    *
    * \param root_nh A NodeHandle in the root of the controller manager namespace.
    * This is where the ROS interfaces are setup (publishers, subscribers, services).
@@ -85,65 +205,93 @@ public:
    * \returns True if initialization was successful and the controller
    * is ready to be started.
    */
-  virtual bool init(T* /*hw*/, ros::NodeHandle& /*root_nh*/, ros::NodeHandle& /*controller_nh*/) {return true;};
+  virtual bool init(T*... /*interfaces*/,
+                    ros::NodeHandle& /*root_nh*/,
+                    ros::NodeHandle& /*controller_nh*/)
+  {
+    return true;
+  }
 
 
 protected:
-  /** \brief Initialize the controller from a RobotHW pointer
+  /**
+   * \brief Initialize the controller from a RobotHW pointer.
    *
-   * This calls \ref init with the hardware interface for this controller if it
-   * can extract the correct interface from \c robot_hw.
+   * This calls \ref init with a RobotHW that is a subset of the input
+   * \c robot_hw parameter, containing only the requested hardware interfaces
+   * (all or some, depending on the value of \c allow_optional_interfaces passed
+   * to the constructor).
    *
+   * \param robot_hw The robot hardware abstraction.
+   *
+   * \param root_nh A NodeHandle in the root of the controller manager namespace.
+   * This is where the ROS interfaces are setup (publishers, subscribers, services).
+   *
+   * \param controller_nh A NodeHandle in the namespace of the controller.
+   * This is where the controller-specific configuration resides.
+   *
+   * \param[out] claimed_resources The resources claimed by this controller.
+   * They can belong to multiple hardware interfaces.
+   *
+   * \returns True if initialization was successful and the controller
+   * is ready to be started.
    */
   virtual bool initRequest(hardware_interface::RobotHW* robot_hw,
                            ros::NodeHandle&             root_nh,
                            ros::NodeHandle&             controller_nh,
                            ClaimedResources&            claimed_resources)
   {
-    // check if construction finished cleanly
+    // Check if construction finished cleanly.
     if (state_ != CONSTRUCTED){
       ROS_ERROR("Cannot initialize this controller because it failed to be constructed");
       return false;
     }
 
-    // get a pointer to the hardware interface
-    T* hw = robot_hw->get<T>();
-    if (!hw)
+    // Check for required hardware interfaces.
+    if (!allow_optional_interfaces_ && !internal::hasInterfaces<T...>(robot_hw))
     {
-      ROS_ERROR("This controller requires a hardware interface of type '%s'."
-                " Make sure this is registered in the hardware_interface::RobotHW class.",
-                getHardwareInterfaceType().c_str());
+      // Error message has already been sent by the checking function.
       return false;
     }
 
-    // return which resources are claimed by this controller
-    hw->clearClaims();
-    if (!init(hw, controller_nh) || !init(hw, root_nh, controller_nh))
+    // Custom controller initialization.
+    if (!init(robot_hw->get<T>()..., controller_nh) ||
+        !init(robot_hw->get<T>()..., root_nh, controller_nh))
     {
       ROS_ERROR("Failed to initialize the controller");
       return false;
     }
-    hardware_interface::InterfaceResources iface_res(getHardwareInterfaceType(), hw->getClaims());
-    claimed_resources.assign(1, iface_res);
-    hw->clearClaims();
 
-    // success
+    // Populate claimed resources.
+    claimed_resources.clear();
+    internal::populateClaimedResources<T...>(robot_hw, claimed_resources);
+    internal::clearClaims<T...>(robot_hw);
+    // NOTE: Above, claims are cleared since we only want to know what they are and report them back
+    // as an output parameter. Actual resource claiming by the controller is done when the controller
+    // is start()ed
+
+    // Initialization has succeeded.
     state_ = INITIALIZED;
     return true;
   }
 
-  /// Get the name of this controller's hardware interface type
-  std::string getHardwareInterfaceType() const
-  {
-    return hardware_interface::internal::demangledTypeName<T>();
-  }
+  /*\}*/
 
 private:
-  Controller<T>(const Controller<T> &c);
-  Controller<T>& operator =(const Controller<T> &c);
+  /** Flag to indicate if hardware interfaces are considered optional (i.e. non-required). */
+  bool allow_optional_interfaces_;
 
+  /**
+   * Construction by copying prohibited. Controllers are not copyable.
+   */
+  Controller(const Controller& c);
+
+  /**
+   * Construction by assignment prohibited. Controllers are not copyable.
+   */
+  Controller& operator =(const Controller& c);
 };
 
-}
+} // namespace
 
 #endif

--- a/controller_interface/include/controller_interface/internal/robothw_interfaces.h
+++ b/controller_interface/include/controller_interface/internal/robothw_interfaces.h
@@ -1,0 +1,150 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2015, PAL Robotics S.L.
+// Copyright (C) 2017, Clearpath Robotics
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the names of PAL Robotics S.L. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+/** \author Adolfo Rodríguez Tsouroukdissian */
+
+#ifndef CONTROLLER_INTERFACE_INTERNAL_ROBOTHW_INTERFACES_H
+#define CONTROLLER_INTERFACE_INTERNAL_ROBOTHW_INTERFACES_H
+
+#include <algorithm>
+#include <sstream>
+
+#include <controller_interface/controller_base.h>
+#include <hardware_interface/robot_hw.h>
+
+namespace controller_interface
+{
+
+/** \cond HIDDEN_SYMBOLS */
+namespace internal
+{
+
+template <class T>
+inline std::string enumerateElements(const T&           val,
+                                     const std::string& delimiter,
+                                     const std::string& prefix,
+                                     const std::string& suffix)
+{
+  std::string ret;
+  if (val.empty()) {return ret;}
+
+  const std::string sdp = suffix+delimiter+prefix;
+  std::stringstream ss;
+  ss << prefix;
+  std::copy(val.begin(), val.end(), std::ostream_iterator<typename T::value_type>(ss, sdp.c_str()));
+  ret = ss.str();
+  if (!ret.empty()) {ret.erase(ret.size() - delimiter.size() - prefix.size());}
+  return ret;
+}
+
+
+template <typename T>
+inline bool hasInterfaces(hardware_interface::RobotHW* robot_hw)
+{
+  T* hw = robot_hw->get<T>();
+  if (!hw)
+  {
+    const std::string hw_name = hardware_interface::internal::demangledTypeName<T>();
+    ROS_ERROR_STREAM("This controller requires a hardware interface of type '" << hw_name << "', " <<
+                     "but is not exposed by the robot. Available interfaces in robot:\n" <<
+                     enumerateElements(robot_hw->getNames(), "\n", "- '", "'")); // delimiter, prefix, suffux
+    return false;
+  }
+  return true;
+}
+
+template <typename T1, typename T2, typename... More>
+inline bool hasInterfaces(hardware_interface::RobotHW* robot_hw)
+{
+  return hasInterfaces<T1>(robot_hw) && hasInterfaces<T2, More...>(robot_hw);
+}
+
+
+template <typename T>
+void clearClaims(hardware_interface::RobotHW* robot_hw)
+{
+  T* hw = robot_hw->get<T>();
+  if (hw)
+  {
+    hw->clearClaims();
+  }
+}
+
+template <typename T1, typename T2, typename... More>
+void clearClaims(hardware_interface::RobotHW* robot_hw)
+{
+  clearClaims<T1>(robot_hw);
+  clearClaims<T2, More...>(robot_hw);
+}
+
+
+template <typename T>
+inline void extractInterfaceResources(hardware_interface::RobotHW* robot_hw_in,
+                                      hardware_interface::RobotHW* robot_hw_out)
+{
+  T* hw = robot_hw_in->get<T>();
+  if (hw) {robot_hw_out->registerInterface(hw);}
+}
+
+template <typename T1, typename T2, typename... More>
+inline void extractInterfaceResources(hardware_interface::RobotHW* robot_hw_in,
+                                      hardware_interface::RobotHW* robot_hw_out)
+{
+  extractInterfaceResources<T1>(robot_hw_in, robot_hw_out);
+  extractInterfaceResources<T2, More...>(robot_hw_in, robot_hw_out);
+}
+
+
+template <typename T>
+inline void populateClaimedResources(hardware_interface::RobotHW*      robot_hw,
+                                     ControllerBase::ClaimedResources& claimed_resources)
+{
+  T* hw = robot_hw->get<T>();
+  if (hw)
+  {
+    hardware_interface::InterfaceResources iface_res;
+    iface_res.hardware_interface = hardware_interface::internal::demangledTypeName<T>();
+    iface_res.resources = hw->getClaims();
+    claimed_resources.push_back(iface_res);
+  }
+}
+
+template <typename T1, typename T2, typename... More>
+inline void populateClaimedResources(hardware_interface::RobotHW*      robot_hw,
+                                     ControllerBase::ClaimedResources& claimed_resources)
+{
+  populateClaimedResources<T1>(robot_hw, claimed_resources);
+  populateClaimedResources<T2, More...>(robot_hw, claimed_resources);
+}
+
+} // namespace
+/** \endcond */
+
+} // namespace
+
+#endif  // CONTROLLER_INTERFACE_INTERNAL_ROBOTHW_INTERFACES_H

--- a/controller_interface/include/controller_interface/internal/robothw_interfaces.h
+++ b/controller_interface/include/controller_interface/internal/robothw_interfaces.h
@@ -35,6 +35,7 @@
 #include <sstream>
 
 #include <controller_interface/controller_base.h>
+#include <hardware_interface/internal/demangle_symbol.h>
 #include <hardware_interface/robot_hw.h>
 
 namespace controller_interface
@@ -86,6 +87,23 @@ inline bool hasInterfaces(hardware_interface::RobotHW* robot_hw)
 
 
 template <typename T>
+inline void populateInterfaces(hardware_interface::RobotHW* robot_hw, T hw)
+{
+  if (hw)
+  {
+    robot_hw->registerInterface(hw);
+  }
+}
+
+template <typename T, typename... More>
+inline void populateInterfaces(hardware_interface::RobotHW* robot_hw, T hw, More... more)
+{
+  populateInterfaces(robot_hw, hw);
+  populateInterfaces(robot_hw, more...);
+}
+
+
+template <typename T>
 void clearClaims(hardware_interface::RobotHW* robot_hw)
 {
   T* hw = robot_hw->get<T>();
@@ -100,23 +118,6 @@ void clearClaims(hardware_interface::RobotHW* robot_hw)
 {
   clearClaims<T1>(robot_hw);
   clearClaims<T2, More...>(robot_hw);
-}
-
-
-template <typename T>
-inline void extractInterfaceResources(hardware_interface::RobotHW* robot_hw_in,
-                                      hardware_interface::RobotHW* robot_hw_out)
-{
-  T* hw = robot_hw_in->get<T>();
-  if (hw) {robot_hw_out->registerInterface(hw);}
-}
-
-template <typename T1, typename T2, typename... More>
-inline void extractInterfaceResources(hardware_interface::RobotHW* robot_hw_in,
-                                      hardware_interface::RobotHW* robot_hw_out)
-{
-  extractInterfaceResources<T1>(robot_hw_in, robot_hw_out);
-  extractInterfaceResources<T2, More...>(robot_hw_in, robot_hw_out);
 }
 
 

--- a/controller_interface/include/controller_interface/internal/robothw_interfaces.h
+++ b/controller_interface/include/controller_interface/internal/robothw_interfaces.h
@@ -57,14 +57,14 @@ inline std::string enumerateElements(const T&           val,
   const std::string sdp = suffix+delimiter+prefix;
   std::stringstream ss;
   ss << prefix;
-  std::copy(val.begin(), val.end(), std::ostream_iterator<typename T::value_type>(ss, sdp.c_str()));
+  std::copy(val.begin(), val.end(), std::ostream_iterator<class T::value_type>(ss, sdp.c_str()));
   ret = ss.str();
   if (!ret.empty()) {ret.erase(ret.size() - delimiter.size() - prefix.size());}
   return ret;
 }
 
 
-template <typename T>
+template <class T>
 inline bool hasInterfaces(hardware_interface::RobotHW* robot_hw)
 {
   T* hw = robot_hw->get<T>();
@@ -79,14 +79,14 @@ inline bool hasInterfaces(hardware_interface::RobotHW* robot_hw)
   return true;
 }
 
-template <typename T1, typename T2, typename... More>
+template <class T1, class T2, class... More>
 inline bool hasInterfaces(hardware_interface::RobotHW* robot_hw)
 {
   return hasInterfaces<T1>(robot_hw) && hasInterfaces<T2, More...>(robot_hw);
 }
 
 
-template <typename T>
+template <class T>
 inline void populateInterfaces(hardware_interface::RobotHW* robot_hw, T hw)
 {
   if (hw)
@@ -95,7 +95,7 @@ inline void populateInterfaces(hardware_interface::RobotHW* robot_hw, T hw)
   }
 }
 
-template <typename T, typename... More>
+template <class T, class... More>
 inline void populateInterfaces(hardware_interface::RobotHW* robot_hw, T hw, More... more)
 {
   populateInterfaces(robot_hw, hw);
@@ -103,7 +103,7 @@ inline void populateInterfaces(hardware_interface::RobotHW* robot_hw, T hw, More
 }
 
 
-template <typename T>
+template <class T>
 void clearClaims(hardware_interface::RobotHW* robot_hw)
 {
   T* hw = robot_hw->get<T>();
@@ -113,7 +113,7 @@ void clearClaims(hardware_interface::RobotHW* robot_hw)
   }
 }
 
-template <typename T1, typename T2, typename... More>
+template <class T1, class T2, class... More>
 void clearClaims(hardware_interface::RobotHW* robot_hw)
 {
   clearClaims<T1>(robot_hw);
@@ -121,7 +121,7 @@ void clearClaims(hardware_interface::RobotHW* robot_hw)
 }
 
 
-template <typename T>
+template <class T>
 inline void populateClaimedResources(hardware_interface::RobotHW*      robot_hw,
                                      ControllerBase::ClaimedResources& claimed_resources)
 {
@@ -135,7 +135,7 @@ inline void populateClaimedResources(hardware_interface::RobotHW*      robot_hw,
   }
 }
 
-template <typename T1, typename T2, typename... More>
+template <class T1, class T2, class... More>
 inline void populateClaimedResources(hardware_interface::RobotHW*      robot_hw,
                                      ControllerBase::ClaimedResources& claimed_resources)
 {

--- a/controller_interface/include/controller_interface/multi_interface_controller.h
+++ b/controller_interface/include/controller_interface/multi_interface_controller.h
@@ -25,325 +25,73 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //////////////////////////////////////////////////////////////////////////////
 
-/** \author Adolfo Rodríguez Tsouroukdissian */
+/** \author Mike Purvis */
 
 #ifndef CONTROLLER_INTERFACE_MULTI_INTERFACE_CONTROLLER_H
 #define CONTROLLER_INTERFACE_MULTI_INTERFACE_CONTROLLER_H
 
-#include <controller_interface/controller_base.h>
+#warning MultiInterfaceController is deprecated. Please use Controller instead.
+
+#include <controller_interface/controller.h>
 #include <controller_interface/internal/robothw_interfaces.h>
-#include <hardware_interface/internal/demangle_symbol.h>
-#include <hardware_interface/robot_hw.h>
-#include <hardware_interface/hardware_interface.h>
 #include <ros/ros.h>
 
 namespace controller_interface
 {
 
 /**
- * \brief %Controller able to claim resources from multiple hardware interfaces.
- *
- * This particular controller implementation allows to claim resources from one
- * up to four different hardware interfaces. The types of these hardware
- * interfaces are specified as template parameters.
- *
- * An example multi-interface controller could claim, for instance, resources
- * from a position-controlled arm and velocity-controlled wheels. Another
- * example would be a controller claiming both position and effort interfaces
- * for the same robot resources, but this would require a robot with a custom
- * (non-exclusive) resource handling policy.
- *
- * By default, all specified hardware interfaces are required, and their
- * existence will be enforced by \ref initRequest. It is possible to make hardware
- * interfaces optional by means of the \c allow_optional_interfaces
- * \ref MultiInterfaceController::MultiInterfaceController "constructor" parameter.
- * This allows to write controllers where some interfaces are mandatory, and
- * others, if present, improve controller performance, but whose absence does not
- * prevent the controller from running.
- *
- * The following is an example of a controller claiming resources from velocity-
- * and effort-controlled joints.
- *
- * \code
- * #include <controller_interface/multi_interface_controller.h>
- * #include <hardware_interface/joint_command_interface.h>
- *
- * using namespace hardware_interface;
- * class VelEffController : public
- *       controller_interface::MultiInterfaceController<VelocityJointInterface,
- *                                                      EffortJointInterface>
- * {
- * public:
- *   VelEffController() {}
- *
- *   bool init(hardware_interface::RobotHW* robot_hw, ros::NodeHandle &n)
- *   {
- *     // robot_hw pointer only contains the two interfaces requested by the
- *     // controller. It is a subset of the entire robot, which may have more
- *     // hardware interfaces
- *
- *     // v and e below are guarranteed to be valid
- *     VelocityJointInterface* v = robot_hw->get<VelocityJointInterface>();
- *     EffortJointInterface*   e = robot_hw->get<EffortJointInterface>();
- *
- *     // Fetch resources from interfaces, perform rest of initialization
- *     //...
- *
- *     return true;
- *   }
- *   void starting(const ros::Time& time);
- *   void update(const ros::Time& time, const ros::Duration& period);
- *   void stopping(const ros::Time& time);
- * };
- * \endcode
- *
- * The following fragment is a modified version of the above example, where
- * controller interfaces are not required. It is left to the controller
- * implementer to verify interface validity. Only the initialization code is
- * shown.
- *
- * \code
- * class VelEffController : public
- *       controller_interface::MultiInterfaceController<VelocityJointInterface,
- *                                                      EffortJointInterface>
- * {
- * public:
- *   // Note true flag passed to parent class, allowing requested hardware
- *   // interfaces to be optional
- *   VelEffController()
- *    : controller_interface::MultiInterfaceController<VelocityJointInterface,
- *                                                     EffortJointInterface> (true)
- *   {}
- *
- *   bool init(hardware_interface::RobotHW* robot_hw, ros::NodeHandle &n)
- *   {
- *     // robot_hw pointer contains at most the two interfaces requested by the
- *     // controller. It may have none, only one or both, depending on whether the
- *     // robot exposes them
- *
- *     // v is a required interface
- *     VelocityJointInterface* v = robot_hw->get<VelocityJointInterface>();
- *     if (!v)
- *     {
- *       return false;
- *     }
- *
- *     // e is an optional interface. If present, additional features are enabled.
- *     // Controller can still function if interface or some of its resources are
- *     // absent
- *     EffortJointInterface* e = robot_hw->get<EffortJointInterface>();
- *
- *     // Fetch resources from interfaces, perform rest of initialization
- *     //...
- *
- *     return true;
- *   }
- *   ...
- * };
- * \endcode
- *
- * \tparam T... Hardware interface types.
- * This parameter is \e required.
+ * \brief Adapter class providing the old MultiInterfaceController API.
  */
 template <typename... T>
-class MultiInterfaceController: public virtual ControllerBase
+class MultiInterfaceController: public Controller<T...>
 {
 public:
-  /**
-   * \param allow_optional_interfaces If set to true, \ref initRequest will
-   * not fail if one or more of the requested interfaces is not present.
-   * If set to false (the default), all requested interfaces are required.
-   */
-  MultiInterfaceController(bool allow_optional_interfaces = false)
-    : allow_optional_interfaces_(allow_optional_interfaces)
-  {state_ = CONSTRUCTED;}
-
-  virtual ~MultiInterfaceController() {}
+  using Controller<T...>::Controller;
 
   /** \name Non Real-Time Safe Functions
    *\{*/
 
-  /**
-   * \brief Custom controller initialization logic.
-   *
-   * In this method resources from different interfaces are claimed, and other
-   * non real-time initialization is performed, such as setup of ROS interfaces
-   * and resource pre-allocation.
-   *
-   * \param robot_hw Robot hardware abstraction containing a subset of the entire
-   * robot. If \ref MultiInterfaceController::MultiInterfaceController
-   * "MultiInterfaceController" was called with \c allow_optional_interfaces set
-   * to \c false (the default), this parameter contains all the interfaces
-   * requested by the controller.
-   * If \c allow_optional_interfaces was set to \c false, this parameter may
-   * contain none, some or all interfaces requested by the controller, depending
-   * on whether the robot exposes them. Please refer to the code examples in the
-   * \ref MultiInterfaceController "class description".
-   *
-   * \param controller_nh A NodeHandle in the namespace from which the controller
-   * should read its configuration, and where it should set up its ROS
-   * interface.
-   *
-   * \returns True if initialization was successful and the controller
-   * is ready to be started.
-   */
   virtual bool init(hardware_interface::RobotHW* /*robot_hw*/,
-                    ros::NodeHandle&             /*controller_nh*/)
-  {return true;}
-
-  /**
-   * \brief Custom controller initialization logic.
-   *
-   * In this method resources from different interfaces are claimed, and other
-   * non real-time initialization is performed, such as setup of ROS interfaces
-   * and resource pre-allocation.
-   *
-   * \param robot_hw Robot hardware abstraction containing a subset of the entire
-   * robot. If \ref MultiInterfaceController::MultiInterfaceController
-   * "MultiInterfaceController" was called with \c allow_optional_interfaces set
-   * to \c false (the default), this parameter contains all the interfaces
-   * requested by the controller.
-   * If \c allow_optional_interfaces was set to \c false, this parameter may
-   * contain none, some or all interfaces requested by the controller, depending
-   * on whether the robot exposes them. Please refer to the code examples in the
-   * \ref MultiInterfaceController "class description".
-   *
-   * \param root_nh A NodeHandle in the root of the controller manager namespace.
-   * This is where the ROS interfaces are setup (publishers, subscribers, services).
-   *
-   * \param controller_nh A NodeHandle in the namespace of the controller.
-   * This is where the controller-specific configuration resides.
-   *
-   * \returns True if initialization was successful and the controller
-   * is ready to be started.
-   */
-  virtual bool init(hardware_interface::RobotHW* /*robot_hw*/,
-                    ros::NodeHandle&             /*root_nh*/,
-                    ros::NodeHandle&             /*controller_nh*/)
-  {return true;}
-
-protected:
-  /**
-   * \brief Initialize the controller from a RobotHW pointer.
-   *
-   * This calls \ref init with a RobotHW that is a subset of the input
-   * \c robot_hw parameter, containing only the requested hardware interfaces
-   * (all or some, depending on the value of \c allow_optional_interfaces passed
-   * to the constructor).
-   *
-   * \param robot_hw The robot hardware abstraction.
-   *
-   * \param root_nh A NodeHandle in the root of the controller manager namespace.
-   * This is where the ROS interfaces are setup (publishers, subscribers, services).
-   *
-   * \param controller_nh A NodeHandle in the namespace of the controller.
-   * This is where the controller-specific configuration resides.
-   *
-   * \param[out] claimed_resources The resources claimed by this controller.
-   * They can belong to multiple hardware interfaces.
-   *
-   * \returns True if initialization was successful and the controller
-   * is ready to be started.
-   */
-  virtual bool initRequest(hardware_interface::RobotHW* robot_hw,
-                           ros::NodeHandle&             root_nh,
-                           ros::NodeHandle&             controller_nh,
-                           ClaimedResources&            claimed_resources)
+                    ros::NodeHandle& /*controller_nh*/)
   {
-    // check if construction finished cleanly
-    if (state_ != CONSTRUCTED){
-      ROS_ERROR("Cannot initialize this controller because it failed to be constructed");
-      return false;
-    }
-
-    // check for required hardware interfaces
-    if (!allow_optional_interfaces_ && !hasRequiredInterfaces(robot_hw)) {return false;}
-
-    // populate robot hardware abstraction containing only controller hardware interfaces (subset of robot)
-    hardware_interface::RobotHW* robot_hw_ctrl_p = &robot_hw_ctrl_;
-    extractInterfaceResources(robot_hw, robot_hw_ctrl_p);
-
-    // custom controller initialization
-    clearClaims(robot_hw_ctrl_p); // claims will be populated on controller init
-    if (!init(robot_hw_ctrl_p, controller_nh) || !init(robot_hw_ctrl_p, root_nh, controller_nh))
-    {
-      ROS_ERROR("Failed to initialize the controller");
-      return false;
-    }
-
-    // populate claimed resources
-    claimed_resources.clear();
-    populateClaimedResources(robot_hw_ctrl_p, claimed_resources);
-    clearClaims(robot_hw_ctrl_p);
-    // NOTE: Above, claims are cleared since we only want to know what they are and report them back
-    // as an output parameter. Actual resource claiming by the controller is done when the controller
-    // is start()ed
-
-    // initialization successful
-    state_ = INITIALIZED;
     return true;
   }
 
-  /*\}*/
-
-  /**
-   * \brief Check if robot hardware abstraction contains all required interfaces.
-   * \param robot_hw Robot hardware abstraction.
-   * \return true if all required hardware interfaces are exposed by \c robot_hw,
-   * false otherwise.
-   */
-  static bool hasRequiredInterfaces(hardware_interface::RobotHW* robot_hw)
+  virtual bool init(hardware_interface::RobotHW* /*robot_hw*/,
+                    ros::NodeHandle& /*root_nh*/,
+                    ros::NodeHandle& /*controller_nh*/)
   {
-    return internal::hasInterfaces<T...>(robot_hw);
+    return true;
   }
-
-  /**
-   * \brief Clear claims from all hardware interfaces requested by this controller.
-   * \param robot_hw Robot hardware abstraction containing the interfaces whose
-   * claims will be cleared.
-   */
-  static void clearClaims(hardware_interface::RobotHW* robot_hw)
-  {
-    internal::clearClaims<T...>(robot_hw);
-  }
-
-  /**
-   * \brief Extract all hardware interfaces requested by this controller from
-   *  \c robot_hw_in, and add them also to \c robot_hw_out.
-   * \param[in] robot_hw_in Robot hardware abstraction containing the interfaces
-   * requested by this controller, and potentially others.
-   * \param[out] robot_hw_out Robot hardware abstraction containing \e only the
-   * interfaces requested by this controller.
-   */
-  static void extractInterfaceResources(hardware_interface::RobotHW* robot_hw_in,
-                                        hardware_interface::RobotHW* robot_hw_out)
-  {
-    internal::extractInterfaceResources<T...>(robot_hw_in, robot_hw_out);
-  }
-
-  /**
-   * \brief Extract all hardware interfaces requested by this controller from
-   *  \c robot_hw_in, and add them also to \c robot_hw_out.
-   * \param[in] robot_hw_in Robot hardware abstraction containing the interfaces
-   * requested by this controller, and potentially others.
-   * \param[out] claimed_resources The resources claimed by this controller.
-   * They can belong to multiple hardware interfaces.
-   */
-  static void populateClaimedResources(hardware_interface::RobotHW* robot_hw,
-                                       ClaimedResources&            claimed_resources)
-  {
-    internal::populateClaimedResources<T...>(robot_hw, claimed_resources);
-  }
-
-  /** Robot hardware abstraction containing only the subset of interfaces requested by the controller. */
-  hardware_interface::RobotHW robot_hw_ctrl_;
-
-  /** Flag to indicate if hardware interfaces are considered optional (i.e. non-required). */
-  bool allow_optional_interfaces_;
 
 private:
-  MultiInterfaceController(const MultiInterfaceController& c);
-  MultiInterfaceController& operator =(const MultiInterfaceController& c);
+  /**
+   * \brief Overrides the new-API init function in the base class,
+   * and calls through to the virtual method with the old API.
+   */
+  bool init(T*... interfaces,
+            ros::NodeHandle& controller_nh) override
+  {
+    hardware_interface::RobotHW robot_hw;
+    internal::populateInterfaces(&robot_hw, interfaces...);
+    return init(&robot_hw, controller_nh);
+  }
+
+  /**
+   * \brief Overrides the new-API init function in the base class,
+   * and calls through to the virtual method with the old API.
+   */
+  bool init(T*... interfaces,
+            ros::NodeHandle& root_nh,
+            ros::NodeHandle& controller_nh) override
+  {
+    hardware_interface::RobotHW robot_hw;
+    internal::populateInterfaces(&robot_hw, interfaces...);
+    return init(&robot_hw, root_nh, controller_nh);
+  }
+  /**
+   * Robot hardware abstraction containing only the subset of interfaces requested by the controller.
+   */
 };
 
 } // namespace

--- a/controller_interface/include/controller_interface/multi_interface_controller.h
+++ b/controller_interface/include/controller_interface/multi_interface_controller.h
@@ -191,7 +191,7 @@ std::string enumerateElements(const T& val,
  * types.
  */
 template <class T1, class T2 = void, class T3 = void, class T4 = void>
-class MultiInterfaceController: public ControllerBase
+class MultiInterfaceController: public virtual ControllerBase
 {
 public:
   /**

--- a/controller_interface/include/controller_interface/multi_interface_controller.h
+++ b/controller_interface/include/controller_interface/multi_interface_controller.h
@@ -42,11 +42,11 @@ namespace controller_interface
 /**
  * \brief Adapter class providing the old MultiInterfaceController API.
  */
-template <typename... T>
-class MultiInterfaceController: public Controller<T...>
+template <class... Interfaces>
+class MultiInterfaceController: public Controller<Interfaces...>
 {
 public:
-  using Controller<T...>::Controller;
+  using Controller<Interfaces...>::Controller;
 
   /** \name Non Real-Time Safe Functions
    *\{*/
@@ -69,7 +69,7 @@ private:
    * \brief Overrides the new-API init function in the base class,
    * and calls through to the virtual method with the old API.
    */
-  bool init(T*... interfaces,
+  bool init(Interfaces*... interfaces,
             ros::NodeHandle& controller_nh) override
   {
     internal::populateInterfaces(&robot_hw_ctrl_, interfaces...);
@@ -80,7 +80,7 @@ private:
    * \brief Overrides the new-API init function in the base class,
    * and calls through to the virtual method with the old API.
    */
-  bool init(T*... interfaces,
+  bool init(Interfaces*... interfaces,
             ros::NodeHandle& root_nh,
             ros::NodeHandle& controller_nh) override
   {

--- a/controller_interface/include/controller_interface/multi_interface_controller.h
+++ b/controller_interface/include/controller_interface/multi_interface_controller.h
@@ -72,9 +72,8 @@ private:
   bool init(T*... interfaces,
             ros::NodeHandle& controller_nh) override
   {
-    hardware_interface::RobotHW robot_hw;
-    internal::populateInterfaces(&robot_hw, interfaces...);
-    return init(&robot_hw, controller_nh);
+    internal::populateInterfaces(&robot_hw_ctrl_, interfaces...);
+    return init(&robot_hw_ctrl_, controller_nh);
   }
 
   /**
@@ -85,13 +84,14 @@ private:
             ros::NodeHandle& root_nh,
             ros::NodeHandle& controller_nh) override
   {
-    hardware_interface::RobotHW robot_hw;
-    internal::populateInterfaces(&robot_hw, interfaces...);
-    return init(&robot_hw, root_nh, controller_nh);
+    internal::populateInterfaces(&robot_hw_ctrl_, interfaces...);
+    return init(&robot_hw_ctrl_, root_nh, controller_nh);
   }
+
   /**
    * Robot hardware abstraction containing only the subset of interfaces requested by the controller.
    */
+  hardware_interface::RobotHW robot_hw_ctrl_;
 };
 
 } // namespace

--- a/controller_interface/package.xml
+++ b/controller_interface/package.xml
@@ -15,6 +15,8 @@
   <author>Wim Meeussen</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+  
+  <build_depend>boost</build_depend>
 
   <depend>hardware_interface</depend>
   <depend>pluginlib</depend>

--- a/controller_manager_tests/CMakeLists.txt
+++ b/controller_manager_tests/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(controller_manager_tests)
 
+set_directory_properties(PROPERTIES COMPILE_OPTIONS "-std=c++11")
+
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS controller_manager controller_interface)
 catkin_python_setup()


### PR DESCRIPTION
As hinted at in https://github.com/ros-controls/ros_control/pull/299#issuecomment-364166135, with C++11 it's now possible to achieve all features of `MultiInterfaceController` with a single `Controller` template that doesn't break the existing API. You basically get an `init()` function which includes pointers to all the hardware interfaces you specify in the template instantiation, eg:

```
class VelEffController : public controller_interface::Controller<VelocityJointInterface, EffortJointInterface>
{
public:
  bool init(VelocityJointInterface* v, EffortJointInterface* e, ros::NodeHandle &n) override;
}
```

With a single argument, this is the same as the legacy `Controller` usage. For compatibility with existing `MultiInterfaceController`, a deprecated adapter header is supplied which populates a reduced `RobotHW` as it worked before.

I'd propose this as a change for ROS Melodic, and removing the now deprecated `multi_interface_controller.h` in ROS N.

----

Note that the diff given here is pretty unhelpful. I'd suggest reviewing the new versions of the headers directly:

https://github.com/mikepurvis/ros_control/blob/single-controller-template/controller_interface/include/controller_interface/controller.h
https://github.com/mikepurvis/ros_control/blob/single-controller-template/controller_interface/include/controller_interface/multi_interface_controller.h

----

@adolfo-rt in particular I'm interested to hear from, as he was the original author of `MultiInterfaceController`, upon which this work builds heavily.