### PR TITLE
catch ROSInterruptException

### DIFF
--- a/controller_manager/scripts/controller_manager
+++ b/controller_manager/scripts/controller_manager
@@ -30,40 +30,43 @@ def print_usage(exit_code = 0):
 
 
 if __name__ == '__main__':
-    args = rospy.myargv()
-    rospy.init_node('controller_manager', anonymous=True)
-    if len(args) < 2:
-        print_usage()
-    if args[1] == 'lt' or args[1] == 'list-types':
-        controller_manager_interface.list_controller_types()
-    elif args[1] == 'lc' or args[1] == 'list':
-        controller_manager_interface.list_controllers()
-    elif args[1] == 'reload-libraries':
-        if '--restore' in args[2:]:
-            controller_manager_interface.reload_libraries(True, restore = True)
+    try:
+        args = rospy.myargv()
+        rospy.init_node('controller_manager', anonymous=True)
+        if len(args) < 2:
+            print_usage()
+        if args[1] == 'lt' or args[1] == 'list-types':
+            controller_manager_interface.list_controller_types()
+        elif args[1] == 'lc' or args[1] == 'list':
+            controller_manager_interface.list_controllers()
+        elif args[1] == 'reload-libraries':
+            if '--restore' in args[2:]:
+                controller_manager_interface.reload_libraries(True, restore = True)
+            else:
+                controller_manager_interface.reload_libraries(True)
+        elif args[1] == 'load':
+            for c in args[2:]:
+                controller_manager_interface.load_controller(c)
+        elif args[1] == 'unload':
+            for c in args[2:]:
+                controller_manager_interface.unload_controller(c)
+        elif args[1] == 'start':
+            for c in args[2:]:
+                controller_manager_interface.start_controller(c)
+        elif args[1] == 'stop':
+            for c in args[2:]:
+                controller_manager_interface.stop_controller(c)
+        elif args[1] == 'sp' or args[1] == 'spawn':
+            for c in args[2:]:
+                controller_manager_interface.load_controller(c)
+            for c in args[2:]:
+                controller_manager_interface.start_controller(c)
+        elif args[1] == 'kl' or args[1] == 'kill':
+            for c in args[2:]:
+                controller_manager_interface.stop_controller(c)
+            for c in args[2:]:
+                controller_manager_interface.unload_controller(c)
         else:
-            controller_manager_interface.reload_libraries(True)
-    elif args[1] == 'load':
-        for c in args[2:]:
-            controller_manager_interface.load_controller(c)
-    elif args[1] == 'unload':
-        for c in args[2:]:
-            controller_manager_interface.unload_controller(c)
-    elif args[1] == 'start':
-        for c in args[2:]:
-            controller_manager_interface.start_controller(c)
-    elif args[1] == 'stop':
-        for c in args[2:]:
-            controller_manager_interface.stop_controller(c)
-    elif args[1] == 'sp' or args[1] == 'spawn':
-        for c in args[2:]:
-            controller_manager_interface.load_controller(c)
-        for c in args[2:]:
-            controller_manager_interface.start_controller(c)
-    elif args[1] == 'kl' or args[1] == 'kill':
-        for c in args[2:]:
-            controller_manager_interface.stop_controller(c)
-        for c in args[2:]:
-            controller_manager_interface.unload_controller(c)
-    else:
-        print_usage(1)
+            print_usage(1)
+    except rospy.exceptions.ROSInterruptException:
+        pass


### PR DESCRIPTION
`controller_manager` output is very noisy when killed.

```
Traceback (most recent call last):
  File "ros_control/controller_manager/scripts/controller_manager", line 60, in <module>
    controller_manager_interface.load_controller(c)
  File "ros_control/controller_manager/src/controller_manager/controller_manager_interface.py", line 59, in load_controller
    rospy.wait_for_service('controller_manager/load_controller')
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/impl/tcpros_service.py", line 163, in wait_for_service
    raise ROSInterruptException("rospy shutdown")
rospy.exceptions.ROSInterruptException: rospy shutdown
```

This pull request catch `ROSInterruptException` and ignore it to suppress the traceback.