### PR TITLE
Update testing repository URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
     - ROSINSTALL_FILENAME=ros_control.rosinstall
     - ROS_PARALLEL_TEST_JOBS=-j1
   matrix:
-    - ROS_DISTRO=melodic ROS_REPO=ros-shadow-fixed
+    - ROS_DISTRO=melodic ROS_REPO=ros-testing
 
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config


### PR DESCRIPTION
In response to the security breach last month, all packages should move from using the `ros-shadow-fixed` repository to the new `ros-testing` repository.

See [@tfoote's post on the discourse](https://discourse.ros.org/t/new-gpg-keys-deployed-for-packages-ros-org/9454).