### PR TITLE
migrate to new class list macros header

### DIFF
--- a/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_1.h
+++ b/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_1.h
@@ -32,7 +32,7 @@
 
 #include <hardware_interface/joint_command_interface.h>
 #include <hardware_interface/robot_hw.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 namespace combined_robot_hw_tests
 {

--- a/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_2.h
+++ b/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_2.h
@@ -32,7 +32,7 @@
 
 #include <hardware_interface/joint_command_interface.h>
 #include <hardware_interface/robot_hw.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 namespace combined_robot_hw_tests
 {

--- a/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_3.h
+++ b/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_3.h
@@ -32,7 +32,7 @@
 
 #include <hardware_interface/joint_command_interface.h>
 #include <hardware_interface/robot_hw.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 namespace combined_robot_hw_tests
 {

--- a/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_4.h
+++ b/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_4.h
@@ -32,7 +32,7 @@
 
 #include <hardware_interface/force_torque_sensor_interface.h>
 #include <hardware_interface/robot_hw.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 namespace combined_robot_hw_tests
 {

--- a/controller_manager_tests/include/controller_manager_tests/effort_test_controller.h
+++ b/controller_manager_tests/include/controller_manager_tests/effort_test_controller.h
@@ -31,7 +31,7 @@
 
 #include <controller_interface/controller.h>
 #include <hardware_interface/joint_command_interface.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 
 namespace controller_manager_tests

--- a/controller_manager_tests/include/controller_manager_tests/my_dummy_controller.h
+++ b/controller_manager_tests/include/controller_manager_tests/my_dummy_controller.h
@@ -32,7 +32,7 @@
 
 #include <controller_interface/controller.h>
 #include <hardware_interface/hardware_interface.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 namespace controller_manager_tests
 {
@@ -61,5 +61,3 @@ public:
 }
 
 #endif
-
-

--- a/controller_manager_tests/include/controller_manager_tests/pos_eff_controller.h
+++ b/controller_manager_tests/include/controller_manager_tests/pos_eff_controller.h
@@ -30,7 +30,7 @@
 
 #include <controller_interface/multi_interface_controller.h>
 #include <hardware_interface/joint_command_interface.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 namespace controller_manager_tests
 {

--- a/controller_manager_tests/include/controller_manager_tests/pos_eff_opt_controller.h
+++ b/controller_manager_tests/include/controller_manager_tests/pos_eff_opt_controller.h
@@ -30,7 +30,7 @@
 
 #include <controller_interface/multi_interface_controller.h>
 #include <hardware_interface/joint_command_interface.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 namespace controller_manager_tests
 {

--- a/controller_manager_tests/include/controller_manager_tests/vel_eff_controller.h
+++ b/controller_manager_tests/include/controller_manager_tests/vel_eff_controller.h
@@ -30,7 +30,7 @@
 
 #include <controller_interface/multi_interface_controller.h>
 #include <hardware_interface/joint_command_interface.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 namespace controller_manager_tests
 {

--- a/transmission_interface/src/bidirectional_effort_joint_interface_provider.cpp
+++ b/transmission_interface/src/bidirectional_effort_joint_interface_provider.cpp
@@ -26,7 +26,7 @@
 //////////////////////////////////////////////////////////////////////////////
 
 // Pluginlib
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 // ros_control
 #include <transmission_interface/bidirectional_effort_joint_interface_provider.h>

--- a/transmission_interface/src/bidirectional_position_joint_interface_provider.cpp
+++ b/transmission_interface/src/bidirectional_position_joint_interface_provider.cpp
@@ -26,7 +26,7 @@
 //////////////////////////////////////////////////////////////////////////////
 
 // Pluginlib
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 // ros_control
 #include <transmission_interface/bidirectional_position_joint_interface_provider.h>

--- a/transmission_interface/src/bidirectional_velocity_joint_interface_provider.cpp
+++ b/transmission_interface/src/bidirectional_velocity_joint_interface_provider.cpp
@@ -26,7 +26,7 @@
 //////////////////////////////////////////////////////////////////////////////
 
 // Pluginlib
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 // ros_control
 #include <transmission_interface/bidirectional_velocity_joint_interface_provider.h>

--- a/transmission_interface/src/differential_transmission_loader.cpp
+++ b/transmission_interface/src/differential_transmission_loader.cpp
@@ -29,7 +29,7 @@
 #include <ros/console.h>
 
 // Pluginlib
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 // ros_control
 #include <hardware_interface/internal/demangle_symbol.h>

--- a/transmission_interface/src/effort_joint_interface_provider.cpp
+++ b/transmission_interface/src/effort_joint_interface_provider.cpp
@@ -27,7 +27,7 @@
 
 
 // Pluginlib
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 // ros_control
 #include <transmission_interface/effort_joint_interface_provider.h>

--- a/transmission_interface/src/four_bar_linkage_transmission_loader.cpp
+++ b/transmission_interface/src/four_bar_linkage_transmission_loader.cpp
@@ -29,7 +29,7 @@
 #include <ros/console.h>
 
 // Pluginlib
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 // ros_control
 #include <hardware_interface/internal/demangle_symbol.h>

--- a/transmission_interface/src/joint_state_interface_provider.cpp
+++ b/transmission_interface/src/joint_state_interface_provider.cpp
@@ -27,7 +27,7 @@
 
 
 // Pluginlib
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 // ros_control
 #include <transmission_interface/joint_state_interface_provider.h>

--- a/transmission_interface/src/position_joint_interface_provider.cpp
+++ b/transmission_interface/src/position_joint_interface_provider.cpp
@@ -27,7 +27,7 @@
 
 
 // Pluginlib
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 // ros_control
 #include <transmission_interface/position_joint_interface_provider.h>

--- a/transmission_interface/src/simple_transmission_loader.cpp
+++ b/transmission_interface/src/simple_transmission_loader.cpp
@@ -29,7 +29,7 @@
 #include <ros/console.h>
 
 // Pluginlib
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 // ros_control
 #include <hardware_interface/internal/demangle_symbol.h>

--- a/transmission_interface/src/velocity_joint_interface_provider.cpp
+++ b/transmission_interface/src/velocity_joint_interface_provider.cpp
@@ -27,7 +27,7 @@
 
 
 // Pluginlib
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 // ros_control
 #include <transmission_interface/velocity_joint_interface_provider.h>


### PR DESCRIPTION
Sry, I have missed the class list macros header in #306 