### PR TITLE
Spawner check for currently running controllers on shutdown

### DIFF
--- a/controller_manager/scripts/spawner
+++ b/controller_manager/scripts/spawner
@@ -41,6 +41,7 @@ import yaml
 from controller_manager_msgs.srv import *
 from std_msgs.msg import *
 import argparse
+import controller_manager.controller_manager_interface
 
 loaded = []
 
@@ -49,27 +50,37 @@ load_controller_service = ""
 switch_controller_service = ""
 unload_controller_service = ""
 
+counter = 0
+
 def shutdown():
     global loaded,unload_controller_service,load_controller_service,switch_controller_service
 
     rospy.loginfo("Shutting down spawner. Stopping and unloading controllers...")
 
     try:
-        # unloader
-        unload_controller = rospy.ServiceProxy(unload_controller_service, UnloadController)
+        # get list of running controllers
+        _running_controllers = []
+        _loaded_controllers = controller_manager.controller_manager_interface.list_controllers()
+        for c in _loaded_controllers:
+            if c.state == "running":
+                _running_controllers.append(c.name)
 
-        # switcher
+        # create unloader and switcher
+        unload_controller = rospy.ServiceProxy(unload_controller_service, UnloadController)
         switch_controller = rospy.ServiceProxy(switch_controller_service, SwitchController)
 
         rospy.loginfo("Stopping all controllers...");
-        switch_controller([], loaded, SwitchControllerRequest.STRICT)
+        switch_controller([], _running_controllers, SwitchControllerRequest.STRICT)
         rospy.loginfo("Unloading all loaded controllers...");
-        for name in reversed(loaded):
+        for name in reversed(_running_controllers):
             rospy.logout("Trying to unload %s" % name)
             unload_controller(name)
             rospy.logout("Succeeded in unloading %s" % name)
     except (rospy.ServiceException, rospy.exceptions.ROSException) as exc:
         rospy.logwarn("Controller Spawner error while taking down controllers: %s"  % (exc))
+        counter += 1
+        if counter < 3:
+            shutdown()
 
 def parse_args(args=None):
     parser = argparse.ArgumentParser(description='Controller spawner')
@@ -190,9 +201,6 @@ def main():
             rospy.logerr("Failed to load %s" % name)
 
     rospy.loginfo("Controller Spawner: Loaded controllers: %s" % ', '.join(loaded))
-
-    if rospy.is_shutdown():
-        return
 
     # start controllers is requested
     if autostart:

--- a/controller_manager/scripts/spawner
+++ b/controller_manager/scripts/spawner
@@ -63,14 +63,17 @@ def shutdown():
             if c.state == "running":
                 _running_controllers.append(c.name)
 
+        # determine if the loaded controllers are still running
+        _running_loaded_controllers = list(set(_running_controllers) & set(loaded))
+
         # create unloader and switcher
         unload_controller = rospy.ServiceProxy(unload_controller_service, UnloadController)
         switch_controller = rospy.ServiceProxy(switch_controller_service, SwitchController)
 
-        rospy.loginfo("Stopping all controllers...");
-        switch_controller([], _running_controllers, SwitchControllerRequest.STRICT)
+        rospy.loginfo("Stopping controllers...");
+        switch_controller([], _running_loaded_controllers, SwitchControllerRequest.STRICT)
         rospy.loginfo("Unloading all loaded controllers...");
-        for name in reversed(_running_controllers):
+        for name in reversed(_running_loaded_controllers):
             rospy.logout("Trying to unload %s" % name)
             unload_controller(name)
             rospy.logout("Succeeded in unloading %s" % name)

--- a/controller_manager/scripts/spawner
+++ b/controller_manager/scripts/spawner
@@ -50,8 +50,6 @@ load_controller_service = ""
 switch_controller_service = ""
 unload_controller_service = ""
 
-counter = 0
-
 def shutdown():
     global loaded,unload_controller_service,load_controller_service,switch_controller_service
 
