### PR TITLE
remove forward declaration of InterfaceResources

### DIFF
--- a/controller_interface/include/controller_interface/controller_base.h
+++ b/controller_interface/include/controller_interface/controller_base.h
@@ -37,11 +37,6 @@
 #include <hardware_interface/robot_hw.h>
 #include <boost/shared_ptr.hpp>
 
-namespace hardware_interface
-{
-  class InterfaceResources;
-}
-
 namespace controller_interface
 {
 


### PR DESCRIPTION
fixes #334.

Not really needed..
I could not figure out why the forward declaration was added in the first place.