### PR TITLE
Update CMakeLists.txt and package.xml

### DIFF
--- a/combined_robot_hw/CMakeLists.txt
+++ b/combined_robot_hw/CMakeLists.txt
@@ -1,33 +1,50 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(combined_robot_hw)
 
+# Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS
   hardware_interface
   pluginlib
   roscpp
 )
 
+# Declare a catkin package
+catkin_package(
+  INCLUDE_DIRS
+    include
+  LIBRARIES
+    ${PROJECT_NAME}
+  CATKIN_DEPENDS
+    hardware_interface
+    pluginlib
+    roscpp
+)
+
+
+###########
+## Build ##
+###########
+
+# Specify header include paths
 include_directories(include ${catkin_INCLUDE_DIRS})
 
-catkin_package(
-  INCLUDE_DIRS include
-  LIBRARIES ${PROJECT_NAME}
-  CATKIN_DEPENDS hardware_interface pluginlib roscpp
-)
-
-add_library(${PROJECT_NAME}
-  src/combined_robot_hw.cpp
-)
+add_library(${PROJECT_NAME} src/combined_robot_hw.cpp)
 add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 
-# Install
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
+#############
+## Install ##
+#############
 
-# Install library
+# Install headers
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)
+
+# Install targets
 install(TARGETS ${PROJECT_NAME}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
+  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+)

--- a/combined_robot_hw/CMakeLists.txt
+++ b/combined_robot_hw/CMakeLists.txt
@@ -30,7 +30,7 @@ include_directories(include ${catkin_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME} src/combined_robot_hw.cpp)
 add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
 
 #############

--- a/combined_robot_hw/package.xml
+++ b/combined_robot_hw/package.xml
@@ -18,7 +18,11 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <depend>hardware_interface</depend>
-  <depend>pluginlib</depend>
   <depend>roscpp</depend>
+
+  <build_depend>hardware_interface</build_depend>
+  <build_depend>pluginlib</build_depend>
+
+  <build_export_depend>hardware_interface</build_export_depend>
+  <build_export_depend>pluginlib</build_export_depend>
 </package>

--- a/combined_robot_hw/package.xml
+++ b/combined_robot_hw/package.xml
@@ -1,8 +1,8 @@
-<?xml version="1.0"?>
 <package format="2">
   <name>combined_robot_hw</name>
   <version>0.15.1</version>
   <description>Combined Robot HW class.</description>
+
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
   <maintainer email="toni@shadowrobot.com">Toni Oliver</maintainer>
   <maintainer email="enrique.fernandez.perdomo@gmail.com">Enrique Fernandez</maintainer>
@@ -17,6 +17,7 @@
   <author email="toni@shadowrobot.com">Toni Oliver</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+
   <depend>hardware_interface</depend>
   <depend>pluginlib</depend>
   <depend>roscpp</depend>

--- a/combined_robot_hw_tests/CMakeLists.txt
+++ b/combined_robot_hw_tests/CMakeLists.txt
@@ -32,7 +32,6 @@ if(CATKIN_ENABLE_TESTING)
     src/my_robot_hw_3.cpp
     src/my_robot_hw_4.cpp
   )
-  add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
   target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
   add_executable(combined_robot_hw_dummy_app EXCLUDE_FROM_ALL src/dummy_app.cpp)
@@ -48,7 +47,7 @@ if(CATKIN_ENABLE_TESTING)
     test/cm_test.test
     test/cm_test.cpp
   )
-  add_dependencies(combined_robot_hw_cm_test combined_robot_hw_dummy_app)
+  add_dependencies(combined_robot_hw_cm_test combined_robot_hw_dummy_app ${catkin_EXPORTED_TARGETS})
   target_link_libraries(combined_robot_hw_cm_test ${PROJECT_NAME} ${catkin_LIBRARIES})
 endif()
 

--- a/combined_robot_hw_tests/CMakeLists.txt
+++ b/combined_robot_hw_tests/CMakeLists.txt
@@ -11,37 +11,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 # Declare a catkin package
-catkin_package(
-  INCLUDE_DIRS
-    include
-  LIBRARIES
-    ${PROJECT_NAME}
-  CATKIN_DEPENDS
-    combined_robot_hw
-    hardware_interface
-    roscpp
-    # Note: controller_manager and controller_manager_tests are only used in tests
-)
-
-
-###########
-## Build ##
-###########
-
-# Specify header include paths
-include_directories(include ${catkin_INCLUDE_DIRS})
-
-add_library(${PROJECT_NAME}
-  src/my_robot_hw_1.cpp
-  src/my_robot_hw_2.cpp
-  src/my_robot_hw_3.cpp
-  src/my_robot_hw_4.cpp
-)
-add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
-
-add_executable(combined_robot_hw_dummy_app src/dummy_app.cpp)
-target_link_libraries(combined_robot_hw_dummy_app ${PROJECT_NAME} ${catkin_LIBRARIES})
+catkin_package()
 
 
 #############
