### PR TITLE
migrate classloader headers

### DIFF
--- a/combined_robot_hw/include/combined_robot_hw/combined_robot_hw.h
+++ b/combined_robot_hw/include/combined_robot_hw/combined_robot_hw.h
@@ -35,7 +35,7 @@
 #include <hardware_interface/internal/interface_manager.h>
 #include <hardware_interface/hardware_interface.h>
 #include <hardware_interface/robot_hw.h>
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 #include <ros/console.h>
 #include <ros/node_handle.h>
 

--- a/controller_manager/include/controller_manager/controller_loader.h
+++ b/controller_manager/include/controller_manager/controller_loader.h
@@ -28,7 +28,7 @@
 #ifndef CONRTOLLER_MANAGER_CONTROLLER_LOADER_H
 #define CONRTOLLER_MANAGER_CONTROLLER_LOADER_H
 
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 #include <controller_manager/controller_loader_interface.h>
 #include <boost/shared_ptr.hpp>
 

--- a/controller_manager/include/controller_manager/controller_manager.h
+++ b/controller_manager/include/controller_manager/controller_manager.h
@@ -43,7 +43,7 @@
 #include <hardware_interface/robot_hw.h>
 #include <realtime_tools/realtime_publisher.h>
 #include <ros/node_handle.h>
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 #include <controller_manager_msgs/ListControllerTypes.h>
 #include <controller_manager_msgs/ListControllers.h>
 #include <controller_manager_msgs/ReloadControllerLibraries.h>

--- a/transmission_interface/include/transmission_interface/transmission_interface_loader.h
+++ b/transmission_interface/include/transmission_interface/transmission_interface_loader.h
@@ -46,7 +46,7 @@
 #include <ros/console.h>
 
 // pluginlib
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 
 // ros_control
 #include <hardware_interface/actuator_state_interface.h>

--- a/transmission_interface/test/differential_transmission_loader_test.cpp
+++ b/transmission_interface/test/differential_transmission_loader_test.cpp
@@ -30,7 +30,7 @@
 #include <string>
 #include <boost/foreach.hpp>
 #include <gtest/gtest.h>
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 #include <transmission_interface/differential_transmission.h>
 #include <transmission_interface/transmission_loader.h>
 #include "read_file.h"

--- a/transmission_interface/test/four_bar_linkage_transmission_loader_test.cpp
+++ b/transmission_interface/test/four_bar_linkage_transmission_loader_test.cpp
@@ -30,7 +30,7 @@
 #include <string>
 #include <boost/foreach.hpp>
 #include <gtest/gtest.h>
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 #include <transmission_interface/four_bar_linkage_transmission.h>
 #include <transmission_interface/transmission_loader.h>
 #include "read_file.h"

--- a/transmission_interface/test/loader_utils.h
+++ b/transmission_interface/test/loader_utils.h
@@ -28,7 +28,7 @@
 /// \author Daniel Pinyol
 
 #include <boost/scoped_ptr.hpp>
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 #include <transmission_interface/simple_transmission.h>
 #include <transmission_interface/transmission_loader.h>
 #include "read_file.h"

--- a/transmission_interface/test/simple_transmission_loader_test.cpp
+++ b/transmission_interface/test/simple_transmission_loader_test.cpp
@@ -30,7 +30,7 @@
 #include <string>
 #include <boost/foreach.hpp>
 #include <gtest/gtest.h>
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 #include <transmission_interface/simple_transmission.h>
 #include <transmission_interface/transmission_loader.h>
 #include "read_file.h"


### PR DESCRIPTION
Just to get rid of the warnings.
Could be even cherry-picked for kinetic (after the next sync)