### PR TITLE
Fix exception module

### DIFF
--- a/controller_manager_msgs/src/controller_manager_msgs/utils.py
+++ b/controller_manager_msgs/src/controller_manager_msgs/utils.py
@@ -141,7 +141,7 @@ def _sloppy_get_controller_managers(namespace):
     try:
         # refresh the list of controller managers we can find
         srv_list = rosservice.get_service_list(namespace=namespace)
-    except ROSServiceIOException:
+    except rosservice.ROSServiceIOException:
         return []
 
     ns_list = []


### PR DESCRIPTION
ROSServiceIOException is under rosservice module.
http://docs.ros.org/lunar/api/rosservice/html/rosservice.ROSServiceIOException-class.html