@@ -78,9 +76,6 @@ def shutdown():
             rospy.logout("Succeeded in unloading %s" % name)
     except (rospy.ServiceException, rospy.exceptions.ROSException) as exc:
         rospy.logwarn("Controller Spawner error while taking down controllers: %s"  % (exc))
-        counter += 1
-        if counter < 3:
-            shutdown()
 
 def parse_args(args=None):
     parser = argparse.ArgumentParser(description='Controller spawner')

--- a/controller_manager/scripts/spawner
+++ b/controller_manager/scripts/spawner
@@ -64,7 +64,7 @@ def shutdown():
                 _running_controllers.append(c.name)
 
         # determine if the loaded controllers are still running
-        _running_loaded_controllers = list(set(_running_controllers) & set(loaded))
+        _running_loaded_controllers = [value for value in _running_controllers if value in loaded] 
 
         # create unloader and switcher
         unload_controller = rospy.ServiceProxy(unload_controller_service, UnloadController)

--- a/controller_manager/scripts/spawner
+++ b/controller_manager/scripts/spawner
@@ -41,7 +41,6 @@ import yaml
 from controller_manager_msgs.srv import *
 from std_msgs.msg import *
 import argparse
-import controller_manager.controller_manager_interface
 
 loaded = []
 
@@ -49,26 +48,33 @@ loaded = []
 load_controller_service = ""
 switch_controller_service = ""
 unload_controller_service = ""
+list_controllers_service = ""
 
 def shutdown():
-    global loaded,unload_controller_service,load_controller_service,switch_controller_service
+    global loaded,unload_controller_service,load_controller_service,switch_controller_service,list_controllers_service
 
     rospy.loginfo("Shutting down spawner. Stopping and unloading controllers...")
 
     try:
+        # lister
+        list_controllers = rospy.ServiceProxy(list_controllers_service, ListControllers)
+
+        # unloader
+        unload_controller = rospy.ServiceProxy(unload_controller_service, UnloadController)
+        
+        # switcher
+        switch_controller = rospy.ServiceProxy(switch_controller_service, SwitchController)
+        
         # get list of running controllers
+        rospy.loginfo("Getting list of controllers...");
+        _controller_list = list_controllers()
         _running_controllers = []
-        _loaded_controllers = controller_manager.controller_manager_interface.list_controllers()
-        for c in _loaded_controllers:
+        for c in _controller_list.controller:
             if c.state == "running":
                 _running_controllers.append(c.name)
 
         # determine if the loaded controllers are still running
         _running_loaded_controllers = [value for value in _running_controllers if value in loaded] 
-
-        # create unloader and switcher
-        unload_controller = rospy.ServiceProxy(unload_controller_service, UnloadController)
-        switch_controller = rospy.ServiceProxy(switch_controller_service, SwitchController)
 
         rospy.loginfo("Stopping controllers...");
         switch_controller([], _running_loaded_controllers, SwitchControllerRequest.STRICT)
@@ -97,7 +103,7 @@ def parse_args(args=None):
     return parser.parse_args(args=args)
 
 def main():
-    global unload_controller_service,load_controller_service,switch_controller_service
+    global unload_controller_service,load_controller_service,switch_controller_service,list_controllers_service
 
     args = parse_args(rospy.myargv()[1:])
 
@@ -119,6 +125,7 @@ def main():
     load_controller_service = robot_namespace+"controller_manager/load_controller"
     unload_controller_service = robot_namespace+"controller_manager/unload_controller"
     switch_controller_service = robot_namespace+"controller_manager/switch_controller"
+    list_controllers_service = robot_namespace+"controller_manager/list_controllers"
 
     try:
         # loader
@@ -137,6 +144,10 @@ def main():
         # early on
         rospy.loginfo("Controller Spawner: Waiting for service "+unload_controller_service)
         rospy.wait_for_service(unload_controller_service, timeout=timeout)
