### PR TITLE
remove unused pthread.h

### DIFF
--- a/controller_manager/include/controller_manager/controller_manager.h
+++ b/controller_manager/include/controller_manager/controller_manager.h
@@ -34,7 +34,6 @@
 #define CONTROLLER_MANAGER_CONTROLLER_MANAGER_H
 
 #include "controller_manager/controller_spec.h"
-#include <pthread.h>
 #include <cstdio>
 #include <map>
 #include <string>


### PR DESCRIPTION
```
#include <pthread.h>
```
would cause build break on Windows since the header is not available. since it's not used in the code, remove