### PR TITLE
Revert CMake include_directories as SYSTEM

### DIFF
--- a/combined_robot_hw/CMakeLists.txt
+++ b/combined_robot_hw/CMakeLists.txt
@@ -7,8 +7,7 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
 )
 
-include_directories(include)
-include_directories(SYSTEM ${catkin_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS})
 
 catkin_package(
   INCLUDE_DIRS include
@@ -32,4 +31,3 @@ install(TARGETS ${PROJECT_NAME}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
-

--- a/combined_robot_hw_tests/CMakeLists.txt
+++ b/combined_robot_hw_tests/CMakeLists.txt
@@ -9,8 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
 )
 
-include_directories(include)
-include_directories(SYSTEM ${catkin_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS})
 
 catkin_package(
   INCLUDE_DIRS include
@@ -59,4 +58,3 @@ install(TARGETS ${PROJECT_NAME}
 
 install(FILES test_robot_hw_plugin.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
-

--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -6,8 +6,7 @@ find_package(catkin REQUIRED COMPONENTS controller_interface controller_manager_
 
 find_package(Boost REQUIRED COMPONENTS thread)
 
-include_directories(include)
-include_directories(SYSTEM ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
+include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
 
 # Declare catkin package
 catkin_package(

--- a/controller_manager_tests/CMakeLists.txt
+++ b/controller_manager_tests/CMakeLists.txt
@@ -5,8 +5,7 @@ project(controller_manager_tests)
 find_package(catkin REQUIRED COMPONENTS controller_manager controller_interface)
 catkin_python_setup()
 
-include_directories(include)
-include_directories(SYSTEM ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
+include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
 
 catkin_package(
   CATKIN_DEPENDS controller_manager controller_interface

--- a/hardware_interface/CMakeLists.txt
+++ b/hardware_interface/CMakeLists.txt
@@ -11,9 +11,8 @@ catkin_package(
 
 if(CATKIN_ENABLE_TESTING)
 
-  find_package(catkin REQUIRED COMPONENTS rosconsole) 
-  include_directories(SYSTEM ${catkin_INCLUDE_DIRS})
-  include_directories(include)
+  find_package(catkin REQUIRED COMPONENTS rosconsole)
+  include_directories(include ${catkin_INCLUDE_DIRS})
 
   catkin_add_gtest(hardware_resource_manager_test  test/hardware_resource_manager_test.cpp)
   target_link_libraries(hardware_resource_manager_test ${catkin_LIBRARIES})

--- a/joint_limits_interface/CMakeLists.txt
+++ b/joint_limits_interface/CMakeLists.txt
@@ -9,13 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
   urdf
 )
 
-include_directories(
-  include)
-include_directories(
-  SYSTEM
-  ${catkin_INCLUDE_DIRS}
-  ${urdfdom_INCLUDE_DIRS}
-)
+include_directories(include ${catkin_INCLUDE_DIRS} ${urdfdom_INCLUDE_DIRS})
 
 # Declare catkin package
 catkin_package(

--- a/transmission_interface/CMakeLists.txt
+++ b/transmission_interface/CMakeLists.txt
@@ -32,8 +32,7 @@ catkin_package(
 ###########
 
 # Build
-include_directories(include)
-include_directories(SYSTEM ${catkin_INCLUDE_DIRS} ${TinyXML_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS} ${TinyXML_INCLUDE_DIRS})
 
 # Transmission parser Library
 add_library(${PROJECT_NAME}_parser


### PR DESCRIPTION
Reverts the changes to the CMakeLists.txt `include_directories` made in #396.

See ros-controls/ros_controllers#425 for more info on the issue.

Tested with clang 6.0.0 and gcc 7.4.0