### PR TITLE
fix license string

### DIFF
--- a/transmission_interface/package.xml
+++ b/transmission_interface/package.xml
@@ -8,7 +8,7 @@
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
   <maintainer email="enrique.fernandez.perdomo@gmail.com">Enrique Fernandez</maintainer>
 
-  <license>Modified BSD</license>
+  <license>BSD</license>
 
   <url type="website">https://github.com/ros-controls/ros_control/wiki</url>
   <url type="bugtracker">https://github.com/ros-controls/ros_control/issues</url>


### PR DESCRIPTION
Fix license string in package xml, addresses #326 

```find ros_control* -name package.xml -print0 | xargs -0 grep BSD``` only shows ```<license>BSD</license>``` now

Second pull request in ros_controllers incoming.