### PR TITLE
add minimum required pluginlib version

### DIFF
--- a/combined_robot_hw/package.xml
+++ b/combined_robot_hw/package.xml
@@ -18,6 +18,6 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <depend>hardware_interface</depend>
-  <depend>pluginlib</depend>
+  <depend version_gte="1.11.2">pluginlib</depend>
   <depend>roscpp</depend>
 </package>

--- a/controller_interface/package.xml
+++ b/controller_interface/package.xml
@@ -17,6 +17,6 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <depend>hardware_interface</depend>
-  <depend>pluginlib</depend>
+  <depend version_gte="1.11.2">pluginlib</depend>
   <depend>roscpp</depend>
 </package>

--- a/controller_manager/package.xml
+++ b/controller_manager/package.xml
@@ -20,6 +20,6 @@
   <depend>controller_interface</depend>
   <depend>controller_manager_msgs</depend>
   <depend>hardware_interface</depend>
-  <depend>pluginlib</depend>
+  <depend version_gte="1.11.2">pluginlib</depend>
   <test_depend>rostest</test_depend>
 </package>

--- a/transmission_interface/package.xml
+++ b/transmission_interface/package.xml
@@ -19,7 +19,7 @@
 
   <depend>tinyxml</depend>
   <depend>roscpp</depend>
-  <depend>pluginlib</depend>
+  <depend version_gte="1.11.2">pluginlib</depend>
   <build_depend>hardware_interface</build_depend>
   <build_depend>cmake_modules</build_depend>
 


### PR DESCRIPTION
follow-up of https://github.com/ros-controls/ros_control/pull/315

For users trying to build this with an outdated pluginlib version