+
+        # lister
+        rospy.loginfo("Controller Spawner: Waiting for service "+list_controllers_service)
+        rospy.wait_for_service(list_controllers_service, timeout=timeout)
 
     except rospy.exceptions.ROSException:
         rospy.logwarn("Controller Spawner couldn't find the expected controller_manager ROS interface.")

--- a/controller_manager/src/controller_manager/controller_manager_interface.py
+++ b/controller_manager/src/controller_manager/controller_manager_interface.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
+from __future__ import print_function
 import rospy
 from controller_manager_msgs.srv import *
+
 
 def list_controller_types():
     rospy.wait_for_service('controller_manager/list_controller_types')
@@ -9,7 +11,8 @@ def list_controller_types():
     for t in resp.types:
         print(t)
 
-def reload_libraries(force_kill, restore = False):
+
+def reload_libraries(force_kill, restore=False):
     rospy.wait_for_service('controller_manager/reload_controller_libraries')
     s = rospy.ServiceProxy('controller_manager/reload_controller_libraries', ReloadControllerLibraries)
 
@@ -41,7 +44,6 @@ def reload_libraries(force_kill, restore = False):
 
 
 def list_controllers():
-    controller_list = []
     rospy.wait_for_service('controller_manager/list_controllers')
     s = rospy.ServiceProxy('controller_manager/list_controllers', ListControllers)
     resp = s.call(ListControllersRequest())
@@ -49,10 +51,8 @@ def list_controllers():
         print("No controllers are loaded in mechanism control")
     else:
         for c in resp.controller:
-            hwi = list(set(r.hardware_interface for r in  c.claimed_resources))
-            print('%s - %s ( %s )'%(c.name, '+'.join(hwi), c.state))
-            controller_list.append(c)
-        return controller_list
+            hwi = list(set(r.hardware_interface for r in c.claimed_resources))
+            print('%s - %s ( %s )' % (c.name, '+'.join(hwi), c.state))
 
 
 def load_controller(name):
@@ -66,6 +66,7 @@ def load_controller(name):
         print("Error when loading", name)
         return False
 
+
 def unload_controller(name):
     rospy.wait_for_service('controller_manager/unload_controller')
     s = rospy.ServiceProxy('controller_manager/unload_controller', UnloadController)
@@ -77,17 +78,22 @@ def unload_controller(name):
         print("Error when unloading", name)
         return False
 
+
 def start_controller(name):
     return start_stop_controllers([name], True)
+
 
 def start_controllers(names):
     return start_stop_controllers(names, True)
 
+
 def stop_controller(name):
     return start_stop_controllers([name], False)
 
+
 def stop_controllers(names):
     return start_stop_controllers(names, False)
+
 
 def start_stop_controllers(names, st):
     rospy.wait_for_service('controller_manager/switch_controller')

--- a/controller_manager/src/controller_manager/controller_manager_interface.py
+++ b/controller_manager/src/controller_manager/controller_manager_interface.py
@@ -1,18 +1,15 @@
 #! /usr/bin/env python
-from __future__ import print_function
 import rospy
 from controller_manager_msgs.srv import *
-
 
 def list_controller_types():
     rospy.wait_for_service('controller_manager/list_controller_types')
     s = rospy.ServiceProxy('controller_manager/list_controller_types', ListControllerTypes)
     resp = s.call(ListControllerTypesRequest())
     for t in resp.types:
-        print(t)
+        print t
 
-
-def reload_libraries(force_kill, restore=False):
+def reload_libraries(force_kill, restore = False):
     rospy.wait_for_service('controller_manager/reload_controller_libraries')
     s = rospy.ServiceProxy('controller_manager/reload_controller_libraries', ReloadControllerLibraries)
 