@@ -50,6 +20,21 @@ target_link_libraries(combined_robot_hw_dummy_app ${PROJECT_NAME} ${catkin_LIBRA
 
 if(CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
+
+  # Specify header include paths
+  include_directories(include ${catkin_INCLUDE_DIRS})
+
+  add_library(${PROJECT_NAME} EXCLUDE_FROM_ALL
+    src/my_robot_hw_1.cpp
+    src/my_robot_hw_2.cpp
+    src/my_robot_hw_3.cpp
+    src/my_robot_hw_4.cpp
+  )
+  add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
+  target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
+
+  add_executable(combined_robot_hw_dummy_app EXCLUDE_FROM_ALL src/dummy_app.cpp)
+  target_link_libraries(combined_robot_hw_dummy_app ${PROJECT_NAME} ${catkin_LIBRARIES})
 
   add_rostest_gtest(combined_robot_hw_test
     test/combined_robot_hw_test.test
@@ -63,25 +48,3 @@ if(CATKIN_ENABLE_TESTING)
   )
   target_link_libraries(combined_robot_hw_cm_test ${PROJECT_NAME} ${catkin_LIBRARIES})
 endif()
-
-
-#############
-## Install ##
-#############
-
-# Install headers
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-)
-
-# Install targets
-install(TARGETS ${PROJECT_NAME} combined_robot_hw_dummy_app
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
-)
-
-# Install plugins
-install(FILES test_robot_hw_plugin.xml
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-)

--- a/combined_robot_hw_tests/CMakeLists.txt
+++ b/combined_robot_hw_tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(combined_robot_hw_tests)
 
+# Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS
   combined_robot_hw
   controller_manager
@@ -9,13 +10,26 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
 )
 
-include_directories(include ${catkin_INCLUDE_DIRS})
-
+# Declare a catkin package
 catkin_package(
-  INCLUDE_DIRS include
-  LIBRARIES ${PROJECT_NAME}
-  CATKIN_DEPENDS combined_robot_hw hardware_interface roscpp
+  INCLUDE_DIRS
+    include
+  LIBRARIES
+    ${PROJECT_NAME}
+  CATKIN_DEPENDS
+    combined_robot_hw
+    hardware_interface
+    roscpp
+    # Note: controller_manager and controller_manager_tests are only used in tests
 )
+
+
+###########
+## Build ##
+###########
+
+# Specify header include paths
+include_directories(include ${catkin_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME}
   src/my_robot_hw_1.cpp
@@ -29,9 +43,14 @@ target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 add_executable(combined_robot_hw_dummy_app src/dummy_app.cpp)
 target_link_libraries(combined_robot_hw_dummy_app ${PROJECT_NAME} ${catkin_LIBRARIES})
 
-if(CATKIN_ENABLE_TESTING)
 
+#############
+## Testing ##
+#############
+
+if(CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
+
   add_rostest_gtest(combined_robot_hw_test
     test/combined_robot_hw_test.test
     test/combined_robot_hw_test.cpp
@@ -43,18 +62,26 @@ if(CATKIN_ENABLE_TESTING)
     test/cm_test.cpp
   )
   target_link_libraries(combined_robot_hw_cm_test ${PROJECT_NAME} ${catkin_LIBRARIES})
-
 endif()
 
-# Install
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
 
-# Install library
-install(TARGETS ${PROJECT_NAME}
+#############
+## Install ##
+#############
+
+# Install headers
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)
+
+# Install targets
+install(TARGETS ${PROJECT_NAME} combined_robot_hw_dummy_app
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
+  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+)
 
+# Install plugins
 install(FILES test_robot_hw_plugin.xml
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/combined_robot_hw_tests/CMakeLists.txt
+++ b/combined_robot_hw_tests/CMakeLists.txt
@@ -38,7 +38,7 @@ add_library(${PROJECT_NAME}
   src/my_robot_hw_4.cpp
 )
 add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
 add_executable(combined_robot_hw_dummy_app src/dummy_app.cpp)
 target_link_libraries(combined_robot_hw_dummy_app ${PROJECT_NAME} ${catkin_LIBRARIES})

--- a/combined_robot_hw_tests/CMakeLists.txt
+++ b/combined_robot_hw_tests/CMakeLists.txt
@@ -49,3 +49,13 @@ if(CATKIN_ENABLE_TESTING)
   add_dependencies(combined_robot_hw_cm_test combined_robot_hw_dummy_app)
   target_link_libraries(combined_robot_hw_cm_test ${PROJECT_NAME} ${catkin_LIBRARIES})
 endif()
+
+
+#############
+## Install ##
+#############
+
+# Install plugins
+install(FILES test_robot_hw_plugin.xml
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/combined_robot_hw_tests/CMakeLists.txt
+++ b/combined_robot_hw_tests/CMakeLists.txt
@@ -5,8 +5,10 @@ project(combined_robot_hw_tests)
 find_package(catkin REQUIRED COMPONENTS
   combined_robot_hw
   controller_manager
+  controller_manager_msgs
   controller_manager_tests
   hardware_interface
+  pluginlib
   roscpp
 )
 

--- a/combined_robot_hw_tests/CMakeLists.txt
+++ b/combined_robot_hw_tests/CMakeLists.txt
@@ -26,7 +26,7 @@ if(CATKIN_ENABLE_TESTING)
   # Specify header include paths
   include_directories(include ${catkin_INCLUDE_DIRS})
 
-  add_library(${PROJECT_NAME} EXCLUDE_FROM_ALL
+  add_library(${PROJECT_NAME}
     src/my_robot_hw_1.cpp
     src/my_robot_hw_2.cpp
     src/my_robot_hw_3.cpp
@@ -57,7 +57,20 @@ endif()
 ## Install ##
 #############
 
-# Install plugins
-install(FILES test_robot_hw_plugin.xml
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-)
+# NOTE: Libraries and plugins required for tests are installed since CI
+# runs tests out of the install space rather than the devel space
+
+if(CATKIN_ENABLE_TESTING)
+
+  # Install targets
+  install(TARGETS ${PROJECT_NAME}
+    ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+  )
+
+  # Install plugins
+  install(FILES test_robot_hw_plugin.xml
+    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+  )
+endif()

--- a/combined_robot_hw_tests/CMakeLists.txt
+++ b/combined_robot_hw_tests/CMakeLists.txt
@@ -46,5 +46,6 @@ if(CATKIN_ENABLE_TESTING)
     test/cm_test.test
     test/cm_test.cpp
   )
+  add_dependencies(combined_robot_hw_cm_test combined_robot_hw_dummy_app)
   target_link_libraries(combined_robot_hw_cm_test ${PROJECT_NAME} ${catkin_LIBRARIES})
 endif()

--- a/combined_robot_hw_tests/package.xml
+++ b/combined_robot_hw_tests/package.xml
@@ -1,7 +1,7 @@
 <package format="2">
   <name>combined_robot_hw_tests</name>
   <version>0.15.1</version>
-  <description>The combined_robot_hw_tests package</description>
+  <description>Tests for the combined Robot HW class.</description>
 
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
   <maintainer email="toni@shadowrobot.com">Toni Oliver</maintainer>

--- a/combined_robot_hw_tests/package.xml
+++ b/combined_robot_hw_tests/package.xml
@@ -18,12 +18,14 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <depend>hardware_interface</depend>
-  <depend>pluginlib</depend>
+  <depend>combined_robot_hw</depend>
+  <depend>controller_manager</depend>
+  <depend>hardware_interface</depend> <!-- exec_depend required for plugin -->
+  <depend>roscpp</depend>
 
-  <build_depend>combined_robot_hw</build_depend>
-  <build_depend>controller_manager</build_depend>
-  <build_depend>roscpp</build_depend>
+  <build_depend>pluginlib</build_depend>
+
+  <build_export_depend>pluginlib</build_export_depend>
 
   <test_depend>controller_manager_msgs</test_depend>
   <test_depend>controller_manager_tests</test_depend>

--- a/combined_robot_hw_tests/package.xml
+++ b/combined_robot_hw_tests/package.xml
@@ -18,12 +18,15 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <depend>combined_robot_hw</depend>
-  <depend>controller_manager</depend>
-  <depend>controller_manager_tests</depend>
   <depend>hardware_interface</depend>
-  <depend>roscpp</depend>
+  <depend>pluginlib</depend>
 
+  <build_depend>combined_robot_hw</build_depend>
+  <build_depend>controller_manager</build_depend>
+  <build_depend>roscpp</build_depend>
+
+  <test_depend>controller_manager_msgs</test_depend>
+  <test_depend>controller_manager_tests</test_depend>
   <test_depend>rostest</test_depend>
 
   <export>

--- a/combined_robot_hw_tests/package.xml
+++ b/combined_robot_hw_tests/package.xml
@@ -1,8 +1,8 @@
-<?xml version="1.0"?>
 <package format="2">
   <name>combined_robot_hw_tests</name>
   <version>0.15.1</version>
   <description>The combined_robot_hw_tests package</description>
+
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
   <maintainer email="toni@shadowrobot.com">Toni Oliver</maintainer>
   <maintainer email="enrique.fernandez.perdomo@gmail.com">Enrique Fernandez</maintainer>
@@ -17,6 +17,7 @@
   <author email="toni@shadowrobot.com">Toni Oliver</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+
   <depend>combined_robot_hw</depend>
   <depend>controller_manager</depend>
   <depend>controller_manager_tests</depend>

--- a/controller_interface/CMakeLists.txt
+++ b/controller_interface/CMakeLists.txt
@@ -4,7 +4,6 @@ project(controller_interface)
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS
   hardware_interface
-  pluginlib
   roscpp
 )
 
@@ -14,7 +13,6 @@ catkin_package(
     include
   CATKIN_DEPENDS
     hardware_interface
-    pluginlib
     roscpp
 )
 

--- a/controller_interface/CMakeLists.txt
+++ b/controller_interface/CMakeLists.txt
@@ -32,8 +32,6 @@ include_directories(include ${catkin_INCLUDE_DIRS})
 #############
 
 if(CATKIN_ENABLE_TESTING)
-  find_package(rosunit REQUIRED)
-
   catkin_add_gmock(controller_base_test test/controller_base_test.cpp)
   target_link_libraries(controller_base_test ${catkin_LIBRARIES})
 endif()

--- a/controller_interface/CMakeLists.txt
+++ b/controller_interface/CMakeLists.txt
@@ -2,32 +2,48 @@ cmake_minimum_required(VERSION 2.8.3)
 project(controller_interface)
 
 # Load catkin and all dependencies required for this package
-find_package(catkin REQUIRED COMPONENTS roscpp hardware_interface pluginlib)
+find_package(catkin REQUIRED COMPONENTS
+  hardware_interface
+  pluginlib
+  roscpp
+)
 
-# Declare catkin package
+# Declare a catkin package
 catkin_package(
-  CATKIN_DEPENDS roscpp hardware_interface pluginlib
-  INCLUDE_DIRS include
-  )
+  INCLUDE_DIRS
+    include
+  CATKIN_DEPENDS
+    hardware_interface
+    pluginlib
+    roscpp
+)
+
+
+###########
+## Build ##
+###########
+
+# Specify header include paths
+include_directories(include ${catkin_INCLUDE_DIRS})
+
+
+#############
+## Testing ##
+#############
 
 if(CATKIN_ENABLE_TESTING)
-
   find_package(rosunit REQUIRED)
 
-  catkin_add_gmock(controller_base_test
-    test/controller_base_test.cpp
-  )
-
-  target_include_directories(controller_base_test PRIVATE include)
-  target_include_directories(controller_base_test SYSTEM PRIVATE ${catkin_INCLUDE_DIRS})
-
-  target_link_libraries(controller_base_test
-    ${catkin_LIBRARIES}
-  )
-
+  catkin_add_gmock(controller_base_test test/controller_base_test.cpp)
+  target_link_libraries(controller_base_test ${catkin_LIBRARIES})
 endif()
 
-# Install
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
 
+#############
+## Install ##
+#############
+
+# Install headers
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)

--- a/controller_interface/package.xml
+++ b/controller_interface/package.xml
@@ -17,6 +17,9 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <depend>hardware_interface</depend>
   <depend>roscpp</depend>
+
+  <build_depend>hardware_interface</build_depend>
+
+  <build_export_depend>hardware_interface</build_export_depend>
 </package>

--- a/controller_interface/package.xml
+++ b/controller_interface/package.xml
@@ -2,6 +2,7 @@
   <name>controller_interface</name>
   <version>0.15.1</version>
   <description>Interface base class for controllers</description>
+
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
   <maintainer email="enrique.fernandez.perdomo@gmail.com">Enrique Fernandez</maintainer>
   <maintainer email="mathias.luedtke@ipa.fraunhofer.de">Mathias Lüdtke</maintainer>

--- a/controller_interface/package.xml
+++ b/controller_interface/package.xml
@@ -18,6 +18,5 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <depend>hardware_interface</depend>
-  <depend>pluginlib</depend>
   <depend>roscpp</depend>
 </package>

--- a/controller_interface/package.xml
+++ b/controller_interface/package.xml
@@ -1,7 +1,7 @@
 <package format="2">
   <name>controller_interface</name>
   <version>0.15.1</version>
-  <description>Interface base class for controllers</description>
+  <description>Interface base class for controllers.</description>
 
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
   <maintainer email="enrique.fernandez.perdomo@gmail.com">Enrique Fernandez</maintainer>

--- a/controller_interface/package.xml
+++ b/controller_interface/package.xml
@@ -20,6 +20,4 @@
   <depend>hardware_interface</depend>
   <depend>pluginlib</depend>
   <depend>roscpp</depend>
-
-  <test_depend>rosunit</test_depend>
 </package>

--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -2,65 +2,92 @@ cmake_minimum_required(VERSION 2.8.3)
 project(controller_manager)
 
 # Load catkin and all dependencies required for this package
-find_package(catkin REQUIRED COMPONENTS controller_interface controller_manager_msgs hardware_interface pluginlib)
+find_package(catkin REQUIRED COMPONENTS
+  controller_interface
+  controller_manager_msgs
+  hardware_interface
+  pluginlib
+)
 
+# Include Boost.Thread
 find_package(Boost REQUIRED COMPONENTS thread)
 
-include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
+catkin_python_setup()
 
-# Declare catkin package
+# Declare a catkin package
 catkin_package(
-  DEPENDS Boost
-  CATKIN_DEPENDS controller_interface controller_manager_msgs hardware_interface pluginlib
-  INCLUDE_DIRS include
-  LIBRARIES ${PROJECT_NAME}
+  INCLUDE_DIRS
+    include
+  LIBRARIES
+    ${PROJECT_NAME}
+  CATKIN_DEPENDS
+    controller_interface
+    controller_manager_msgs
+    hardware_interface
+    pluginlib
+  DEPENDS
+    Boost
 )
+
+
+###########
+## Build ##
+###########
+
+# Specify header include paths
+include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIR})
 
 add_library(${PROJECT_NAME}
-  src/controller_manager.cpp
-  include/controller_manager/controller_manager.h
-  include/controller_manager/controller_loader_interface.h
   include/controller_manager/controller_loader.h
+  include/controller_manager/controller_loader_interface.h
+  include/controller_manager/controller_manager.h
+  src/controller_manager.cpp
 )
+add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
-if(catkin_EXPORTED_TARGETS)
-  add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
-endif()
+
+#############
+## Testing ##
+#############
 
 if(CATKIN_ENABLE_TESTING)
-
   find_package(rostest REQUIRED)
 
-  add_rostest_gtest(controller_manager_hwi_switch_test
+  add_rostest_gtest(${PROJECT_NAME}_hwi_switch_test
     test/hwi_switch_test.test
     test/hwi_switch_test.cpp
   )
-  target_link_libraries(controller_manager_hwi_switch_test ${PROJECT_NAME} ${catkin_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}_hwi_switch_test ${PROJECT_NAME} ${catkin_LIBRARIES})
 
-  add_rostest_gmock(controller_manager_hwi_update_test
+  add_rostest_gmock(${PROJECT_NAME}_hwi_update_test
     test/hwi_update_test.test
     test/hwi_update_test.cpp
   )
-  target_link_libraries(controller_manager_hwi_update_test ${PROJECT_NAME} ${catkin_LIBRARIES})
-
+  target_link_libraries(${PROJECT_NAME}_hwi_update_test ${PROJECT_NAME} ${catkin_LIBRARIES})
 endif()
 
-# Install
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
 
-# Install library
+#############
+## Install ##
+#############
+
+# Install python scripts
+catkin_install_python(PROGRAMS scripts/controller_group
+                               scripts/controller_manager
+                               scripts/spawner
+                               scripts/unspawner
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+# Install headers
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)
+
+# Install targets
 install(TARGETS ${PROJECT_NAME}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
-
-catkin_install_python(PROGRAMS
-  scripts/controller_group
-  scripts/controller_manager
-  scripts/spawner
-  scripts/unspawner
-  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
-
-catkin_python_setup()
+  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+)

--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(catkin REQUIRED COMPONENTS
   controller_manager_msgs
   hardware_interface
   pluginlib
+  roscpp
 )
 
 # Include Boost.Thread
@@ -25,6 +26,7 @@ catkin_package(
     controller_manager_msgs
     hardware_interface
     pluginlib
+    roscpp
   DEPENDS
     Boost
 )

--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -60,12 +60,14 @@ if(CATKIN_ENABLE_TESTING)
     test/hwi_switch_test.test
     test/hwi_switch_test.cpp
   )
+  add_dependencies(${PROJECT_NAME}_hwi_switch_test ${catkin_EXPORTED_TARGETS})
   target_link_libraries(${PROJECT_NAME}_hwi_switch_test ${PROJECT_NAME} ${catkin_LIBRARIES})
 
   add_rostest_gmock(${PROJECT_NAME}_hwi_update_test
     test/hwi_update_test.test
     test/hwi_update_test.cpp
   )
+  add_dependencies(${PROJECT_NAME}_hwi_update_test ${catkin_EXPORTED_TARGETS})
   target_link_libraries(${PROJECT_NAME}_hwi_update_test ${PROJECT_NAME} ${catkin_LIBRARIES})
 endif()
 

--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -37,7 +37,7 @@ catkin_package(
 ###########
 
 # Specify header include paths
-include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIR})
+include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME}
   include/controller_manager/controller_loader.h

--- a/controller_manager/package.xml
+++ b/controller_manager/package.xml
@@ -22,6 +22,7 @@
   <depend>controller_manager_msgs</depend>
   <depend>hardware_interface</depend>
   <depend>pluginlib</depend>
+  <depend>roscpp</depend>
 
   <test_depend>rostest</test_depend>
 </package>

--- a/controller_manager/package.xml
+++ b/controller_manager/package.xml
@@ -19,11 +19,17 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <depend>boost</depend>
-  <depend>controller_interface</depend>
-  <depend>controller_manager_msgs</depend>
-  <depend>hardware_interface</depend>
-  <depend>pluginlib</depend>
   <depend>roscpp</depend>
+
+  <build_depend>controller_interface</build_depend>
+  <build_depend>controller_manager_msgs</build_depend>
+  <build_depend>hardware_interface</build_depend>
+  <build_depend>pluginlib</build_depend>
+
+  <build_export_depend>controller_interface</build_export_depend>
+  <build_export_depend>controller_manager_msgs</build_export_depend>
+  <build_export_depend>hardware_interface</build_export_depend>
+  <build_export_depend>pluginlib</build_export_depend>
 
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>rosparam</exec_depend>

--- a/controller_manager/package.xml
+++ b/controller_manager/package.xml
@@ -18,11 +18,16 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <depend>boost</depend>
   <depend>controller_interface</depend>
   <depend>controller_manager_msgs</depend>
   <depend>hardware_interface</depend>
   <depend>pluginlib</depend>
   <depend>roscpp</depend>
+
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>rosparam</exec_depend>
+  <exec_depend>rospy</exec_depend>
 
   <test_depend>rostest</test_depend>
 </package>

--- a/controller_manager/package.xml
+++ b/controller_manager/package.xml
@@ -2,6 +2,7 @@
   <name>controller_manager</name>
   <version>0.15.1</version>
   <description>The controller manager.</description>
+
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
   <maintainer email="enrique.fernandez.perdomo@gmail.com">Enrique Fernandez</maintainer>
   <maintainer email="mathias.luedtke@ipa.fraunhofer.de">Mathias Lüdtke</maintainer>
@@ -21,5 +22,6 @@
   <depend>controller_manager_msgs</depend>
   <depend>hardware_interface</depend>
   <depend>pluginlib</depend>
+
   <test_depend>rostest</test_depend>
 </package>

--- a/controller_manager_msgs/CMakeLists.txt
+++ b/controller_manager_msgs/CMakeLists.txt
@@ -2,35 +2,39 @@ cmake_minimum_required(VERSION 2.8.3)
 project(controller_manager_msgs)
 
 # Load catkin and all dependencies required for this package
-find_package(catkin REQUIRED COMPONENTS message_generation std_msgs)
+find_package(catkin REQUIRED COMPONENTS
+  message_generation
+  std_msgs
+)
 
 catkin_python_setup()
 
-# Add message and service files
-add_message_files(
-  FILES
+# Add message files
+add_message_files(FILES
   ControllerState.msg
   ControllerStatistics.msg
   ControllersStatistics.msg
   HardwareInterfaceResources.msg
-  )
+)
 
-add_service_files(
-  FILES
+# Add service files
+add_service_files(FILES
   ListControllerTypes.srv
   ListControllers.srv
   LoadController.srv
   ReloadControllerLibraries.srv
   SwitchController.srv
   UnloadController.srv
-  )
+)
 
 # Generate added messages and services with any dependencies listed here
-generate_messages(
-  DEPENDENCIES std_msgs
-  )
+generate_messages(DEPENDENCIES
+  std_msgs
+)
 
-# Declare catkin package
+# Declare a catkin package
 catkin_package(
-  CATKIN_DEPENDS std_msgs message_runtime
-  )
+  CATKIN_DEPENDS
+    message_runtime
+    std_msgs
+)

