### PR TITLE
use this_thread::sleep_for on Windows

### DIFF
--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -32,12 +32,15 @@
 #include <algorithm>
 #include <boost/thread/thread.hpp>
 #include <boost/thread/condition.hpp>
-#include <chrono>
-#include <thread>
 #include <sstream>
 #include <ros/console.h>
 #include <controller_manager/controller_loader.h>
 #include <controller_manager_msgs/ControllerState.h>
+
+#ifdef _WIN32
+  #include <chrono>
+  #include <thread>
+#endif
 
 namespace controller_manager{
 
@@ -149,10 +152,17 @@ bool ControllerManager::loadController(const std::string& name)
 
   // get reference to controller list
   int free_controllers_list = (current_controllers_list_ + 1) % 2;
-  while (ros::ok() && free_controllers_list == used_by_realtime_){
+  while (ros::ok() && free_controllers_list == used_by_realtime_)
+  {
     if (!ros::ok())
+    {
       return false;
+    }
+#ifdef _WIN32
     std::this_thread::sleep_for(std::chrono::microseconds(200));
+#else
+    usleep(200);
+#endif
   }
   std::vector<ControllerSpec>
     &from = controllers_lists_[current_controllers_list_],
@@ -261,10 +271,17 @@ bool ControllerManager::loadController(const std::string& name)
   // Destroys the old controllers list when the realtime thread is finished with it.
   int former_current_controllers_list_ = current_controllers_list_;
   current_controllers_list_ = free_controllers_list;
-  while (ros::ok() && used_by_realtime_ == former_current_controllers_list_){
+  while (ros::ok() && used_by_realtime_ == former_current_controllers_list_)
+  {
     if (!ros::ok())
+    {
       return false;
+    }
+#ifdef _WIN32
     std::this_thread::sleep_for(std::chrono::microseconds(200));
+#else
+    usleep(200);
+#endif
   }
   from.clear();
 
@@ -284,10 +301,17 @@ bool ControllerManager::unloadController(const std::string &name)
 
   // get reference to controller list
   int free_controllers_list = (current_controllers_list_ + 1) % 2;
-  while (ros::ok() && free_controllers_list == used_by_realtime_){
+  while (ros::ok() && free_controllers_list == used_by_realtime_)
+  {
     if (!ros::ok())
+    {
       return false;
+    }
+#ifdef _WIN32
     std::this_thread::sleep_for(std::chrono::microseconds(200));
+#else
+    usleep(200);
+#endif
   }
   std::vector<ControllerSpec>
     &from = controllers_lists_[current_controllers_list_],
@@ -324,10 +348,17 @@ bool ControllerManager::unloadController(const std::string &name)
   ROS_DEBUG("Realtime switches over to new controller list");
   int former_current_controllers_list_ = current_controllers_list_;
   current_controllers_list_ = free_controllers_list;
-  while (ros::ok() && used_by_realtime_ == former_current_controllers_list_){
+  while (ros::ok() && used_by_realtime_ == former_current_controllers_list_)
+  {
     if (!ros::ok())
+    {
       return false;
+    }
+#ifdef _WIN32
     std::this_thread::sleep_for(std::chrono::microseconds(200));
+#else
+    usleep(200);
+#endif
   }
   ROS_DEBUG("Destruct controller");
   from.clear();
@@ -505,10 +536,17 @@ bool ControllerManager::switchController(const std::vector<std::string>& start_c
 
   // wait until switch is finished
   ROS_DEBUG("Request atomic controller switch from realtime loop");
-  while (ros::ok() && please_switch_){
+  while (ros::ok() && please_switch_)
+  {
     if (!ros::ok())
+    {
       return false;
+    }
+#ifdef _WIN32
     std::this_thread::sleep_for(std::chrono::microseconds(100));
+#else
+    usleep(100);
+#endif
   }
   start_request_.clear();
   stop_request_.clear();

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -32,6 +32,8 @@
 #include <algorithm>
 #include <boost/thread/thread.hpp>
 #include <boost/thread/condition.hpp>
+#include <chrono>
+#include <thread>
 #include <sstream>
 #include <ros/console.h>
 #include <controller_manager/controller_loader.h>
@@ -150,7 +152,7 @@ bool ControllerManager::loadController(const std::string& name)
   while (ros::ok() && free_controllers_list == used_by_realtime_){
     if (!ros::ok())
       return false;
-    usleep(200);
+    std::this_thread::sleep_for(std::chrono::microseconds(200));
   }
   std::vector<ControllerSpec>
     &from = controllers_lists_[current_controllers_list_],
@@ -262,7 +264,7 @@ bool ControllerManager::loadController(const std::string& name)
   while (ros::ok() && used_by_realtime_ == former_current_controllers_list_){
     if (!ros::ok())
       return false;
-    usleep(200);
+    std::this_thread::sleep_for(std::chrono::microseconds(200));
   }
   from.clear();
 
@@ -285,7 +287,7 @@ bool ControllerManager::unloadController(const std::string &name)
   while (ros::ok() && free_controllers_list == used_by_realtime_){
     if (!ros::ok())
       return false;
-    usleep(200);
+    std::this_thread::sleep_for(std::chrono::microseconds(200));
   }
   std::vector<ControllerSpec>
     &from = controllers_lists_[current_controllers_list_],
@@ -325,7 +327,7 @@ bool ControllerManager::unloadController(const std::string &name)
   while (ros::ok() && used_by_realtime_ == former_current_controllers_list_){
     if (!ros::ok())
       return false;
-    usleep(200);
+    std::this_thread::sleep_for(std::chrono::microseconds(200));
   }
   ROS_DEBUG("Destruct controller");
   from.clear();
@@ -506,7 +508,7 @@ bool ControllerManager::switchController(const std::vector<std::string>& start_c
   while (ros::ok() && please_switch_){
     if (!ros::ok())
       return false;
-    usleep(100);
+    std::this_thread::sleep_for(std::chrono::microseconds(100));
   }
   start_request_.clear();
   stop_request_.clear();

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -36,11 +36,8 @@
 #include <ros/console.h>
 #include <controller_manager/controller_loader.h>
 #include <controller_manager_msgs/ControllerState.h>
-
-#ifdef _WIN32
-  #include <chrono>
-  #include <thread>
-#endif
+#include <chrono>
+#include <thread>
 
 namespace controller_manager{
 
@@ -158,11 +155,7 @@ bool ControllerManager::loadController(const std::string& name)
     {
       return false;
     }
-#ifdef _WIN32
     std::this_thread::sleep_for(std::chrono::microseconds(200));
-#else
-    usleep(200);
-#endif
   }
   std::vector<ControllerSpec>
     &from = controllers_lists_[current_controllers_list_],
@@ -277,11 +270,7 @@ bool ControllerManager::loadController(const std::string& name)
     {
       return false;
     }
-#ifdef _WIN32
     std::this_thread::sleep_for(std::chrono::microseconds(200));
-#else
-    usleep(200);
-#endif
   }
   from.clear();
 
@@ -307,11 +296,7 @@ bool ControllerManager::unloadController(const std::string &name)
     {
       return false;
     }
-#ifdef _WIN32
     std::this_thread::sleep_for(std::chrono::microseconds(200));
-#else
-    usleep(200);
-#endif
   }
   std::vector<ControllerSpec>
     &from = controllers_lists_[current_controllers_list_],
@@ -354,11 +339,7 @@ bool ControllerManager::unloadController(const std::string &name)
     {
       return false;
     }
-#ifdef _WIN32
     std::this_thread::sleep_for(std::chrono::microseconds(200));
-#else
-    usleep(200);
-#endif
   }
   ROS_DEBUG("Destruct controller");
   from.clear();
@@ -542,11 +523,7 @@ bool ControllerManager::switchController(const std::vector<std::string>& start_c
     {
       return false;
     }
-#ifdef _WIN32
     std::this_thread::sleep_for(std::chrono::microseconds(100));
-#else
-    usleep(100);
-#endif
   }
   start_request_.clear();
   stop_request_.clear();


### PR DESCRIPTION
very similar to https://github.com/ros-controls/realtime_tools/pull/32, `usleep` is not available on Windows. use `this_thread::sleep_for` from `c++11` instead

additionally, some refactoring changes are also introduced to improve readability