@@ -20,16 +17,16 @@ def reload_libraries(force_kill, restore=False):
     load_srv = rospy.ServiceProxy('controller_manager/load_controller', LoadController)
     switch_srv = rospy.ServiceProxy('controller_manager/switch_controller', SwitchController)
 
-    print("Restore:", restore)
+    print "Restore:", restore
     if restore:
         originally = list_srv.call(ListControllersRequest())
 
     resp = s.call(ReloadControllerLibrariesRequest(force_kill))
     if resp.ok:
-        print("Successfully reloaded libraries")
+        print "Successfully reloaded libraries"
         result = True
     else:
-        print("Failed to reload libraries. Do you still have controllers loaded?")
+        print "Failed to reload libraries. Do you still have controllers loaded?"
         result = False
 
     if restore:
@@ -39,20 +36,23 @@ def reload_libraries(force_kill, restore=False):
         switch_srv(start_controllers=to_start,
                    stop_controllers=[],
                    strictness=SwitchControllerRequest.BEST_EFFORT)
-        print("Controllers restored to original state")
+        print "Controllers restored to original state"
     return result
 
 
 def list_controllers():
+    controller_list = []
     rospy.wait_for_service('controller_manager/list_controllers')
     s = rospy.ServiceProxy('controller_manager/list_controllers', ListControllers)
     resp = s.call(ListControllersRequest())
     if len(resp.controller) == 0:
-        print("No controllers are loaded in mechanism control")
+        print "No controllers are loaded in mechanism control"
     else:
         for c in resp.controller:
-            hwi = list(set(r.hardware_interface for r in c.claimed_resources))
-            print('%s - %s ( %s )' % (c.name, '+'.join(hwi), c.state))
+            hwi = list(set(r.hardware_interface for r in  c.claimed_resources))
+            print '%s - %s ( %s )'%(c.name, '+'.join(hwi), c.state)
+            controller_list.append(c)
+        return controller_list
 
 
 def load_controller(name):
@@ -60,40 +60,34 @@ def load_controller(name):
     s = rospy.ServiceProxy('controller_manager/load_controller', LoadController)
     resp = s.call(LoadControllerRequest(name))
     if resp.ok:
-        print("Loaded", name)
+        print "Loaded", name
         return True
     else:
-        print("Error when loading", name)
+        print "Error when loading", name
         return False
-
 
 def unload_controller(name):
     rospy.wait_for_service('controller_manager/unload_controller')
     s = rospy.ServiceProxy('controller_manager/unload_controller', UnloadController)
     resp = s.call(UnloadControllerRequest(name))
     if resp.ok == 1:
-        print("Unloaded %s successfully" % name)
+        print "Unloaded %s successfully" % name
         return True
     else:
-        print("Error when unloading", name)
+        print "Error when unloading", name
         return False
-
 
 def start_controller(name):
     return start_stop_controllers([name], True)
 
-
 def start_controllers(names):
     return start_stop_controllers(names, True)
-
 
 def stop_controller(name):
     return start_stop_controllers([name], False)
 
-
 def stop_controllers(names):
     return start_stop_controllers(names, False)
-
 
 def start_stop_controllers(names, st):
     rospy.wait_for_service('controller_manager/switch_controller')
@@ -108,13 +102,13 @@ def start_stop_controllers(names, st):
     resp = s.call(SwitchControllerRequest(start, stop, strictness))
     if resp.ok == 1:
         if st:
-            print("Started {} successfully".format(names))
+            print "Started {} successfully".format(names)
         else:
-            print("Stopped {} successfully".format(names))
+            print "Stopped {} successfully".format(names)
         return True
     else:
         if st:
-            print("Error when starting ", names)
+            print "Error when starting ", names
         else:
-            print("Error when stopping ", names)
+            print "Error when stopping ", names
         return False

