### PR TITLE
Remove legacy gitignore workaround

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,3 @@ controller_manager_msgs/src/controller_manager_msgs/srv/*
 qtcreator-build-*
 CMakeLists.txt.user
 gh-pages
-
-# We had to disable manifest.xml in joint_limits_interface because of a package naming conflict
-# See issue https://github.com/ros-controls/ros_control/issues/101#issuecomment-21781620
-joint_limits_interface/manifest.xml


### PR DESCRIPTION
Removes a workaround left from the rosbuild days and irrelevant in today's Catkin ecosystem.

See issue #101 and PR #108.