### PR TITLE
Add controller_group script that allows switching groups easily

### DIFF
--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -46,7 +46,11 @@ install(DIRECTORY include/${PROJECT_NAME}/
 install(TARGETS ${PROJECT_NAME}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 
-install(PROGRAMS scripts/spawner scripts/unspawner scripts/controller_manager
+catkin_install_python(PROGRAMS
+  scripts/controller_group
+  scripts/controller_manager
+  scripts/spawner
+  scripts/unspawner
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 catkin_python_setup()

--- a/controller_manager/scripts/controller_group
+++ b/controller_manager/scripts/controller_group
@@ -1,0 +1,135 @@
+#!/usr/bin/env python
+# Copyright (c) 2018, Clearpath Robotics, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the Willow Garage, Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived from
+#       this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Support controller groups so it is easy to spawn a set controllers and also switch
+# to any other group at run time.
+#
+# Author: Yong Li
+#
+import rospy
+from argparse import ArgumentParser
+from controller_manager import controller_manager_interface
+from controller_manager_msgs.srv import ListControllers, ListControllersRequest
+
+
+def _read_group(group):
+    ''''
+    Return 2 sets of controllers. The first set includes controllers required for the given group,
+    and the second set includes the controllers that should be stopped if the given group is chosen.
+    '''
+    groups = rospy.get_param('controller_groups', {})
+    desired_controllers = set(groups.get(group, ()))
+    if not desired_controllers:
+        rospy.logerr('There is no controller defined in group {}'.format(group))
+        return None, None
+    # Remove duplicates.
+    all_controllers = set()
+    for controllers in groups.values():
+        all_controllers.update(controllers)
+    return desired_controllers, all_controllers - desired_controllers
+
+
+def _get_loaded_controllers():
+    rospy.wait_for_service('controller_manager/list_controllers', timeout=5)
+    s = rospy.ServiceProxy('controller_manager/list_controllers', ListControllers)
+    resp = s(ListControllersRequest())
+    controllers = {}
+    for controller in resp.controller:
+        controllers[controller.name] = controller.state == 'running'
+        if controller.state not in ('running', 'stopped'):
+            rospy.logerr('Unknown controller state {}'.format(controller.state))
+    return controllers
+
+
+def _list_group(args):
+    groups = rospy.get_param('controller_groups', {})
+    print('Number of groups: {}'.format(len(groups)))
+    for group, controllers in sorted(groups.items()):
+        print('  {}'.format(group))
+        for controller in controllers:
+            print('      {}'.format(controller))
+
+
+def _spawn_group(args):
+    desired_controllers, _ = _read_group(args.group)
+    if not desired_controllers:
+        return
+    for controller in desired_controllers:
+        controller_manager_interface.load_controller(controller)
+    for controller in desired_controllers:
+        controller_manager_interface.start_controller(controller)
+
+
+def _switch_group(args):
+    desired_controllers, other_controllers = _read_group(args.group)
+    if not desired_controllers:
+        return
+    loaded_controllers = _get_loaded_controllers()
+
+    # Stop running controllers that we no longer need.
+    to_stop = []
+    for controller in other_controllers:
+        if loaded_controllers.get(controller, False):
+            to_stop.append(controller)
+
+    # Load and start every desired controller if needed.
+    to_start = []
+    for controller in desired_controllers:
+        if controller not in loaded_controllers:
+            if not controller_manager_interface.load_controller(controller):
+                # load_controller() already prints an error.
+                print('Cancel group switching')
+                return
+        if not loaded_controllers.get(controller, False):
+            to_start.append(controller)
+
+    controller_manager_interface.start_stop_controllers(start_controllers=to_start, stop_controllers=to_stop)
+
+
+def _main():
+    parser = ArgumentParser(description='Controller Group Utility')
+    subparsers = parser.add_subparsers(title='Commands', metavar='')
+
+    list_parser = subparsers.add_parser('list', help='list available groups')
+    list_parser.set_defaults(func=_list_group)
+
+    spawn_parser = subparsers.add_parser(
+        'spawn', help='load all controllers in all groups and start controllers in the specified group')
+    spawn_parser.add_argument('group', help='name of the group to start')
+    spawn_parser.set_defaults(func=_spawn_group)
+
+    switch_parser = subparsers.add_parser('switch', help='switch to the specified group')
+    switch_parser.add_argument('group', help='name of the group to switch to')
+    switch_parser.set_defaults(func=_switch_group)
+
+    args = parser.parse_args(rospy.myargv()[1:])
+    args.func(args)
+
+
+if __name__ == '__main__':
+    _main()

--- a/controller_manager/src/controller_manager/controller_manager_interface.py
+++ b/controller_manager/src/controller_manager/controller_manager_interface.py
@@ -75,37 +75,28 @@ def unload_controller(name):
         return False
 
 def start_controller(name):
-    return start_stop_controllers([name], True)
+    return start_stop_controllers(start_controllers=[name])
 
 def start_controllers(names):
-    return start_stop_controllers(names, True)
+    return start_stop_controllers(start_controllers=names)
 
 def stop_controller(name):
-    return start_stop_controllers([name], False)
+    return start_stop_controllers(stop_controllers=[name])
 
 def stop_controllers(names):
-    return start_stop_controllers(names, False)
+    return start_stop_controllers(stop_controllers=names)
 
-def start_stop_controllers(names, st):
+def start_stop_controllers(start_controllers=[], stop_controllers=[]):
     rospy.wait_for_service('controller_manager/switch_controller')
     s = rospy.ServiceProxy('controller_manager/switch_controller', SwitchController)
-    start = []
-    stop = []
     strictness = SwitchControllerRequest.STRICT
-    if st:
-        start = names
-    else:
-        stop = names
-    resp = s.call(SwitchControllerRequest(start, stop, strictness))
+    resp = s.call(SwitchControllerRequest(start_controllers, stop_controllers, strictness))
     if resp.ok == 1:
-        if st:
-            print "Started {} successfully".format(names)
-        else:
-            print "Stopped {} successfully".format(names)
+        if start_controllers:
+            print "Started {} successfully".format(start_controllers)
+        if stop_controllers:
+            print "Stopped {} successfully".format(stop_controllers)
         return True
     else:
-        if st:
-            print "Error when starting ", names
-        else:
-            print "Error when stopping ", names
+        print "Error when starting {} and stopping {}".format(start_controllers, stop_controllers)
         return False

--- a/controller_manager_tests/test/controller_manager_scripts.py
+++ b/controller_manager_tests/test/controller_manager_scripts.py
@@ -23,6 +23,10 @@ reload_response = 'Restore: False\nSuccessfully reloaded libraries\n'
 def run_cm(*args):
     return subprocess.check_output('rosrun controller_manager controller_manager ' + ' '.join(args), shell=True)
 
+# run controller_group in process
+def run_cg(*args):
+    return subprocess.check_output('rosrun controller_manager controller_group ' + ' '.join(args), shell=True)
+
 # helper function that return the actual and expected response
 def load_c(name):
     return run_cm('load', name), loaded_fmt % name
@@ -41,6 +45,7 @@ def spawn_c(name):
 
 def kill_c(name):
     return run_cm('kill', name), stopped_fmt % name + unloaded_fmt % name
+
 
 class TestUtils(unittest.TestCase):
     def test_scripts(self):
@@ -106,6 +111,36 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(run_cm('list'), no_controllers)
 
         self.assertEqual(run_cm('reload-libraries'), reload_response)
+
+        # controller_group
+        # list
+        self.assertEqual(
+            run_cg('list'),
+            'Number of groups: 3\n'
+            '  group1\n      my_controller1\n      my_controller3\n'
+            '  group2\n      my_controller2\n      my_controller3\n'
+            '  group3\n      my_controller1\n      my_controller2\n')
+
+        # spawn
+        self.assertEqual(
+            run_cg('spawn group1'),
+            'Loaded my_controller1\n'
+            'Loaded my_controller3\n'
+            'Started [\'my_controller1\'] successfully\n'
+            'Started [\'my_controller3\'] successfully\n')
+
+        # switch
+        self.assertEqual(
+            run_cg('switch group2'),
+            'Loaded my_controller2\n'
+            'Started [\'my_controller2\'] successfully\n'
+            'Stopped [\'my_controller1\'] successfully\n')
+
+        # switch to faulty group because my_controller1 conflicts with my_controller2
+        self.assertEqual(
+            run_cg('switch group3'),
+            'Error when starting [\'my_controller1\'] and stopping [\'my_controller3\']\n')
+
 
 if __name__ == '__main__':
     import rostest

--- a/controller_manager_tests/test/controller_manager_scripts.test
+++ b/controller_manager_tests/test/controller_manager_scripts.test
@@ -8,6 +8,16 @@
       type: controller_manager_tests/EffortTestController
       joints:
       - hiDOF_joint3
+    controller_groups:
+      group1:
+        - my_controller1
+        - my_controller3
+      group2:
+        - my_controller2
+        - my_controller3
+      group3:
+        - my_controller1
+        - my_controller2
   </rosparam>
 
   <node pkg="controller_manager_tests" type="dummy_app" name="dummy_app"/>


### PR DESCRIPTION
The groups are read from ROS parameter "/controller_groups".

This is for the scenario that there can be multiple set of controllers that talk to same hardware interfaces but for different purposes. Without this script, one will have to stop all the production controllers and start a special set of controllers one by one. This script makes switching from a set to another much easier.