--- a/controller_manager/src/controller_manager/controller_manager_interface.py
+++ b/controller_manager/src/controller_manager/controller_manager_interface.py
@@ -7,7 +7,7 @@ def list_controller_types():
     s = rospy.ServiceProxy('controller_manager/list_controller_types', ListControllerTypes)
     resp = s.call(ListControllerTypesRequest())
     for t in resp.types:
-        print t
+        print(t)
 
 def reload_libraries(force_kill, restore = False):
     rospy.wait_for_service('controller_manager/reload_controller_libraries')
@@ -17,16 +17,16 @@ def reload_libraries(force_kill, restore = False):
     load_srv = rospy.ServiceProxy('controller_manager/load_controller', LoadController)
     switch_srv = rospy.ServiceProxy('controller_manager/switch_controller', SwitchController)
 
-    print "Restore:", restore
+    print("Restore:", restore)
     if restore:
         originally = list_srv.call(ListControllersRequest())
 
     resp = s.call(ReloadControllerLibrariesRequest(force_kill))
     if resp.ok:
-        print "Successfully reloaded libraries"
+        print("Successfully reloaded libraries")
         result = True
     else:
-        print "Failed to reload libraries. Do you still have controllers loaded?"
+        print("Failed to reload libraries. Do you still have controllers loaded?")
         result = False
 
     if restore:
@@ -36,7 +36,7 @@ def reload_libraries(force_kill, restore = False):
         switch_srv(start_controllers=to_start,
                    stop_controllers=[],
                    strictness=SwitchControllerRequest.BEST_EFFORT)
-        print "Controllers restored to original state"
+        print("Controllers restored to original state")
     return result
 
 
@@ -46,11 +46,11 @@ def list_controllers():
     s = rospy.ServiceProxy('controller_manager/list_controllers', ListControllers)
     resp = s.call(ListControllersRequest())
     if len(resp.controller) == 0:
-        print "No controllers are loaded in mechanism control"
+        print("No controllers are loaded in mechanism control")
     else:
         for c in resp.controller:
             hwi = list(set(r.hardware_interface for r in  c.claimed_resources))
-            print '%s - %s ( %s )'%(c.name, '+'.join(hwi), c.state)
+            print('%s - %s ( %s )'%(c.name, '+'.join(hwi), c.state))
             controller_list.append(c)
         return controller_list
 
@@ -60,10 +60,10 @@ def load_controller(name):
     s = rospy.ServiceProxy('controller_manager/load_controller', LoadController)
     resp = s.call(LoadControllerRequest(name))
     if resp.ok:
-        print "Loaded", name
+        print("Loaded", name)
         return True
     else:
-        print "Error when loading", name
+        print("Error when loading", name)
         return False
 
 def unload_controller(name):
@@ -71,10 +71,10 @@ def unload_controller(name):
     s = rospy.ServiceProxy('controller_manager/unload_controller', UnloadController)
     resp = s.call(UnloadControllerRequest(name))
     if resp.ok == 1:
-        print "Unloaded %s successfully" % name
+        print("Unloaded %s successfully" % name)
         return True
     else:
-        print "Error when unloading", name
+        print("Error when unloading", name)
         return False
 
 def start_controller(name):
@@ -102,13 +102,13 @@ def start_stop_controllers(names, st):
     resp = s.call(SwitchControllerRequest(start, stop, strictness))
     if resp.ok == 1:
         if st:
-            print "Started {} successfully".format(names)
+            print("Started {} successfully".format(names))
         else:
-            print "Stopped {} successfully".format(names)
+            print("Stopped {} successfully".format(names))
         return True
     else:
         if st:
-            print "Error when starting ", names
+            print("Error when starting ", names)
         else:
-            print "Error when stopping ", names
+            print("Error when stopping ", names)
         return False


### PR DESCRIPTION
This PR improves controller shutdown by getting the list of currently running controllers before attempting to stop and unload them.  Previously, shutdown simply stopped and unloaded the controllers that were spawned on launch. This behavior caused errors if a different controller was running at the time shutdown was requested.