### PR TITLE
Fix compiler warnings

### DIFF
--- a/combined_robot_hw_tests/src/my_robot_hw_1.cpp
+++ b/combined_robot_hw_tests/src/my_robot_hw_1.cpp
@@ -36,7 +36,7 @@ MyRobotHW1::MyRobotHW1()
 {
 }
 
-bool MyRobotHW1::init(ros::NodeHandle& root_nh, ros::NodeHandle &robot_hw_nh)
+bool MyRobotHW1::init(ros::NodeHandle& /*root_nh*/, ros::NodeHandle &/*robot_hw_nh*/)
 {
   using namespace hardware_interface;
 
@@ -90,19 +90,19 @@ bool MyRobotHW1::init(ros::NodeHandle& root_nh, ros::NodeHandle &robot_hw_nh)
 }
 
 
-void MyRobotHW1::read(const ros::Time& time, const ros::Duration& period)
+void MyRobotHW1::read(const ros::Time& /*time*/, const ros::Duration& /*period*/)
 {
   joint_position_[0] = 2.7;
 }
 
-void MyRobotHW1::write(const ros::Time& time, const ros::Duration& period)
+void MyRobotHW1::write(const ros::Time& /*time*/, const ros::Duration& /*period*/)
 {
   // Just to test that write() is called
   joint_effort_command_[1] = joint_effort_command_[0];
 }
 
 bool MyRobotHW1::prepareSwitch(const std::list<hardware_interface::ControllerInfo>& start_list,
-                               const std::list<hardware_interface::ControllerInfo>& stop_list)
+                               const std::list<hardware_interface::ControllerInfo>& /*stop_list*/)
 {
   for (std::list<hardware_interface::ControllerInfo>::const_iterator it = start_list.begin(); it != start_list.end(); ++it)
   {
@@ -139,7 +139,7 @@ bool MyRobotHW1::prepareSwitch(const std::list<hardware_interface::ControllerInf
 }
 
 void MyRobotHW1::doSwitch(const std::list<hardware_interface::ControllerInfo>& start_list,
-                          const std::list<hardware_interface::ControllerInfo>& stop_list)
+                          const std::list<hardware_interface::ControllerInfo>& /*stop_list*/)
 {
   for (std::list<hardware_interface::ControllerInfo>::const_iterator it = start_list.begin(); it != start_list.end(); ++it)
   {

--- a/combined_robot_hw_tests/src/my_robot_hw_2.cpp
+++ b/combined_robot_hw_tests/src/my_robot_hw_2.cpp
@@ -36,7 +36,7 @@ MyRobotHW2::MyRobotHW2()
 {
 }
 
-bool MyRobotHW2::init(ros::NodeHandle& root_nh, ros::NodeHandle &robot_hw_nh)
+bool MyRobotHW2::init(ros::NodeHandle& /*root_nh*/, ros::NodeHandle &robot_hw_nh)
 {
   using namespace hardware_interface;
 
@@ -74,17 +74,17 @@ bool MyRobotHW2::init(ros::NodeHandle& root_nh, ros::NodeHandle &robot_hw_nh)
 }
 
 
-void MyRobotHW2::read(const ros::Time& time, const ros::Duration& period)
+void MyRobotHW2::read(const ros::Time& /*time*/, const ros::Duration& /*period*/)
 {
 
 }
 
-void MyRobotHW2::write(const ros::Time& time, const ros::Duration& period)
+void MyRobotHW2::write(const ros::Time& /*time*/, const ros::Duration& /*period*/)
 {
 }
 
 bool MyRobotHW2::prepareSwitch(const std::list<hardware_interface::ControllerInfo>& start_list,
-                               const std::list<hardware_interface::ControllerInfo>& stop_list)
+                               const std::list<hardware_interface::ControllerInfo>& /*stop_list*/)
 {
   for (std::list<hardware_interface::ControllerInfo>::const_iterator it = start_list.begin(); it != start_list.end(); ++it)
   {
@@ -119,7 +119,7 @@ bool MyRobotHW2::prepareSwitch(const std::list<hardware_interface::ControllerInf
 }
 
 void MyRobotHW2::doSwitch(const std::list<hardware_interface::ControllerInfo>& start_list,
-                          const std::list<hardware_interface::ControllerInfo>& stop_list)
+                          const std::list<hardware_interface::ControllerInfo>& /*stop_list*/)
 {
   for (std::list<hardware_interface::ControllerInfo>::const_iterator it = start_list.begin(); it != start_list.end(); ++it)
   {

--- a/combined_robot_hw_tests/src/my_robot_hw_3.cpp
+++ b/combined_robot_hw_tests/src/my_robot_hw_3.cpp
@@ -35,7 +35,7 @@ MyRobotHW3::MyRobotHW3()
 {
 }
 
-bool MyRobotHW3::init(ros::NodeHandle& root_nh, ros::NodeHandle &robot_hw_nh)
+bool MyRobotHW3::init(ros::NodeHandle& /*root_nh*/, ros::NodeHandle &robot_hw_nh)
 {
   using namespace hardware_interface;
 
@@ -79,12 +79,12 @@ bool MyRobotHW3::init(ros::NodeHandle& root_nh, ros::NodeHandle &robot_hw_nh)
 }
 
 
-void MyRobotHW3::read(const ros::Time& time, const ros::Duration& period)
+void MyRobotHW3::read(const ros::Time& /*time*/, const ros::Duration& /*period*/)
 {
 
 }
 
-void MyRobotHW3::write(const ros::Time& time, const ros::Duration& period)
+void MyRobotHW3::write(const ros::Time& /*time*/, const ros::Duration& /*period*/)
 {
 }
 

--- a/combined_robot_hw_tests/src/my_robot_hw_4.cpp
+++ b/combined_robot_hw_tests/src/my_robot_hw_4.cpp
@@ -35,7 +35,7 @@ MyRobotHW4::MyRobotHW4()
 {
 }
 
-bool MyRobotHW4::init(ros::NodeHandle& root_nh, ros::NodeHandle &robot_hw_nh)
+bool MyRobotHW4::init(ros::NodeHandle& /*root_nh*/, ros::NodeHandle &/*robot_hw_nh*/)
 {
   using namespace hardware_interface;
 
@@ -57,12 +57,12 @@ bool MyRobotHW4::init(ros::NodeHandle& root_nh, ros::NodeHandle &robot_hw_nh)
 }
 
 
-void MyRobotHW4::read(const ros::Time& time, const ros::Duration& period)
+void MyRobotHW4::read(const ros::Time& /*time*/, const ros::Duration& /*period*/)
 {
   force_[2] = 1.2;
 }
 
-void MyRobotHW4::write(const ros::Time& time, const ros::Duration& period)
+void MyRobotHW4::write(const ros::Time& /*time*/, const ros::Duration& /*period*/)
 {
 }
 

--- a/controller_manager_tests/src/extensible_controllers.cpp
+++ b/controller_manager_tests/src/extensible_controllers.cpp
@@ -31,7 +31,7 @@
 using namespace controller_manager_tests;
 
 bool ExtensibleController::init(hardware_interface::RobotHW* robot_hw,
-          ros::NodeHandle& root_nh, ros::NodeHandle& controller_nh)
+          ros::NodeHandle& /*root_nh*/, ros::NodeHandle& controller_nh)
 {
   std::string vel_joint_name;
   controller_nh.getParam("velocity_joint", vel_joint_name);

--- a/controller_manager_tests/test/cm_test.cpp
+++ b/controller_manager_tests/test/cm_test.cpp
@@ -408,8 +408,8 @@ TEST(CMTests, listControllerTypes)
   bool call_success = types_client.call(srv);
   ASSERT_TRUE(call_success);
   // Weak test that the number of available types and base classes is not lower than those defined in this test package
-  EXPECT_GE(srv.response.types.size(), 3);
-  EXPECT_GE(srv.response.base_classes.size(), 3);
+  EXPECT_GE(srv.response.types.size(), 3u);
+  EXPECT_GE(srv.response.base_classes.size(), 3u);
 }
 
 TEST(CMTests, listControllers)
@@ -442,7 +442,7 @@ TEST(CMTests, listControllers)
     ListControllers srv;
     bool call_success = list_client.call(srv);
     ASSERT_TRUE(call_success);
-    ASSERT_EQ(srv.response.controller.size(), 2);
+    ASSERT_EQ(srv.response.controller.size(), 2u);
 
     ControllerState state1, state2;
     if (srv.response.controller[0].name == "my_controller")
@@ -459,22 +459,22 @@ TEST(CMTests, listControllers)
     EXPECT_EQ(state1.name, "my_controller");
     EXPECT_EQ(state1.state, "running");
     EXPECT_EQ(state1.type, "controller_manager_tests/EffortTestController");
-    ASSERT_EQ(state1.claimed_resources.size(), 1);
+    ASSERT_EQ(state1.claimed_resources.size(), 1u);
     EXPECT_EQ(state1.claimed_resources[0].hardware_interface, "hardware_interface::EffortJointInterface");
-    ASSERT_EQ(state1.claimed_resources[0].resources.size(), 2);
+    ASSERT_EQ(state1.claimed_resources[0].resources.size(), 2u);
     EXPECT_EQ(state1.claimed_resources[0].resources[0], "hiDOF_joint1");
     EXPECT_EQ(state1.claimed_resources[0].resources[1], "hiDOF_joint2");
 
     EXPECT_EQ(state2.name, "vel_eff_controller");
     EXPECT_EQ(state2.state, "initialized");
     EXPECT_EQ(state2.type, "controller_manager_tests/VelEffController");
-    EXPECT_EQ(state2.claimed_resources.size(), 2);
+    EXPECT_EQ(state2.claimed_resources.size(), 2u);
     EXPECT_EQ(state2.claimed_resources[0].hardware_interface, "hardware_interface::VelocityJointInterface");
-    ASSERT_EQ(state2.claimed_resources[0].resources.size(), 2);
+    ASSERT_EQ(state2.claimed_resources[0].resources.size(), 2u);
     EXPECT_EQ(state2.claimed_resources[0].resources[0], "hiDOF_joint1");
     EXPECT_EQ(state2.claimed_resources[0].resources[1], "hiDOF_joint2");
     EXPECT_EQ(state2.claimed_resources[1].hardware_interface, "hardware_interface::EffortJointInterface");
-    ASSERT_EQ(state2.claimed_resources[1].resources.size(), 1);
+    ASSERT_EQ(state2.claimed_resources[1].resources.size(), 1u);
     EXPECT_EQ(state2.claimed_resources[1].resources[0], "hiDOF_joint3");
   }
 
@@ -526,12 +526,12 @@ TEST(CMTests, extensibleControllers)
   {
     ListControllers srv;
     ASSERT_TRUE(list_client.call(srv));
-    ASSERT_EQ(2, srv.response.controller.size());
+    ASSERT_EQ(2u, srv.response.controller.size());
     ControllerState state = srv.response.controller[0].name == "extensible_controller" ?
         srv.response.controller[0] : srv.response.controller[1];
     EXPECT_EQ("extensible_controller", state.name);
     EXPECT_EQ("running", state.state);
-    ASSERT_EQ(1, state.claimed_resources.size());
+    ASSERT_EQ(1u, state.claimed_resources.size());
   }
 
   // Start the derived controller instead.
@@ -548,12 +548,12 @@ TEST(CMTests, extensibleControllers)
   {
     ListControllers srv;
     ASSERT_TRUE(list_client.call(srv));
-    ASSERT_EQ(2, srv.response.controller.size());
+    ASSERT_EQ(2u, srv.response.controller.size());
     ControllerState state = srv.response.controller[
       srv.response.controller[0].name == "derived_controller" ? 0 : 1];
     EXPECT_EQ("derived_controller", state.name);
     EXPECT_EQ("running", state.state);
-    ASSERT_EQ(2, state.claimed_resources.size());
+    ASSERT_EQ(2u, state.claimed_resources.size());
   }
 
   // Stop controller.

--- a/hardware_interface/include/hardware_interface/internal/interface_manager.h
+++ b/hardware_interface/include/hardware_interface/internal/interface_manager.h
@@ -63,10 +63,10 @@ struct CheckIsResourceManager {
 
   // method called if C is not a ResourceManager
   template <typename C>
-  static void callCM(typename std::vector<C*>& managers, C* result, ...) {}
+  static void callCM(typename std::vector<C*>& /*managers*/, C* /*result*/, ...) {}
 
   // calls ResourceManager::concatManagers if C is a ResourceManager
-  static const void callConcatManagers(typename std::vector<T*>& managers, T* result)
+  static void callConcatManagers(typename std::vector<T*>& managers, T* result)
   { callCM<T>(managers, result, 0); }
 
 
@@ -79,7 +79,7 @@ struct CheckIsResourceManager {
 
   // method called if C is not a ResourceManager
   template <typename C>
-  static void callGR(std::vector<std::string> &resources, T* iface, ...) { }
+  static void callGR(std::vector<std::string> &/*resources*/, T* /*iface*/, ...) { }
 
   // calls ResourceManager::concatManagers if C is a ResourceManager
   static void callGetResources(std::vector<std::string> &resources, T* iface)
@@ -96,7 +96,7 @@ struct CheckIsResourceManager {
 
   // method called if C is not a ResourceManager
   template <typename C>
-  static T* newCI(boost::ptr_vector<ResourceManagerBase> &guards, ...) {
+  static T* newCI(boost::ptr_vector<ResourceManagerBase> &/*guards*/, ...) {
     // it is not a ResourceManager
     ROS_ERROR("You cannot register multiple interfaces of the same type which are "
               "not of type ResourceManager. There is no established protocol "

--- a/hardware_interface/include/hardware_interface/robot_hw.h
+++ b/hardware_interface/include/hardware_interface/robot_hw.h
@@ -78,7 +78,7 @@ public:
    *
    * \returns True if initialization was successful
    */
-  virtual bool init(ros::NodeHandle& root_nh, ros::NodeHandle &robot_hw_nh) {return true;}
+  virtual bool init(ros::NodeHandle& /*root_nh*/, ros::NodeHandle &/*robot_hw_nh*/) {return true;}
 
   /** \name Resource Management
    *\{*/
@@ -138,8 +138,8 @@ public:
    * with regard to necessary hardware interface switches and prepare the switching. Start and stop list are disjoint.
    * This handles the check and preparation, the actual switch is commited in doSwitch()
    */
-  virtual bool prepareSwitch(const std::list<ControllerInfo>& start_list,
-                             const std::list<ControllerInfo>& stop_list) { return true; }
+  virtual bool prepareSwitch(const std::list<ControllerInfo>& /*start_list*/,
+                             const std::list<ControllerInfo>& /*stop_list*/) { return true; }
 
   /**
    * Perform (in realtime) all necessary hardware interface switches in order to start and stop the given controllers.
@@ -173,7 +173,7 @@ public:
    * \param time The current time
    * \param period The time passed since the last call to \ref read
    */
-  virtual void read(const ros::Time& time, const ros::Duration& period) {}
+  virtual void read(const ros::Time& /*time*/, const ros::Duration& /*period*/) {}
 
   /**
    * Writes data to the robot HW
@@ -181,7 +181,7 @@ public:
    * \param time The current time
    * \param period The time passed since the last call to \ref write
    */
-  virtual void write(const ros::Time& time, const ros::Duration& period) {}
+  virtual void write(const ros::Time& /*time*/, const ros::Duration& /*period*/) {}
 };
 
 typedef std::shared_ptr<RobotHW> RobotHWSharedPtr;

--- a/transmission_interface/src/bidirectional_effort_joint_interface_provider.cpp
+++ b/transmission_interface/src/bidirectional_effort_joint_interface_provider.cpp
@@ -77,4 +77,4 @@ bool BiDirectionalEffortJointInterfaceProvider::registerTransmission(Transmissio
 } // namespace
 
 PLUGINLIB_EXPORT_CLASS(transmission_interface::BiDirectionalEffortJointInterfaceProvider, 
-                       transmission_interface::RequisiteProvider);
+                       transmission_interface::RequisiteProvider)

--- a/transmission_interface/src/bidirectional_position_joint_interface_provider.cpp
+++ b/transmission_interface/src/bidirectional_position_joint_interface_provider.cpp
@@ -77,4 +77,4 @@ bool BiDirectionalPositionJointInterfaceProvider::registerTransmission(Transmiss
 }
 
 PLUGINLIB_EXPORT_CLASS(transmission_interface::BiDirectionalPositionJointInterfaceProvider, 
-                       transmission_interface::RequisiteProvider);
+                       transmission_interface::RequisiteProvider)


### PR DESCRIPTION
- Comment out unused parameters
- Make some integer literals unsigned to avoid comparison between signed and unsigned
- Remove unnecessary semicolons
- Make const void return type to void