--- a/controller_manager_msgs/package.xml
+++ b/controller_manager_msgs/package.xml
@@ -22,4 +22,6 @@
   <build_depend>message_generation</build_depend>
 
   <exec_depend>message_runtime</exec_depend>
+  <exec_depend>rosservice</exec_depend>
+  <exec_depend>rospy</exec_depend>
 </package>

--- a/controller_manager_msgs/package.xml
+++ b/controller_manager_msgs/package.xml
@@ -2,6 +2,7 @@
   <name>controller_manager_msgs</name>
   <version>0.15.1</version>
   <description>Messages and services for the controller manager.</description>
+
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
   <maintainer email="enrique.fernandez.perdomo@gmail.com">Enrique Fernandez</maintainer>
   <maintainer email="mathias.luedtke@ipa.fraunhofer.de">Mathias Lüdtke</maintainer>
@@ -17,6 +18,8 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <depend>std_msgs</depend>
+
   <build_depend>message_generation</build_depend>
+
   <exec_depend>message_runtime</exec_depend>
 </package>

--- a/controller_manager_tests/CMakeLists.txt
+++ b/controller_manager_tests/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(catkin REQUIRED COMPONENTS
   controller_interface
   controller_manager
   hardware_interface
+  pluginlib
   roscpp
 )
 

--- a/controller_manager_tests/CMakeLists.txt
+++ b/controller_manager_tests/CMakeLists.txt
@@ -37,9 +37,11 @@ if(CATKIN_ENABLE_TESTING)
   target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
   add_executable(dummy_app EXCLUDE_FROM_ALL src/dummy_app.cpp)
+  add_dependencies(dummy_app ${catkin_EXPORTED_TARGETS})
   target_link_libraries(dummy_app ${PROJECT_NAME} ${catkin_LIBRARIES})
 
   add_executable(cm_test EXCLUDE_FROM_ALL test/cm_test.cpp)
+  add_dependencies(cm_test ${catkin_EXPORTED_TARGETS})
   target_link_libraries(cm_test ${catkin_LIBRARIES} ${GTEST_LIBRARIES})
 
   catkin_add_nosetests(test)

--- a/controller_manager_tests/CMakeLists.txt
+++ b/controller_manager_tests/CMakeLists.txt
@@ -5,6 +5,7 @@ project(controller_manager_tests)
 find_package(catkin REQUIRED COMPONENTS
   controller_interface
   controller_manager
+  hardware_interface
   roscpp
 )
 

