### PR TITLE
update include statements to use new pluginlib and class_loader headers

### DIFF
--- a/combined_robot_hw/include/combined_robot_hw/combined_robot_hw.h
+++ b/combined_robot_hw/include/combined_robot_hw/combined_robot_hw.h
@@ -35,7 +35,7 @@
 #include <hardware_interface/internal/interface_manager.h>
 #include <hardware_interface/hardware_interface.h>
 #include <hardware_interface/robot_hw.h>
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 #include <ros/console.h>
 #include <ros/node_handle.h>
 

--- a/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_1.h
+++ b/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_1.h
@@ -32,7 +32,7 @@
 
 #include <hardware_interface/joint_command_interface.h>
 #include <hardware_interface/robot_hw.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 namespace combined_robot_hw_tests
 {

--- a/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_2.h
+++ b/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_2.h
@@ -32,7 +32,7 @@
 
 #include <hardware_interface/joint_command_interface.h>
 #include <hardware_interface/robot_hw.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 namespace combined_robot_hw_tests
 {

--- a/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_3.h
+++ b/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_3.h
@@ -32,7 +32,7 @@
 
 #include <hardware_interface/joint_command_interface.h>
 #include <hardware_interface/robot_hw.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 namespace combined_robot_hw_tests
 {

--- a/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_4.h
+++ b/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_4.h
@@ -32,7 +32,7 @@
 
 #include <hardware_interface/force_torque_sensor_interface.h>
 #include <hardware_interface/robot_hw.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 namespace combined_robot_hw_tests
 {

--- a/controller_manager/include/controller_manager/controller_loader.h
+++ b/controller_manager/include/controller_manager/controller_loader.h
@@ -28,7 +28,7 @@
 #ifndef CONRTOLLER_MANAGER_CONTROLLER_LOADER_H
 #define CONRTOLLER_MANAGER_CONTROLLER_LOADER_H
 
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 #include <controller_manager/controller_loader_interface.h>
 #include <boost/shared_ptr.hpp>
 

--- a/controller_manager/include/controller_manager/controller_manager.h
+++ b/controller_manager/include/controller_manager/controller_manager.h
@@ -43,7 +43,7 @@
 #include <hardware_interface/robot_hw.h>
 #include <realtime_tools/realtime_publisher.h>
 #include <ros/node_handle.h>
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 #include <controller_manager_msgs/ListControllerTypes.h>
 #include <controller_manager_msgs/ListControllers.h>
 #include <controller_manager_msgs/ReloadControllerLibraries.h>

--- a/controller_manager_tests/include/controller_manager_tests/effort_test_controller.h
+++ b/controller_manager_tests/include/controller_manager_tests/effort_test_controller.h
@@ -31,7 +31,7 @@
 
 #include <controller_interface/controller.h>
 #include <hardware_interface/joint_command_interface.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 
 namespace controller_manager_tests

--- a/controller_manager_tests/include/controller_manager_tests/my_dummy_controller.h
+++ b/controller_manager_tests/include/controller_manager_tests/my_dummy_controller.h
@@ -32,7 +32,7 @@
 
 #include <controller_interface/controller.h>
 #include <hardware_interface/hardware_interface.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 namespace controller_manager_tests
 {

--- a/controller_manager_tests/include/controller_manager_tests/pos_eff_controller.h
+++ b/controller_manager_tests/include/controller_manager_tests/pos_eff_controller.h
@@ -30,7 +30,7 @@
 
 #include <controller_interface/multi_interface_controller.h>
 #include <hardware_interface/joint_command_interface.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 namespace controller_manager_tests
 {

--- a/controller_manager_tests/include/controller_manager_tests/pos_eff_opt_controller.h
+++ b/controller_manager_tests/include/controller_manager_tests/pos_eff_opt_controller.h
@@ -30,7 +30,7 @@
 
 #include <controller_interface/multi_interface_controller.h>
 #include <hardware_interface/joint_command_interface.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 namespace controller_manager_tests
 {

--- a/controller_manager_tests/include/controller_manager_tests/vel_eff_controller.h
+++ b/controller_manager_tests/include/controller_manager_tests/vel_eff_controller.h
@@ -30,7 +30,7 @@
 
 #include <controller_interface/multi_interface_controller.h>
 #include <hardware_interface/joint_command_interface.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 namespace controller_manager_tests
 {

--- a/transmission_interface/include/transmission_interface/transmission_interface_loader.h
+++ b/transmission_interface/include/transmission_interface/transmission_interface_loader.h
@@ -46,7 +46,7 @@
 #include <ros/console.h>
 
 // pluginlib
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 
 // ros_control
 #include <hardware_interface/actuator_state_interface.h>

--- a/transmission_interface/src/bidirectional_effort_joint_interface_provider.cpp
+++ b/transmission_interface/src/bidirectional_effort_joint_interface_provider.cpp
@@ -26,7 +26,7 @@
 //////////////////////////////////////////////////////////////////////////////
 
 // Pluginlib
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 // ros_control
 #include <transmission_interface/bidirectional_effort_joint_interface_provider.h>

--- a/transmission_interface/src/bidirectional_position_joint_interface_provider.cpp
+++ b/transmission_interface/src/bidirectional_position_joint_interface_provider.cpp
@@ -26,7 +26,7 @@
 //////////////////////////////////////////////////////////////////////////////
 
 // Pluginlib
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 // ros_control
 #include <transmission_interface/bidirectional_position_joint_interface_provider.h>

--- a/transmission_interface/src/bidirectional_velocity_joint_interface_provider.cpp
+++ b/transmission_interface/src/bidirectional_velocity_joint_interface_provider.cpp
@@ -26,7 +26,7 @@
 //////////////////////////////////////////////////////////////////////////////
 
 // Pluginlib
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 // ros_control
 #include <transmission_interface/bidirectional_velocity_joint_interface_provider.h>

--- a/transmission_interface/src/differential_transmission_loader.cpp
+++ b/transmission_interface/src/differential_transmission_loader.cpp
@@ -29,7 +29,7 @@
 #include <ros/console.h>
 
 // Pluginlib
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 // ros_control
 #include <hardware_interface/internal/demangle_symbol.h>

--- a/transmission_interface/src/effort_joint_interface_provider.cpp
+++ b/transmission_interface/src/effort_joint_interface_provider.cpp
@@ -27,7 +27,7 @@
 
 
 // Pluginlib
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 // ros_control
 #include <transmission_interface/effort_joint_interface_provider.h>

--- a/transmission_interface/src/four_bar_linkage_transmission_loader.cpp
+++ b/transmission_interface/src/four_bar_linkage_transmission_loader.cpp
@@ -29,7 +29,7 @@
 #include <ros/console.h>
 
 // Pluginlib
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 // ros_control
 #include <hardware_interface/internal/demangle_symbol.h>

--- a/transmission_interface/src/joint_state_interface_provider.cpp
+++ b/transmission_interface/src/joint_state_interface_provider.cpp
@@ -27,7 +27,7 @@
 
 
 // Pluginlib
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 // ros_control
 #include <transmission_interface/joint_state_interface_provider.h>

--- a/transmission_interface/src/position_joint_interface_provider.cpp
+++ b/transmission_interface/src/position_joint_interface_provider.cpp
@@ -27,7 +27,7 @@
 
 
 // Pluginlib
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 // ros_control
 #include <transmission_interface/position_joint_interface_provider.h>

--- a/transmission_interface/src/simple_transmission_loader.cpp
+++ b/transmission_interface/src/simple_transmission_loader.cpp
@@ -29,7 +29,7 @@
 #include <ros/console.h>
 
 // Pluginlib
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 // ros_control
 #include <hardware_interface/internal/demangle_symbol.h>

--- a/transmission_interface/src/velocity_joint_interface_provider.cpp
+++ b/transmission_interface/src/velocity_joint_interface_provider.cpp
@@ -27,7 +27,7 @@
 
 
 // Pluginlib
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 // ros_control
 #include <transmission_interface/velocity_joint_interface_provider.h>

--- a/transmission_interface/test/differential_transmission_loader_test.cpp
+++ b/transmission_interface/test/differential_transmission_loader_test.cpp
@@ -30,7 +30,7 @@
 #include <string>
 #include <boost/foreach.hpp>
 #include <gtest/gtest.h>
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 #include <transmission_interface/differential_transmission.h>
 #include <transmission_interface/transmission_loader.h>
 #include "read_file.h"

--- a/transmission_interface/test/four_bar_linkage_transmission_loader_test.cpp
+++ b/transmission_interface/test/four_bar_linkage_transmission_loader_test.cpp
@@ -30,7 +30,7 @@
 #include <string>
 #include <boost/foreach.hpp>
 #include <gtest/gtest.h>
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 #include <transmission_interface/four_bar_linkage_transmission.h>
 #include <transmission_interface/transmission_loader.h>
 #include "read_file.h"

--- a/transmission_interface/test/loader_utils.h
+++ b/transmission_interface/test/loader_utils.h
@@ -28,7 +28,7 @@
 /// \author Daniel Pinyol
 
 #include <boost/scoped_ptr.hpp>
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 #include <transmission_interface/simple_transmission.h>
 #include <transmission_interface/transmission_loader.h>
 #include "read_file.h"

--- a/transmission_interface/test/simple_transmission_loader_test.cpp
+++ b/transmission_interface/test/simple_transmission_loader_test.cpp
@@ -30,7 +30,7 @@
 #include <string>
 #include <boost/foreach.hpp>
 #include <gtest/gtest.h>
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 #include <transmission_interface/simple_transmission.h>
 #include <transmission_interface/transmission_loader.h>
 #include "read_file.h"


### PR DESCRIPTION
Disclaimer: This in an automated PR, if it is not relevant on this branch, apologies for the inconveniance, feel free close it.

----

`pluginlib` and `class_loader` headers have been refactored and renamed. The previous headers `.h` have been deprecated in favor of their `.hpp` equivalent. The new headers are available on all active ROS distributions and the deprecated ones will be removed in a future version of ROS (likely ROS-N).

This PR migrates the include statements to use the non-deprecated ones and should compile for any active ROS distribution starting with Indigo
The migration was done by running the scripts [pluginlib_headers_migration.py](https://github.com/ros/pluginlib/blob/6ada92c4665a392339c683682de1d1503658c209/scripts/pluginlib_headers_migration.py) and [class_loader_headers_update.py](https://github.com/ros/class_loader/blob/1515546103de4d987daa8f5519ca43fe6cffbca6/scripts/class_loader_headers_update.py) on this repository.
Note: this will not work for Jade