--- a/controller_manager_tests/CMakeLists.txt
+++ b/controller_manager_tests/CMakeLists.txt
@@ -10,37 +10,7 @@ find_package(catkin REQUIRED COMPONENTS
 catkin_python_setup()
 
 # Declare a catkin package
-catkin_package(
-  INCLUDE_DIRS
-    include
-  LIBRARIES
-    ${PROJECT_NAME}
-  CATKIN_DEPENDS
-    controller_interface
-    controller_manager
-)
-
-
-###########
-## Build ##
-###########
-
-# Specify header include paths
-include_directories(include ${catkin_INCLUDE_DIRS})
-
-add_library(${PROJECT_NAME}
-  src/effort_test_controller.cpp
-  src/extensible_controllers.cpp
-  src/my_dummy_controller.cpp
-  src/my_robot_hw.cpp
-  src/pos_eff_controller.cpp
-  src/pos_eff_opt_controller.cpp
-  src/vel_eff_controller.cpp
-)
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
-
-add_executable(dummy_app src/dummy_app.cpp)
-target_link_libraries(dummy_app ${PROJECT_NAME} ${catkin_LIBRARIES})
+catkin_package()
 
 
 #############
@@ -50,7 +20,24 @@ target_link_libraries(dummy_app ${PROJECT_NAME} ${catkin_LIBRARIES})
 if(CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
 
-  add_executable(cm_test test/cm_test.cpp)
+  # Specify header include paths
+  include_directories(include ${catkin_INCLUDE_DIRS})
+
+  add_library(${PROJECT_NAME} EXCLUDE_FROM_ALL
+    src/effort_test_controller.cpp
+    src/extensible_controllers.cpp
+    src/my_dummy_controller.cpp
+    src/my_robot_hw.cpp
+    src/pos_eff_controller.cpp
+    src/pos_eff_opt_controller.cpp
+    src/vel_eff_controller.cpp
+  )
+  target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
+
+  add_executable(dummy_app EXCLUDE_FROM_ALL src/dummy_app.cpp)
+  target_link_libraries(dummy_app ${PROJECT_NAME} ${catkin_LIBRARIES})
+
+  add_executable(cm_test EXCLUDE_FROM_ALL test/cm_test.cpp)
   add_dependencies(tests cm_test)
   target_link_libraries(cm_test ${catkin_LIBRARIES} ${GTEST_LIBRARIES})
 
@@ -62,25 +49,3 @@ if(CATKIN_ENABLE_TESTING)
 
   add_rostest(test/controller_manager_scripts.test)
 endif()
-
-
-#############
-## Install ##
-#############
-
-# Install headers
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-)
-
-# Install targets
-install(TARGETS ${PROJECT_NAME} dummy_app
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
-)
-
-# Install plugins
-install(FILES test_controllers_plugin.xml
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-)

--- a/controller_manager_tests/CMakeLists.txt
+++ b/controller_manager_tests/CMakeLists.txt
@@ -5,6 +5,7 @@ project(controller_manager_tests)
 find_package(catkin REQUIRED COMPONENTS
   controller_interface
   controller_manager
+  roscpp
 )
 
 catkin_python_setup()

--- a/controller_manager_tests/CMakeLists.txt
+++ b/controller_manager_tests/CMakeLists.txt
@@ -26,7 +26,7 @@ catkin_package(
 ###########
 
 # Specify header include paths
-include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIR})
+include_directories(include ${catkin_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME}
   src/effort_test_controller.cpp

--- a/controller_manager_tests/CMakeLists.txt
+++ b/controller_manager_tests/CMakeLists.txt
@@ -25,7 +25,7 @@ if(CATKIN_ENABLE_TESTING)
   # Specify header include paths
   include_directories(include ${catkin_INCLUDE_DIRS})
 
-  add_library(${PROJECT_NAME} EXCLUDE_FROM_ALL
+  add_library(${PROJECT_NAME}
     src/effort_test_controller.cpp
     src/extensible_controllers.cpp
     src/my_dummy_controller.cpp
@@ -56,7 +56,20 @@ endif()
 ## Install ##
 #############
 
-# Install plugins
-install(FILES test_controllers_plugin.xml
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-)
+# NOTE: Libraries and plugins required for tests are installed since CI
+# runs tests out of the install space rather than the devel space
+
+if(CATKIN_ENABLE_TESTING)
+
+  # Install targets
+  install(TARGETS ${PROJECT_NAME}
+    ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+  )
+
+  # Install plugins
+  install(FILES test_controllers_plugin.xml
+    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+  )
+endif()

--- a/controller_manager_tests/CMakeLists.txt
+++ b/controller_manager_tests/CMakeLists.txt
@@ -2,18 +2,32 @@ cmake_minimum_required(VERSION 2.8.3)
 project(controller_manager_tests)
 
 # Load catkin and all dependencies required for this package
-find_package(catkin REQUIRED COMPONENTS controller_manager controller_interface)
+find_package(catkin REQUIRED COMPONENTS
+  controller_interface
+  controller_manager
+)
+
 catkin_python_setup()
 
-include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
-
+# Declare a catkin package
 catkin_package(
-  CATKIN_DEPENDS controller_manager controller_interface
-  INCLUDE_DIRS include
-  LIBRARIES ${PROJECT_NAME}
-  )
+  INCLUDE_DIRS
+    include
+  LIBRARIES
+    ${PROJECT_NAME}
+  CATKIN_DEPENDS
+    controller_interface
+    controller_manager
+)
 
-#common commands for building c++ executables and libraries
+
+###########
+## Build ##
+###########
+
+# Specify header include paths
+include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIR})
+
 add_library(${PROJECT_NAME}
   src/effort_test_controller.cpp
   src/extensible_controllers.cpp
@@ -28,30 +42,45 @@ target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 add_executable(dummy_app src/dummy_app.cpp)
 target_link_libraries(dummy_app ${PROJECT_NAME} ${catkin_LIBRARIES})
 
+
+#############
+## Testing ##
+#############
+
 if(CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
+
   add_executable(cm_test test/cm_test.cpp)
   add_dependencies(tests cm_test)
-  target_link_libraries(cm_test ${GTEST_LIBRARIES} ${catkin_LIBRARIES})
+  target_link_libraries(cm_test ${catkin_LIBRARIES} ${GTEST_LIBRARIES})
+
   add_rostest(test/cm_test.test)
+
   catkin_add_nosetests(test)
+
   add_rostest(test/cm_msgs_utils_rostest.test)
+
   add_rostest(test/controller_manager_scripts.test)
 endif()
 
-# Install
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
 
-# Install library
-install(TARGETS ${PROJECT_NAME}
+#############
+## Install ##
+#############
+
+# Install headers
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)
+
+# Install targets
+install(TARGETS ${PROJECT_NAME} dummy_app
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
+  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+)
 
-# Install executable
-install(TARGETS dummy_app
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
-
+# Install plugins
 install(FILES test_controllers_plugin.xml
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/controller_manager_tests/CMakeLists.txt
+++ b/controller_manager_tests/CMakeLists.txt
@@ -38,14 +38,13 @@ if(CATKIN_ENABLE_TESTING)
   target_link_libraries(dummy_app ${PROJECT_NAME} ${catkin_LIBRARIES})
 
   add_executable(cm_test EXCLUDE_FROM_ALL test/cm_test.cpp)
-  add_dependencies(tests cm_test)
   target_link_libraries(cm_test ${catkin_LIBRARIES} ${GTEST_LIBRARIES})
-
-  add_rostest(test/cm_test.test)
 
   catkin_add_nosetests(test)
 
+  add_rostest(test/cm_test.test DEPENDENCIES dummy_app cm_test)
+
   add_rostest(test/cm_msgs_utils_rostest.test)
 
-  add_rostest(test/controller_manager_scripts.test)
+  add_rostest(test/controller_manager_scripts.test DEPENDENCIES dummy_app)
 endif()

--- a/controller_manager_tests/CMakeLists.txt
+++ b/controller_manager_tests/CMakeLists.txt
@@ -49,3 +49,13 @@ if(CATKIN_ENABLE_TESTING)
 
   add_rostest(test/controller_manager_scripts.test DEPENDENCIES dummy_app)
 endif()
+
+
+#############
+## Install ##
+#############
+
+# Install plugins
+install(FILES test_controllers_plugin.xml
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/controller_manager_tests/package.xml
+++ b/controller_manager_tests/package.xml
@@ -20,6 +20,7 @@
 
   <depend>controller_interface</depend>
   <depend>controller_manager</depend>
+  <depend>roscpp</depend>
 
   <test_depend>rosbash</test_depend>
   <test_depend>rosnode</test_depend>

--- a/controller_manager_tests/package.xml
+++ b/controller_manager_tests/package.xml
@@ -18,11 +18,15 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <depend>controller_interface</depend>
+  <depend>controller_interface</depend> <!-- exec_depend required for plugin -->
   <depend>controller_manager</depend>
-  <depend>hardware_interface</depend>
+  <depend>roscpp</depend>
 
-  <build_depend>roscpp</build_depend>
+  <build_depend>hardware_interface</build_depend>
+  <build_depend>pluginlib</build_depend>
+
+  <build_export_depend>hardware_interface</build_export_depend>
+  <build_export_depend>pluginlib</build_export_depend>
 
   <exec_depend>controller_manager_msgs</exec_depend>
   <exec_depend>rospy</exec_depend>

--- a/controller_manager_tests/package.xml
+++ b/controller_manager_tests/package.xml
@@ -1,7 +1,7 @@
 <package format="2">
   <name>controller_manager_tests</name>
   <version>0.15.1</version>
-  <description>controller_manager_tests</description>
+  <description>Tests for the controller manager.</description>
 
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
   <maintainer email="enrique.fernandez.perdomo@gmail.com">Enrique Fernandez</maintainer>

--- a/controller_manager_tests/package.xml
+++ b/controller_manager_tests/package.xml
@@ -1,7 +1,8 @@
-<package>
+<package format="2">
   <name>controller_manager_tests</name>
   <version>0.15.1</version>
   <description>controller_manager_tests</description>
+
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
   <maintainer email="enrique.fernandez.perdomo@gmail.com">Enrique Fernandez</maintainer>
   <maintainer email="mathias.luedtke@ipa.fraunhofer.de">Mathias Lüdtke</maintainer>
@@ -17,14 +18,13 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>controller_manager</build_depend>
-  <build_depend>controller_interface</build_depend>
-  <run_depend>controller_manager</run_depend>
-  <run_depend>controller_interface</run_depend>
-  <test_depend>rostest</test_depend>
-  <test_depend>rosservice</test_depend>
+  <depend>controller_interface</depend>
+  <depend>controller_manager</depend>
+
   <test_depend>rosbash</test_depend>
   <test_depend>rosnode</test_depend>
+  <test_depend>rosservice</test_depend>
+  <test_depend>rostest</test_depend>
 
   <export>
     <controller_interface plugin="${prefix}/test_controllers_plugin.xml"/>

--- a/controller_manager_tests/package.xml
+++ b/controller_manager_tests/package.xml
@@ -20,11 +20,15 @@
 
   <depend>controller_interface</depend>
   <depend>controller_manager</depend>
-  <depend>roscpp</depend>
+  <depend>hardware_interface</depend>
+
+  <build_depend>roscpp</build_depend>
+
+  <exec_depend>controller_manager_msgs</exec_depend>
+  <exec_depend>rospy</exec_depend>
 
   <test_depend>rosbash</test_depend>
   <test_depend>rosnode</test_depend>
-  <test_depend>rosservice</test_depend>
   <test_depend>rostest</test_depend>
 
   <export>

--- a/hardware_interface/CMakeLists.txt
+++ b/hardware_interface/CMakeLists.txt
@@ -28,8 +28,6 @@ include_directories(include ${catkin_INCLUDE_DIRS})
 #############
 
 if(CATKIN_ENABLE_TESTING)
-  find_package(catkin REQUIRED COMPONENTS rosconsole) # TODO: Investigate
-
   catkin_add_gtest(hardware_resource_manager_test           test/hardware_resource_manager_test.cpp)
   target_link_libraries(hardware_resource_manager_test      ${catkin_LIBRARIES})
 

--- a/hardware_interface/CMakeLists.txt
+++ b/hardware_interface/CMakeLists.txt
@@ -1,54 +1,75 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(hardware_interface)
 
-find_package(catkin REQUIRED COMPONENTS roscpp)
+# Load catkin and all dependencies required for this package
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+)
 
-# Declare catkin package
+# Declare a catkin package
 catkin_package(
-  CATKIN_DEPENDS roscpp
-  INCLUDE_DIRS include
-  )
+  INCLUDE_DIRS
+    include
+  CATKIN_DEPENDS
+    roscpp
+)
+
+
+###########
+## Build ##
+###########
+
+# Specify header include paths
+include_directories(include ${catkin_INCLUDE_DIRS})
+
+
+#############
+## Testing ##
+#############
 
 if(CATKIN_ENABLE_TESTING)
+  find_package(catkin REQUIRED COMPONENTS rosconsole) # TODO: Investigate
 
-  find_package(catkin REQUIRED COMPONENTS rosconsole)
-  include_directories(include ${catkin_INCLUDE_DIRS})
+  catkin_add_gtest(hardware_resource_manager_test           test/hardware_resource_manager_test.cpp)
+  target_link_libraries(hardware_resource_manager_test      ${catkin_LIBRARIES})
 
-  catkin_add_gtest(hardware_resource_manager_test  test/hardware_resource_manager_test.cpp)
-  target_link_libraries(hardware_resource_manager_test ${catkin_LIBRARIES})
+  catkin_add_gtest(actuator_state_interface_test            test/actuator_state_interface_test.cpp)
+  target_link_libraries(actuator_state_interface_test       ${catkin_LIBRARIES})
 
-  catkin_add_gtest(actuator_state_interface_test   test/actuator_state_interface_test.cpp)
-  target_link_libraries(actuator_state_interface_test ${catkin_LIBRARIES})
+  catkin_add_gtest(actuator_command_interface_test          test/actuator_command_interface_test.cpp)
+  target_link_libraries(actuator_command_interface_test     ${catkin_LIBRARIES})
 
-  catkin_add_gtest(actuator_command_interface_test test/actuator_command_interface_test.cpp)
-  target_link_libraries(actuator_command_interface_test ${catkin_LIBRARIES})
+  catkin_add_gtest(joint_state_interface_test               test/joint_state_interface_test.cpp)
+  target_link_libraries(joint_state_interface_test          ${catkin_LIBRARIES})
 
-  catkin_add_gtest(joint_state_interface_test      test/joint_state_interface_test.cpp)
-  target_link_libraries(joint_state_interface_test ${catkin_LIBRARIES})
+  catkin_add_gtest(joint_command_interface_test             test/joint_command_interface_test.cpp)
+  target_link_libraries(joint_command_interface_test        ${catkin_LIBRARIES})
 
-  catkin_add_gtest(joint_command_interface_test    test/joint_command_interface_test.cpp)
-  target_link_libraries(joint_command_interface_test ${catkin_LIBRARIES})
+  catkin_add_gtest(force_torque_sensor_interface_test       test/force_torque_sensor_interface_test.cpp)
+  target_link_libraries(force_torque_sensor_interface_test  ${catkin_LIBRARIES})
 
-  catkin_add_gtest(force_torque_sensor_interface_test test/force_torque_sensor_interface_test.cpp)
-  target_link_libraries(force_torque_sensor_interface_test ${catkin_LIBRARIES})
+  catkin_add_gtest(imu_sensor_interface_test                test/imu_sensor_interface_test.cpp)
+  target_link_libraries(imu_sensor_interface_test           ${catkin_LIBRARIES})
 
-  catkin_add_gtest(imu_sensor_interface_test       test/imu_sensor_interface_test.cpp)
-  target_link_libraries(imu_sensor_interface_test ${catkin_LIBRARIES})
+  catkin_add_gtest(robot_hw_test                            test/robot_hw_test.cpp)
+  target_link_libraries(robot_hw_test                       ${catkin_LIBRARIES})
 
-  catkin_add_gtest(robot_hw_test                   test/robot_hw_test.cpp)
-  target_link_libraries(robot_hw_test ${catkin_LIBRARIES})
+  catkin_add_gtest(interface_manager_test                   test/interface_manager_test.cpp)
+  target_link_libraries(interface_manager_test              ${catkin_LIBRARIES})
 
-  catkin_add_gtest(interface_manager_test          test/interface_manager_test.cpp)
-  target_link_libraries(interface_manager_test ${catkin_LIBRARIES})
+  catkin_add_gtest(posvel_command_interface_test            test/posvel_command_interface_test.cpp)
+  target_link_libraries(posvel_command_interface_test       ${catkin_LIBRARIES})
 
-  catkin_add_gtest(posvel_command_interface_test test/posvel_command_interface_test.cpp)
-  target_link_libraries(posvel_command_interface_test ${catkin_LIBRARIES})
-
-  catkin_add_gtest(posvelacc_command_interface_test test/posvelacc_command_interface_test.cpp)
-  target_link_libraries(posvelacc_command_interface_test ${catkin_LIBRARIES})
-
+  catkin_add_gtest(posvelacc_command_interface_test         test/posvelacc_command_interface_test.cpp)
+  target_link_libraries(posvelacc_command_interface_test    ${catkin_LIBRARIES})
 endif()
 
-# Install
+
+#############
+## Install ##
+#############
+
+# Install headers
 install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)

--- a/hardware_interface/CMakeLists.txt
+++ b/hardware_interface/CMakeLists.txt
@@ -15,6 +15,8 @@ catkin_package(
     include
   CATKIN_DEPENDS
     roscpp
+  DEPENDS
+    Boost # TODO: Should header-only dependencies be DEPENDS or INCLUDE_DIRS?
 )
 
 

--- a/hardware_interface/CMakeLists.txt
+++ b/hardware_interface/CMakeLists.txt
@@ -6,6 +6,9 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
 )
 
+# Include header-only Boost libraries
+find_package(Boost REQUIRED)
+
 # Declare a catkin package
 catkin_package(
   INCLUDE_DIRS
@@ -20,7 +23,7 @@ catkin_package(
 ###########
 
 # Specify header include paths
-include_directories(include ${catkin_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 
 
 #############

--- a/hardware_interface/CMakeLists.txt
+++ b/hardware_interface/CMakeLists.txt
@@ -16,7 +16,7 @@ catkin_package(
   CATKIN_DEPENDS
     roscpp
   DEPENDS
-    Boost # TODO: Should header-only dependencies be DEPENDS or INCLUDE_DIRS?
+    Boost
 )
 
 

--- a/hardware_interface/package.xml
+++ b/hardware_interface/package.xml
@@ -20,6 +20,5 @@
 
   <depend>roscpp</depend>
 
-  <test_depend>rostest</test_depend>
   <test_depend>rosunit</test_depend>
 </package>

--- a/hardware_interface/package.xml
+++ b/hardware_interface/package.xml
@@ -18,6 +18,9 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <depend>boost</depend>
   <depend>roscpp</depend>
+
+  <build_depend>boost</build_depend>
+
+  <build_export_depend>boost</build_export_depend>
 </package>

--- a/hardware_interface/package.xml
+++ b/hardware_interface/package.xml
@@ -19,6 +19,4 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <depend>roscpp</depend>
-
-  <test_depend>rosunit</test_depend>
 </package>

--- a/hardware_interface/package.xml
+++ b/hardware_interface/package.xml
@@ -18,5 +18,6 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <depend>boost</depend>
   <depend>roscpp</depend>
 </package>

--- a/hardware_interface/package.xml
+++ b/hardware_interface/package.xml
@@ -2,6 +2,7 @@
   <name>hardware_interface</name>
   <version>0.15.1</version>
   <description>Hardware Interface base class.</description>
+
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
   <maintainer email="enrique.fernandez.perdomo@gmail.com">Enrique Fernandez</maintainer>
   <maintainer email="mathias.luedtke@ipa.fraunhofer.de">Mathias Lüdtke</maintainer>
@@ -16,7 +17,9 @@
   <author>Adolfo Rodriguez Tsouroukdissian</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+
   <depend>roscpp</depend>
+
   <test_depend>rostest</test_depend>
   <test_depend>rosunit</test_depend>
 </package>

--- a/joint_limits_interface/CMakeLists.txt
+++ b/joint_limits_interface/CMakeLists.txt
@@ -17,7 +17,8 @@ catkin_package(
     include
   CATKIN_DEPENDS
     hardware_interface
-    roscpp urdf
+    roscpp
+    urdf
   DEPENDS
     urdfdom
 )

--- a/joint_limits_interface/CMakeLists.txt
+++ b/joint_limits_interface/CMakeLists.txt
@@ -8,9 +8,6 @@ find_package(catkin REQUIRED COMPONENTS
   urdf
 )
 
-# Include urdfdom
-find_package(urdfdom REQUIRED) # TODO: Delete
-
 # Declare a catkin package
 catkin_package(
   INCLUDE_DIRS
@@ -19,8 +16,6 @@ catkin_package(
     hardware_interface
     roscpp
     urdf
-  DEPENDS
-    urdfdom
 )
 
 
@@ -29,7 +24,7 @@ catkin_package(
 ###########
 
 # Specify header include paths
-include_directories(include ${catkin_INCLUDE_DIRS} ${urdfdom_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS})
 
 
 #############
@@ -40,16 +35,16 @@ if(CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
 
   catkin_add_gtest(joint_limits_interface_test test/joint_limits_interface_test.cpp)
-  target_link_libraries(joint_limits_interface_test ${catkin_LIBRARIES} ${urdfdom_LIBRARIES})
+  target_link_libraries(joint_limits_interface_test ${catkin_LIBRARIES})
 
   catkin_add_gtest(joint_limits_urdf_test test/joint_limits_urdf_test.cpp)
-  target_link_libraries(joint_limits_urdf_test ${catkin_LIBRARIES} ${urdfdom_LIBRARIES})
+  target_link_libraries(joint_limits_urdf_test ${catkin_LIBRARIES})
 
   add_rostest_gtest(joint_limits_rosparam_test
     test/joint_limits_rosparam.test
     test/joint_limits_rosparam_test.cpp
   )
-  target_link_libraries(joint_limits_rosparam_test ${catkin_LIBRARIES} ${urdfdom_LIBRARIES})
+  target_link_libraries(joint_limits_rosparam_test ${catkin_LIBRARIES})
 endif()
 
 

--- a/joint_limits_interface/CMakeLists.txt
+++ b/joint_limits_interface/CMakeLists.txt
@@ -1,52 +1,62 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(joint_limits_interface)
 
-find_package(urdfdom REQUIRED)
-
+# Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS
   hardware_interface
   roscpp
   urdf
 )
 
-include_directories(include ${catkin_INCLUDE_DIRS} ${urdfdom_INCLUDE_DIRS})
+# Include urdfdom
+find_package(urdfdom REQUIRED) # TODO: Delete
 
-# Declare catkin package
+# Declare a catkin package
 catkin_package(
-  CATKIN_DEPENDS
-    hardware_interface
-    roscpp
-    urdf
   INCLUDE_DIRS
     include
+  CATKIN_DEPENDS
+    hardware_interface
+    roscpp urdf
   DEPENDS
     urdfdom
 )
 
+
+###########
+## Build ##
+###########
+
+# Specify header include paths
+include_directories(include ${catkin_INCLUDE_DIRS} ${urdfdom_INCLUDE_DIRS})
+
+
+#############
+## Testing ##
+#############
+
 if(CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
+
   catkin_add_gtest(joint_limits_interface_test test/joint_limits_interface_test.cpp)
-  target_link_libraries(joint_limits_interface_test
-    ${catkin_LIBRARIES}
-    ${urdfdom_LIBRARIES}
-  )
+  target_link_libraries(joint_limits_interface_test ${catkin_LIBRARIES} ${urdfdom_LIBRARIES})
 
   catkin_add_gtest(joint_limits_urdf_test test/joint_limits_urdf_test.cpp)
-  target_link_libraries(joint_limits_urdf_test
-    ${catkin_LIBRARIES}
-    ${urdfdom_LIBRARIES}
-  )
+  target_link_libraries(joint_limits_urdf_test ${catkin_LIBRARIES} ${urdfdom_LIBRARIES})
 
   add_rostest_gtest(joint_limits_rosparam_test
     test/joint_limits_rosparam.test
     test/joint_limits_rosparam_test.cpp
   )
-  target_link_libraries(joint_limits_rosparam_test
-    ${catkin_LIBRARIES}
-    ${urdfdom_LIBRARIES}
-  )
+  target_link_libraries(joint_limits_rosparam_test ${catkin_LIBRARIES} ${urdfdom_LIBRARIES})
 endif()
 
-# Install
+
+#############
+## Install ##
+#############
+
+# Install headers
 install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)

--- a/joint_limits_interface/package.xml
+++ b/joint_limits_interface/package.xml
@@ -23,6 +23,5 @@
   <depend>roscpp</depend>
   <depend>urdf</depend>
 
-  <test_depend>rosunit</test_depend>
   <test_depend>rostest</test_depend>
 </package>

--- a/joint_limits_interface/package.xml
+++ b/joint_limits_interface/package.xml
@@ -15,7 +15,6 @@
 
   <author>Adolfo Rodriguez Tsouroukdissian</author>
 
-
   <buildtool_depend>catkin</buildtool_depend>
 
   <depend>hardware_interface</depend>

--- a/joint_limits_interface/package.xml
+++ b/joint_limits_interface/package.xml
@@ -19,7 +19,6 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <depend>hardware_interface</depend>
-  <depend>liburdfdom-dev</depend>
   <depend>roscpp</depend>
   <depend>urdf</depend>
 

--- a/joint_limits_interface/package.xml
+++ b/joint_limits_interface/package.xml
@@ -17,9 +17,12 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <depend>hardware_interface</depend>
   <depend>roscpp</depend>
   <depend>urdf</depend>
+
+  <build_depend>hardware_interface</build_depend>
+
+  <build_export_depend>hardware_interface</build_export_depend>
 
   <test_depend>rostest</test_depend>
 </package>

--- a/joint_limits_interface/package.xml
+++ b/joint_limits_interface/package.xml
@@ -2,22 +2,26 @@
   <name>joint_limits_interface</name>
   <version>0.15.1</version>
   <description>Interface for enforcing joint limits.</description>
+
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
   <maintainer email="enrique.fernandez.perdomo@gmail.com">Enrique Fernandez</maintainer>
   <maintainer email="mathias.luedtke@ipa.fraunhofer.de">Mathias Lüdtke</maintainer>
+
   <license>BSD</license>
 
   <url type="website">https://github.com/ros-controls/ros_control/wiki</url>
   <url type="bugtracker">https://github.com/ros-controls/ros_control/issues</url>
   <url type="repository">https://github.com/ros-controls/ros_control</url>
+
   <author>Adolfo Rodriguez Tsouroukdissian</author>
+
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <depend>roscpp</depend>
   <depend>hardware_interface</depend>
-  <depend>urdf</depend>
   <depend>liburdfdom-dev</depend>
+  <depend>roscpp</depend>
+  <depend>urdf</depend>
 
   <test_depend>rosunit</test_depend>
   <test_depend>rostest</test_depend>

--- a/ros_control/package.xml
+++ b/ros_control/package.xml
@@ -17,16 +17,16 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <exec_depend>joint_limits_interface</exec_depend>
-  <exec_depend>transmission_interface</exec_depend>
-  <exec_depend>realtime_tools</exec_depend>
-  <exec_depend>controller_manager</exec_depend>
-  <exec_depend>controller_interface</exec_depend>
-  <exec_depend>hardware_interface</exec_depend>
-  <exec_depend>controller_manager_tests</exec_depend>
-  <exec_depend>controller_manager_msgs</exec_depend>
   <exec_depend>combined_robot_hw</exec_depend>
   <exec_depend>combined_robot_hw_tests</exec_depend>
+  <exec_depend>controller_interface</exec_depend>
+  <exec_depend>controller_manager</exec_depend>
+  <exec_depend>controller_manager_msgs</exec_depend>
+  <exec_depend>controller_manager_tests</exec_depend>
+  <exec_depend>hardware_interface</exec_depend>
+  <exec_depend>joint_limits_interface</exec_depend>
+  <exec_depend>realtime_tools</exec_depend>
+  <exec_depend>transmission_interface</exec_depend>
 
   <export>
     <metapackage/>

--- a/rqt_controller_manager/CMakeLists.txt
+++ b/rqt_controller_manager/CMakeLists.txt
@@ -1,19 +1,30 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rqt_controller_manager)
 
+# Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS)
+
 catkin_python_setup()
+
+# Declare a catkin package
 catkin_package()
 
-install(FILES plugin.xml
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-)
 
+#############
+## Install ##
+#############
+
+# Install resources
 install(DIRECTORY resource
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 
-install(PROGRAMS
-  scripts/rqt_controller_manager
+# Install python scripts
+catkin_install_python(PROGRAMS scripts/rqt_controller_manager
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+# Install plugins
+install(FILES plugin.xml
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )

--- a/rqt_controller_manager/CMakeLists.txt
+++ b/rqt_controller_manager/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(rqt_controller_manager)
 
 # Load catkin and all dependencies required for this package
-find_package(catkin REQUIRED COMPONENTS)
+find_package(catkin REQUIRED)
 
 catkin_python_setup()
 

--- a/rqt_controller_manager/package.xml
+++ b/rqt_controller_manager/package.xml
@@ -18,9 +18,10 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <exec_depend>controller_manager</exec_depend>
-  <exec_depend>rqt_gui</exec_depend>
+  <exec_depend>controller_manager_msgs</exec_depend>
   <exec_depend>rospy</exec_depend>
+  <exec_depend>rqt_gui</exec_depend>
+  <exec_depend>rqt_gui_py</exec_depend>
 
   <export>
     <rqt_gui plugin="${prefix}/plugin.xml"/>

--- a/rqt_controller_manager/package.xml
+++ b/rqt_controller_manager/package.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0"?>
 <package format="2">
   <name>rqt_controller_manager</name>
   <version>0.15.1</version>
@@ -23,6 +22,6 @@
   <exec_depend>rqt_gui</exec_depend>
 
   <export>
-    <rqt_gui plugin="${prefix}/plugin.xml" />
+    <rqt_gui plugin="${prefix}/plugin.xml"/>
   </export>
 </package>

--- a/rqt_controller_manager/package.xml
+++ b/rqt_controller_manager/package.xml
@@ -1,7 +1,7 @@
 <package format="2">
   <name>rqt_controller_manager</name>
   <version>0.15.1</version>
-  <description>The rqt_controller_manager package</description>
+  <description>Graphical frontend for interacting with the controller manager.</description>
 
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
   <maintainer email="enrique.fernandez.perdomo@gmail.com">Enrique Fernandez</maintainer>

--- a/rqt_controller_manager/package.xml
+++ b/rqt_controller_manager/package.xml
@@ -20,6 +20,7 @@
 
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>rqt_gui</exec_depend>
+  <exec_depend>rospy</exec_depend>
 
   <export>
     <rqt_gui plugin="${prefix}/plugin.xml"/>

--- a/transmission_interface/CMakeLists.txt
+++ b/transmission_interface/CMakeLists.txt
@@ -9,6 +9,9 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
 )
 
+# Include header-only Boost libraries
+find_package(Boost REQUIRED)
+
 # Include a custom cmake file for TinyXML
 find_package(TinyXML REQUIRED)
 
@@ -33,7 +36,7 @@ catkin_package(
 ###########
 
 # Specify header include paths
-include_directories(include ${catkin_INCLUDE_DIRS} ${TinyXML_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS} ${TinyXML_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 
 # Transmission parser library
 add_library(${PROJECT_NAME}_parser
@@ -85,37 +88,32 @@ target_link_libraries(${PROJECT_NAME}_loader_plugins ${PROJECT_NAME}_loader)
 #############
 
 if(CATKIN_ENABLE_TESTING)
-  find_package(catkin REQUIRED COMPONENTS resource_retriever roscpp) # TODO: Investigate
-  find_package(Boost REQUIRED COMPONENTS system thread)
+  find_package(resource_retriever REQUIRED)
 
   catkin_add_gtest(simple_transmission_test                       test/simple_transmission_test.cpp)
-  target_link_libraries(simple_transmission_test                  ${Boost_LIBRARIES})
 
   catkin_add_gtest(differential_transmission_test                 test/differential_transmission_test.cpp)
-  target_link_libraries(differential_transmission_test            ${Boost_LIBRARIES})
 
   catkin_add_gtest(four_bar_linkage_transmission_test             test/four_bar_linkage_transmission_test.cpp)
-  target_link_libraries(four_bar_linkage_transmission_test        ${Boost_LIBRARIES})
 
   catkin_add_gtest(transmission_interface_test                    test/transmission_interface_test.cpp)
-  target_link_libraries(transmission_interface_test               ${TinyXML_LIBRARIES} ${catkin_LIBRARIES})
+  target_link_libraries(transmission_interface_test               ${catkin_LIBRARIES})
 
   catkin_add_gtest(transmission_parser_test                       test/transmission_parser_test.cpp)
-  target_link_libraries(transmission_parser_test                  ${PROJECT_NAME}_parser ${catkin_LIBRARIES})
+  target_link_libraries(transmission_parser_test                  ${PROJECT_NAME}_parser ${resource_retriever_LIBRARIES})
 
   catkin_add_gtest(simple_transmission_loader_test                test/simple_transmission_loader_test.cpp)
-  target_link_libraries(simple_transmission_loader_test           ${PROJECT_NAME}_parser ${catkin_LIBRARIES})
+  target_link_libraries(simple_transmission_loader_test           ${PROJECT_NAME}_parser ${resource_retriever_LIBRARIES})
 
   catkin_add_gtest(differential_transmission_loader_test          test/differential_transmission_loader_test.cpp)
-  target_link_libraries(differential_transmission_loader_test     ${PROJECT_NAME}_parser ${catkin_LIBRARIES})
+  target_link_libraries(differential_transmission_loader_test     ${PROJECT_NAME}_parser ${resource_retriever_LIBRARIES})
 
   catkin_add_gtest(four_bar_linkage_transmission_loader_test      test/four_bar_linkage_transmission_loader_test.cpp)
-  target_link_libraries(four_bar_linkage_transmission_loader_test ${PROJECT_NAME}_parser ${catkin_LIBRARIES})
+  target_link_libraries(four_bar_linkage_transmission_loader_test ${PROJECT_NAME}_parser ${resource_retriever_LIBRARIES})
 
   catkin_add_gtest(transmission_interface_loader_test             test/transmission_interface_loader_test.cpp)
-  target_link_libraries(transmission_interface_loader_test        ${PROJECT_NAME}_parser
-                                                                  transmission_interface_loader
-                                                                  ${catkin_LIBRARIES})
+  target_link_libraries(transmission_interface_loader_test        transmission_interface_loader
+                                                                  ${resource_retriever_LIBRARIES})
 endif()
 
 

--- a/transmission_interface/CMakeLists.txt
+++ b/transmission_interface/CMakeLists.txt
@@ -14,12 +14,12 @@ find_package(TinyXML REQUIRED)
 
 # Declare a catkin package
 catkin_package(
+  INCLUDE_DIRS
+    include
   LIBRARIES
     ${PROJECT_NAME}_parser
     ${PROJECT_NAME}_loader
     ${PROJECT_NAME}_loader_plugins
-  INCLUDE_DIRS
-    include
   CATKIN_DEPENDS
     pluginlib
     roscpp
@@ -27,99 +27,117 @@ catkin_package(
     TinyXML
 )
 
+
 ###########
 ## Build ##
 ###########
 
-# Build
+# Specify header include paths
 include_directories(include ${catkin_INCLUDE_DIRS} ${TinyXML_INCLUDE_DIRS})
 
-# Transmission parser Library
+# Transmission parser library
 add_library(${PROJECT_NAME}_parser
-  src/transmission_parser.cpp include/transmission_interface/transmission_parser.h
+  include/transmission_interface/transmission_parser.h
+  src/transmission_parser.cpp
 )
 target_link_libraries(${PROJECT_NAME}_parser ${catkin_LIBRARIES} ${TinyXML_LIBRARIES})
 
-
 # Transmission loader library
 add_library(${PROJECT_NAME}_loader
-  src/transmission_loader.cpp           include/transmission_interface/transmission_loader.h
-  src/transmission_interface_loader.cpp include/transmission_interface/transmission_interface_loader.h
+  include/transmission_interface/transmission_interface_loader.h
+  include/transmission_interface/transmission_loader.h
+  src/transmission_interface_loader.cpp
+  src/transmission_loader.cpp
 )
 target_link_libraries(${PROJECT_NAME}_loader
   ${PROJECT_NAME}_parser
   ${catkin_LIBRARIES}
-  ${TinyXML_LIBRARIES})
-
-
-add_library(${PROJECT_NAME}_loader_plugins
-  src/simple_transmission_loader.cpp                      include/transmission_interface/simple_transmission_loader.h
-  src/differential_transmission_loader.cpp                include/transmission_interface/differential_transmission_loader.h
-  src/four_bar_linkage_transmission_loader.cpp            include/transmission_interface/four_bar_linkage_transmission_loader.h
-  src/joint_state_interface_provider.cpp                  include/transmission_interface/joint_state_interface_provider.h
-  src/position_joint_interface_provider.cpp               include/transmission_interface/position_joint_interface_provider.h
-  src/velocity_joint_interface_provider.cpp               include/transmission_interface/velocity_joint_interface_provider.h
-  src/effort_joint_interface_provider.cpp                 include/transmission_interface/effort_joint_interface_provider.h
-  src/bidirectional_position_joint_interface_provider.cpp include/transmission_interface/bidirectional_position_joint_interface_provider.h
-  src/bidirectional_velocity_joint_interface_provider.cpp include/transmission_interface/bidirectional_velocity_joint_interface_provider.h
-  src/bidirectional_effort_joint_interface_provider.cpp   include/transmission_interface/bidirectional_effort_joint_interface_provider.h)
-target_link_libraries(${PROJECT_NAME}_loader_plugins ${PROJECT_NAME}_loader)
-
-
-#############
-## Install ##
-#############
-
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
-
-# Install library
-install(TARGETS ${PROJECT_NAME}_parser
-                ${PROJECT_NAME}_loader
-                ${PROJECT_NAME}_loader_plugins
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+  ${TinyXML_LIBRARIES}
 )
 
-install(FILES ros_control_plugins.xml
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+add_library(${PROJECT_NAME}_loader_plugins
+  include/transmission_interface/bidirectional_effort_joint_interface_provider.h
+  include/transmission_interface/bidirectional_position_joint_interface_provider.h
+  include/transmission_interface/bidirectional_velocity_joint_interface_provider.h
+  include/transmission_interface/differential_transmission_loader.h
+  include/transmission_interface/effort_joint_interface_provider.h
+  include/transmission_interface/four_bar_linkage_transmission_loader.h
+  include/transmission_interface/joint_state_interface_provider.h
+  include/transmission_interface/position_joint_interface_provider.h
+  include/transmission_interface/simple_transmission_loader.h
+  include/transmission_interface/velocity_joint_interface_provider.h
+  src/bidirectional_effort_joint_interface_provider.cpp
+  src/bidirectional_position_joint_interface_provider.cpp
+  src/bidirectional_velocity_joint_interface_provider.cpp
+  src/differential_transmission_loader.cpp
+  src/effort_joint_interface_provider.cpp
+  src/four_bar_linkage_transmission_loader.cpp
+  src/joint_state_interface_provider.cpp
+  src/position_joint_interface_provider.cpp
+  src/simple_transmission_loader.cpp
+  src/velocity_joint_interface_provider.cpp
+)
+target_link_libraries(${PROJECT_NAME}_loader_plugins ${PROJECT_NAME}_loader)
+
 
 #############
 ## Testing ##
 #############
 
 if(CATKIN_ENABLE_TESTING)
-
+  find_package(catkin REQUIRED COMPONENTS resource_retriever roscpp) # TODO: Investigate
   find_package(Boost REQUIRED COMPONENTS system thread)
-  find_package(catkin REQUIRED COMPONENTS resource_retriever roscpp)
 
-  catkin_add_gtest(simple_transmission_test test/simple_transmission_test.cpp)
-  target_link_libraries(simple_transmission_test ${Boost_LIBRARIES})
+  catkin_add_gtest(simple_transmission_test                       test/simple_transmission_test.cpp)
+  target_link_libraries(simple_transmission_test                  ${Boost_LIBRARIES})
 
-  catkin_add_gtest(differential_transmission_test test/differential_transmission_test.cpp)
-  target_link_libraries(differential_transmission_test ${Boost_LIBRARIES})
+  catkin_add_gtest(differential_transmission_test                 test/differential_transmission_test.cpp)
+  target_link_libraries(differential_transmission_test            ${Boost_LIBRARIES})
 
-  catkin_add_gtest(four_bar_linkage_transmission_test test/four_bar_linkage_transmission_test.cpp)
-  target_link_libraries(four_bar_linkage_transmission_test ${Boost_LIBRARIES})
+  catkin_add_gtest(four_bar_linkage_transmission_test             test/four_bar_linkage_transmission_test.cpp)
+  target_link_libraries(four_bar_linkage_transmission_test        ${Boost_LIBRARIES})
 
-  catkin_add_gtest(transmission_interface_test test/transmission_interface_test.cpp)
-  target_link_libraries(transmission_interface_test ${TinyXML_LIBRARIES} ${catkin_LIBRARIES})
+  catkin_add_gtest(transmission_interface_test                    test/transmission_interface_test.cpp)
+  target_link_libraries(transmission_interface_test               ${TinyXML_LIBRARIES} ${catkin_LIBRARIES})
 
-  catkin_add_gtest(transmission_parser_test test/transmission_parser_test.cpp)
-  target_link_libraries(transmission_parser_test ${PROJECT_NAME}_parser ${catkin_LIBRARIES})
+  catkin_add_gtest(transmission_parser_test                       test/transmission_parser_test.cpp)
+  target_link_libraries(transmission_parser_test                  ${PROJECT_NAME}_parser ${catkin_LIBRARIES})
 
-  catkin_add_gtest(simple_transmission_loader_test test/simple_transmission_loader_test.cpp)
-  target_link_libraries(simple_transmission_loader_test ${PROJECT_NAME}_parser ${catkin_LIBRARIES})
+  catkin_add_gtest(simple_transmission_loader_test                test/simple_transmission_loader_test.cpp)
+  target_link_libraries(simple_transmission_loader_test           ${PROJECT_NAME}_parser ${catkin_LIBRARIES})
 
-  catkin_add_gtest(differential_transmission_loader_test test/differential_transmission_loader_test.cpp)
-  target_link_libraries(differential_transmission_loader_test ${PROJECT_NAME}_parser ${catkin_LIBRARIES})
+  catkin_add_gtest(differential_transmission_loader_test          test/differential_transmission_loader_test.cpp)
+  target_link_libraries(differential_transmission_loader_test     ${PROJECT_NAME}_parser ${catkin_LIBRARIES})
 
-  catkin_add_gtest(four_bar_linkage_transmission_loader_test test/four_bar_linkage_transmission_loader_test.cpp)
+  catkin_add_gtest(four_bar_linkage_transmission_loader_test      test/four_bar_linkage_transmission_loader_test.cpp)
   target_link_libraries(four_bar_linkage_transmission_loader_test ${PROJECT_NAME}_parser ${catkin_LIBRARIES})
 
-  catkin_add_gtest(transmission_interface_loader_test test/transmission_interface_loader_test.cpp)
-  target_link_libraries(transmission_interface_loader_test ${PROJECT_NAME}_parser
-                                                          transmission_interface_loader
-                                                          ${catkin_LIBRARIES})
+  catkin_add_gtest(transmission_interface_loader_test             test/transmission_interface_loader_test.cpp)
+  target_link_libraries(transmission_interface_loader_test        ${PROJECT_NAME}_parser
+                                                                  transmission_interface_loader
+                                                                  ${catkin_LIBRARIES})
 endif()
+
+
+#############
+## Install ##
+#############
+
+# Install headers
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)
+
+# Install targets
+install(TARGETS ${PROJECT_NAME}_loader
+                ${PROJECT_NAME}_loader_plugins
+                ${PROJECT_NAME}_parser
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+)
+
+# Install plugins
+install(FILES ros_control_plugins.xml
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/transmission_interface/CMakeLists.txt
+++ b/transmission_interface/CMakeLists.txt
@@ -28,7 +28,7 @@ catkin_package(
     pluginlib
     roscpp
   DEPENDS
-    Boost # TODO: Should header-only dependencies be DEPENDS or INCLUDE_DIRS?
+    Boost
     TinyXML
 )
 

--- a/transmission_interface/CMakeLists.txt
+++ b/transmission_interface/CMakeLists.txt
@@ -24,9 +24,11 @@ catkin_package(
     ${PROJECT_NAME}_loader
     ${PROJECT_NAME}_loader_plugins
   CATKIN_DEPENDS
+    hardware_interface
     pluginlib
     roscpp
   DEPENDS
+    Boost # TODO: Should header-only dependencies be DEPENDS or INCLUDE_DIRS?
     TinyXML
 )
 

--- a/transmission_interface/package.xml
+++ b/transmission_interface/package.xml
@@ -17,17 +17,18 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <depend>tinyxml</depend>
-  <depend>roscpp</depend>
   <depend>pluginlib</depend>
-  <build_depend>hardware_interface</build_depend>
-  <build_depend>cmake_modules</build_depend>
+  <depend>roscpp</depend>
+  <depend>tinyxml</depend>
 
-  <test_depend>rosunit</test_depend>
+  <build_depend>cmake_modules</build_depend>
+  <build_depend>hardware_interface</build_depend>
+
   <test_depend>resource_retriever</test_depend>
+  <test_depend>rosunit</test_depend>
 
   <export>
     <rosdoc config="rosdoc.yaml"/>
-    <transmission_interface plugin="${prefix}/ros_control_plugins.xml" />
+    <transmission_interface plugin="${prefix}/ros_control_plugins.xml"/>
   </export>
 </package>

--- a/transmission_interface/package.xml
+++ b/transmission_interface/package.xml
@@ -17,13 +17,17 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <depend>boost</depend>
-  <depend>hardware_interface</depend>
-  <depend>pluginlib</depend>
   <depend>roscpp</depend>
   <depend>tinyxml</depend>
 
+  <build_depend>boost</build_depend>
   <build_depend>cmake_modules</build_depend>
+  <build_depend>hardware_interface</build_depend>
+  <build_depend>pluginlib</build_depend>
+
+  <build_export_depend>boost</build_export_depend>
+  <build_export_depend>hardware_interface</build_export_depend>
+  <build_export_depend>pluginlib</build_export_depend>
 
   <test_depend>resource_retriever</test_depend>
 

--- a/transmission_interface/package.xml
+++ b/transmission_interface/package.xml
@@ -17,12 +17,13 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <depend>boost</depend>
+  <depend>hardware_interface</depend>
   <depend>pluginlib</depend>
   <depend>roscpp</depend>
   <depend>tinyxml</depend>
 
   <build_depend>cmake_modules</build_depend>
-  <build_depend>hardware_interface</build_depend>
 
   <test_depend>resource_retriever</test_depend>
 

--- a/transmission_interface/package.xml
+++ b/transmission_interface/package.xml
@@ -25,7 +25,6 @@
   <build_depend>hardware_interface</build_depend>
 
   <test_depend>resource_retriever</test_depend>
-  <test_depend>rosunit</test_depend>
 
   <export>
     <rosdoc config="rosdoc.yaml"/>


### PR DESCRIPTION
Various fixes and formatting for `CMakeLists.txt` and `package.xml` files, including fixes suggested by `catkin_lint`.

---
#### Apply consistent format to CMakeLists.txt and package.xml files

The format is largely based on the existing files. The most important change is that this PR corrects the order of commands in the `CMakeLists.txt`.

I'm not at all attached to the format used in the CMakeLists.txt, happy to gut out the comments or make other stylistic changes as desired. I would mostly just like them to be consistent, as it makes it much easier to identify issues and to maintain.

----

#### Beyond stylistic changes, the following changes were made:

`combined_robot_hw`:
 - Remove unnecessary `boost` library dependency

`combined_robot_hw_tests`:
 - Remove unnecessary `boost` library dependency
 - Add missing `${catkin_EXPORTED_TARGETS}` dependency
 - Gut the `catkin_package()` and `install()` commands
 - Move all targets into the `if(CATKIN_ENABLE_TESTING)` block
 - Update package description
 - Add missing dependencies to `package.xml`

`controller_interface`:
 - Remove `rosunit` dependency (See note at bottom)
 - Remove unneeded pluginlib dependency

`controller_manager`:
 - Add missing `roscpp` dependency
 - Add missing `${catkin_EXPORTED_TARGETS}` dependency
 - Add missing `exec_depends` for python scripts

`controller_manager_msgs`:
 - Add missing `exec_depends` for python scripts

`controller_manager_tests`:
 - Remove unnecessary `boost` include_dir dependency
 - Add missing `hardware_interface` and `roscpp` dependencies
 - Add missing `${catkin_EXPORTED_TARGETS}` dependency
 - Gut the `catkin_package()` and `install()` commands
 - Move all targets into the `if(CATKIN_ENABLE_TESTING)` block
 - Update package description
 - Update dependencies in `package.xml`

`hardware_interface`:
 - Add missing `find_package(Boost REQUIRED)` for header-only library dependency `ptr_container`
 - Add missing `boost` depend in package.xml
 - Remove redundant `rosconsole` dependency (Already included via `roscpp`)
 - Remove unused `rostest` test_depend
 - Remove `rosunit` dependency (See note at bottom)

`joint_limits_interface`:
 - Remove `liburdfdom-dev` dependency (See https://github.com/ros-controls/ros_control/pull/404#discussion_r365019612)

`rqt_controller_manager`:
 - Install python scripts with `catkin_install_python()` rather than the default cmake `install()`
 - Update package description
 - Add missing dependencies

`transmission_interface`:
 - Add missing `find_package(Boost REQUIRED)` for header-only library dependency `lexical_cast`
 - Add missing `boost` depend in package.xml
 - Remove unused `Boost` dependencies in tests
 - Fix `find_package()` in tests, to not override previous `find_package(catkin [...])`. See https://github.com/ros/rosdistro/issues/3010#issuecomment-42116904

---

#### Notes:

I was unable to find up-to-date documentation on `rosunit` and the corresponding `catkin_add_gtest`/`catkin_add_gmock`. In particular, I don't know if it is necessary to `find_package(rosunit)` or `<test_depend>rosunit</test_depend>`. I believe the `find_package` is unecessary. I think the `test_depend` is required, but I'm not sure.

For header-only Boost libraries, I used `find_package(Boost REQUIRED)` and `include_directories(${Boost_INCLUDE_DIRS})`. I was not able to find any other examples of this use in large ROS packages, so I just wanted to highlight it here in case there's a better approach.

---

#### TODO:

Couple things I just want to look through before changing this from a draft to a normal PR:

 - ~Make sure `add_dependencies(${catkin_EXPORTED_TARGETS})` is used everywhere it's required~ Done in fa93166
 - ~Make sure `roscpp` is depended upon directly everywhere that it's required~ Done in 79b504c
 - ~Investigate the `urdf`/`liburdf-dev` situation, and see if things can be simplified~ Done in 7ca25ab