### PR TITLE
Use nullptr

### DIFF
--- a/combined_robot_hw_tests/test/combined_robot_hw_test.cpp
+++ b/combined_robot_hw_tests/test/combined_robot_hw_test.cpp
@@ -50,14 +50,14 @@ TEST(CombinedRobotHWTests, combinationOk)
   hardware_interface::HardwareInterface*              plain_hw_interface = robot_hw.get<hardware_interface::HardwareInterface>();
   hardware_interface::PositionJointInterface*         pj_interface = robot_hw.get<hardware_interface::PositionJointInterface>();
 
-  ASSERT_TRUE(js_interface != NULL);
-  ASSERT_TRUE(ej_interface != NULL);
-  ASSERT_TRUE(vj_interface != NULL);
-  ASSERT_TRUE(ft_interface != NULL);
-  ASSERT_TRUE(plain_hw_interface != NULL);
+  ASSERT_TRUE(js_interface != nullptr);
+  ASSERT_TRUE(ej_interface != nullptr);
+  ASSERT_TRUE(vj_interface != nullptr);
+  ASSERT_TRUE(ft_interface != nullptr);
+  ASSERT_TRUE(plain_hw_interface != nullptr);
 
   // Test that no PositionJointInterface was found
-  ASSERT_EQ(NULL, pj_interface);
+  ASSERT_EQ(nullptr, pj_interface);
 
   // Test some handles from my_robot_hw_1
   hardware_interface::JointStateHandle js_handle = js_interface->getHandle("test_joint1");

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -54,7 +54,7 @@ ControllerManager::ControllerManager(hardware_interface::RobotHW *robot_hw, cons
   used_by_realtime_(-1)
 {
   // create controller loader
-  controller_loaders_.push_back( 
+  controller_loaders_.push_back(
     ControllerLoaderInterfaceSharedPtr(new ControllerLoader<controller_interface::ControllerBase>("controller_interface",
                                                                                                   "controller_interface::ControllerBase") ) );
 
@@ -111,7 +111,7 @@ controller_interface::ControllerBase* ControllerManager::getControllerByName(con
     if (controllers[i].info.name == name)
       return controllers[i].c.get();
   }
-  return NULL;
+  return nullptr;
 }
 
 void ControllerManager::getControllerNames(std::vector<std::string> &names)
@@ -477,7 +477,7 @@ bool ControllerManager::switchController(const std::vector<std::string>& start_c
   for (unsigned int i=0; i<stop_controllers.size(); i++)
   {
     ct = getControllerByName(stop_controllers[i]);
-    if (ct == NULL){
+    if (ct == nullptr){
       if (strictness ==  controller_manager_msgs::SwitchController::Request::STRICT){
         ROS_ERROR("Could not stop controller with name '%s' because no controller with this name exists",
                   stop_controllers[i].c_str());
@@ -501,7 +501,7 @@ bool ControllerManager::switchController(const std::vector<std::string>& start_c
   for (unsigned int i=0; i<start_controllers.size(); i++)
   {
     ct = getControllerByName(start_controllers[i]);
-    if (ct == NULL){
+    if (ct == nullptr){
       if (strictness ==  controller_manager_msgs::SwitchController::Request::STRICT){
         ROS_ERROR("Could not start controller with name '%s' because no controller with this name exists",
                   start_controllers[i].c_str());

--- a/hardware_interface/include/hardware_interface/actuator_command_interface.h
+++ b/hardware_interface/include/hardware_interface/actuator_command_interface.h
@@ -40,7 +40,7 @@ namespace hardware_interface
 class ActuatorHandle : public ActuatorStateHandle
 {
 public:
-  ActuatorHandle() : ActuatorStateHandle(), cmd_(0) {}
+  ActuatorHandle() : ActuatorStateHandle(), cmd_(nullptr) {}
 
   /**
    * \param as This actuator's state handle

--- a/hardware_interface/include/hardware_interface/actuator_state_interface.h
+++ b/hardware_interface/include/hardware_interface/actuator_state_interface.h
@@ -37,15 +37,15 @@
 namespace hardware_interface
 {
 
-/** 
+/**
  * \brief A handle used to read the state of a single actuator.
- * Currently, position, velocity and effort fields are required 
+ * Currently, position, velocity and effort fields are required
  * while absolute position and torque sensors are optional.
  */
 class ActuatorStateHandle
 {
 public:
-  ActuatorStateHandle() : name_(), pos_(0), vel_(0), eff_(0), absolute_pos_(0), torque_sensor_(0) {}
+  ActuatorStateHandle() : name_(), pos_(nullptr), vel_(nullptr), eff_(nullptr), absolute_pos_(nullptr), torque_sensor_(nullptr) {}
 
   /**
    * \param name The name of the actuator
@@ -54,7 +54,7 @@ public:
    * \param eff A pointer to the storage for this actuator's effort (force or torque)
    */
   ActuatorStateHandle(const std::string& name, const double* pos, const double* vel, const double* eff)
-    : name_(name), pos_(pos), vel_(vel), eff_(eff), absolute_pos_(0), torque_sensor_(0)
+    : name_(name), pos_(pos), vel_(vel), eff_(eff), absolute_pos_(nullptr), torque_sensor_(nullptr)
   {
     if (!pos)
     {
@@ -114,7 +114,7 @@ public:
    */
   ActuatorStateHandle(const std::string& name, const double* pos, const double* vel, const double* eff,
                       const double* absolute_pos)
-    : name_(name), pos_(pos), vel_(vel), eff_(eff), absolute_pos_(absolute_pos), torque_sensor_(0)
+    : name_(name), pos_(pos), vel_(vel), eff_(eff), absolute_pos_(absolute_pos), torque_sensor_(nullptr)
   {
     if (!pos)
     {
@@ -144,7 +144,7 @@ public:
    */
   ActuatorStateHandle(const std::string& name, const double* pos, const double* vel, const double* eff,
                       const double* torque_sensor, bool)
-    : name_(name), pos_(pos), vel_(vel), eff_(eff), absolute_pos_(0), torque_sensor_(torque_sensor)
+    : name_(name), pos_(pos), vel_(vel), eff_(eff), absolute_pos_(nullptr), torque_sensor_(torque_sensor)
   {
     if (!pos)
     {
@@ -169,7 +169,7 @@ public:
   double getVelocity()  const {assert(vel_); return *vel_;}
   double getEffort()    const {assert(eff_); return *eff_;}
 
-  double getAbsolutePosition() const 
+  double getAbsolutePosition() const
   {
     if(!hasAbsolutePosition())
     {
@@ -178,7 +178,7 @@ public:
     return *absolute_pos_;
   }
 
-  double getTorqueSensor() const 
+  double getTorqueSensor() const
   {
     if(!hasTorqueSensor())
     {
@@ -191,7 +191,7 @@ public:
   const double* getVelocityPtr() const {return vel_;}
   const double* getEffortPtr()   const {return eff_;}
 
-  const double* getAbsolutePositionPtr() const 
+  const double* getAbsolutePositionPtr() const
   {
     if(!hasAbsolutePosition())
     {
@@ -200,7 +200,7 @@ public:
     return absolute_pos_;
   }
 
-  const double* getTorqueSensorPtr() const 
+  const double* getTorqueSensorPtr() const
   {
     if(!hasTorqueSensor())
     {

--- a/hardware_interface/include/hardware_interface/force_torque_sensor_interface.h
+++ b/hardware_interface/include/hardware_interface/force_torque_sensor_interface.h
@@ -40,7 +40,7 @@ namespace hardware_interface
 class ForceTorqueSensorHandle
 {
 public:
-  ForceTorqueSensorHandle() : name_(""), frame_id_(""), force_(0), torque_(0) {}
+  ForceTorqueSensorHandle() : name_(""), frame_id_(""), force_(nullptr), torque_(nullptr) {}
 
   /**
    * \param name The name of the sensor

--- a/hardware_interface/include/hardware_interface/imu_sensor_interface.h
+++ b/hardware_interface/include/hardware_interface/imu_sensor_interface.h
@@ -49,12 +49,12 @@ public:
     Data()
       : name(),
         frame_id(),
-        orientation(0),
-        orientation_covariance(0),
-        angular_velocity(0),
-        angular_velocity_covariance(0),
-        linear_acceleration(0),
-        linear_acceleration_covariance(0) {}
+        orientation(nullptr),
+        orientation_covariance(nullptr),
+        angular_velocity(nullptr),
+        angular_velocity_covariance(nullptr),
+        linear_acceleration(nullptr),
+        linear_acceleration_covariance(nullptr) {}
 
     std::string name;                       ///< The name of the sensor
     std::string frame_id;                   ///< The reference frame to which this sensor is associated

--- a/hardware_interface/include/hardware_interface/internal/demangle_symbol.h
+++ b/hardware_interface/include/hardware_interface/internal/demangle_symbol.h
@@ -51,7 +51,7 @@ inline std::string demangleSymbol(const char* name)
 {
   #if (__GNUC__ && __cplusplus && __GNUC__ >= 3)
     int         status;
-    char* res = abi::__cxa_demangle(name, 0, 0, &status);
+    char* res = abi::__cxa_demangle(name, nullptr, nullptr, &status);
     if (res)
     {
       const std::string demangled_name(res);

--- a/hardware_interface/include/hardware_interface/internal/interface_manager.h
+++ b/hardware_interface/include/hardware_interface/internal/interface_manager.h
@@ -67,7 +67,7 @@ struct CheckIsResourceManager {
 
   // calls ResourceManager::concatManagers if C is a ResourceManager
   static void callConcatManagers(typename std::vector<T*>& managers, T* result)
-  { callCM<T>(managers, result, 0); }
+  { callCM<T>(managers, result, nullptr); }
 
 
   // method called if C is a ResourceManager
@@ -83,7 +83,7 @@ struct CheckIsResourceManager {
 
   // calls ResourceManager::concatManagers if C is a ResourceManager
   static void callGetResources(std::vector<std::string> &resources, T* iface)
-  { return callGR<T>(resources, iface, 0); }
+  { return callGR<T>(resources, iface, nullptr); }
 
   template <typename C>
   static T* newCI(boost::ptr_vector<ResourceManagerBase> &guards, typename C::resource_manager_type*)
@@ -101,12 +101,12 @@ struct CheckIsResourceManager {
     ROS_ERROR("You cannot register multiple interfaces of the same type which are "
               "not of type ResourceManager. There is no established protocol "
               "for combining them.");
-    return NULL;
+    return nullptr;
   }
 
   static T* newCombinedInterface(boost::ptr_vector<ResourceManagerBase> &guards)
   {
-    return newCI<T>(guards, 0);
+    return newCI<T>(guards, nullptr);
   }
 
 };
@@ -165,7 +165,7 @@ public:
       if (!iface) {
         ROS_ERROR_STREAM("Failed reconstructing type T = '" << type_name.c_str() <<
                          "'. This should never happen");
-        return NULL;
+        return nullptr;
       }
       iface_list.push_back(iface);
     }
@@ -179,7 +179,7 @@ public:
     }
 
     if(iface_list.size() == 0)
-      return NULL;
+      return nullptr;
 
     if(iface_list.size() == 1)
       return iface_list.front();
@@ -208,7 +208,7 @@ public:
         ROS_ERROR("You cannot register multiple interfaces of the same type which are "
                   "not of type ResourceManager. There is no established protocol "
                   "for combining them.");
-        iface_combo = NULL;
+        iface_combo = nullptr;
       }
     }
     return iface_combo;

--- a/hardware_interface/include/hardware_interface/joint_command_interface.h
+++ b/hardware_interface/include/hardware_interface/joint_command_interface.h
@@ -42,7 +42,7 @@ namespace hardware_interface
 class JointHandle : public JointStateHandle
 {
 public:
-  JointHandle() : JointStateHandle(), cmd_(0) {}
+  JointHandle() : JointStateHandle(), cmd_(nullptr) {}
 
   /**
    * \param js This joint's state handle

--- a/hardware_interface/include/hardware_interface/joint_mode_interface.h
+++ b/hardware_interface/include/hardware_interface/joint_mode_interface.h
@@ -64,7 +64,7 @@ namespace hardware_interface
   public:
 
     JointModeHandle():
-      name_(), mode_(0){}
+      name_(), mode_(nullptr){}
 
     /** \param mode Which mode to start in */
     JointModeHandle(std::string name, JointCommandModes* mode)

--- a/hardware_interface/include/hardware_interface/joint_state_interface.h
+++ b/hardware_interface/include/hardware_interface/joint_state_interface.h
@@ -37,15 +37,15 @@
 namespace hardware_interface
 {
 
-/** 
+/**
  * \brief A handle used to read the state of a single joint.
- * Currently, position, velocity and effort fields are required 
+ * Currently, position, velocity and effort fields are required
  * while absolute position and torque sensors are optional.
  */
 class JointStateHandle
 {
 public:
-  JointStateHandle() : name_(), pos_(0), vel_(0), eff_(0), absolute_pos_(0), torque_sensor_(0) {}
+  JointStateHandle() : name_(), pos_(nullptr), vel_(nullptr), eff_(nullptr), absolute_pos_(nullptr), torque_sensor_(nullptr) {}
 
   /**
    * \param name The name of the joint
@@ -54,7 +54,7 @@ public:
    * \param eff A pointer to the storage for this joint's effort (force or torque)
    */
   JointStateHandle(const std::string& name, const double* pos, const double* vel, const double* eff)
-    : name_(name), pos_(pos), vel_(vel), eff_(eff), absolute_pos_(0), torque_sensor_(0)
+    : name_(name), pos_(pos), vel_(vel), eff_(eff), absolute_pos_(nullptr), torque_sensor_(nullptr)
   {
     if (!pos)
     {
@@ -113,7 +113,7 @@ public:
    */
   JointStateHandle(const std::string& name, const double* pos, const double* vel, const double* eff,
                    const double* absolute_pos)
-    : name_(name), pos_(pos), vel_(vel), eff_(eff), absolute_pos_(absolute_pos), torque_sensor_(0)
+    : name_(name), pos_(pos), vel_(vel), eff_(eff), absolute_pos_(absolute_pos), torque_sensor_(nullptr)
   {
     if (!pos)
     {
@@ -143,7 +143,7 @@ public:
    */
   JointStateHandle(const std::string& name, const double* pos, const double* vel, const double* eff,
                    const double* torque_sensor, bool)
-    : name_(name), pos_(pos), vel_(vel), eff_(eff), absolute_pos_(0), torque_sensor_(torque_sensor)
+    : name_(name), pos_(pos), vel_(vel), eff_(eff), absolute_pos_(nullptr), torque_sensor_(torque_sensor)
   {
     if (!pos)
     {
@@ -168,7 +168,7 @@ public:
   double getVelocity()  const {assert(vel_); return *vel_;}
   double getEffort()    const {assert(eff_); return *eff_;}
 
-  double getAbsolutePosition() const 
+  double getAbsolutePosition() const
   {
     if(!hasAbsolutePosition())
     {
@@ -177,7 +177,7 @@ public:
     return *absolute_pos_;
   }
 
-  double getTorqueSensor() const 
+  double getTorqueSensor() const
   {
     if(!hasTorqueSensor())
     {
@@ -199,7 +199,7 @@ public:
     return absolute_pos_;
   }
 
-  const double* getTorqueSensorPtr() const 
+  const double* getTorqueSensorPtr() const
   {
     if(!hasTorqueSensor())
     {

--- a/hardware_interface/include/hardware_interface/posvel_command_interface.h
+++ b/hardware_interface/include/hardware_interface/posvel_command_interface.h
@@ -42,7 +42,7 @@ namespace hardware_interface
 class PosVelJointHandle : public JointStateHandle
 {
 public:
-  PosVelJointHandle() : JointStateHandle(), cmd_pos_(0), cmd_vel_(0) {}
+  PosVelJointHandle() : JointStateHandle(), cmd_pos_(nullptr), cmd_vel_(nullptr) {}
 
   /**
    * \param js This joint's state handle

--- a/hardware_interface/include/hardware_interface/posvelacc_command_interface.h
+++ b/hardware_interface/include/hardware_interface/posvelacc_command_interface.h
@@ -42,7 +42,7 @@ namespace hardware_interface
 class PosVelAccJointHandle : public PosVelJointHandle
 {
 public:
-  PosVelAccJointHandle() : PosVelJointHandle(), cmd_acc_(0) {}
+  PosVelAccJointHandle() : PosVelJointHandle(), cmd_acc_(nullptr) {}
 
   /**
    * \param js This joint's state handle

--- a/hardware_interface/test/actuator_command_interface_test.cpp
+++ b/hardware_interface/test/actuator_command_interface_test.cpp
@@ -41,11 +41,11 @@ TEST(ActuatorCommandHandleTest, HandleConstruction)
   double pos, vel, eff;
   double cmd;
   EXPECT_NO_THROW(ActuatorHandle tmp(ActuatorStateHandle(name, &pos, &vel, &eff), &cmd));
-  EXPECT_THROW(ActuatorHandle tmp(ActuatorStateHandle(name, &pos, &vel, &eff), 0), HardwareInterfaceException);
+  EXPECT_THROW(ActuatorHandle tmp(ActuatorStateHandle(name, &pos, &vel, &eff), nullptr), HardwareInterfaceException);
 
   // Print error messages
   // Requires manual output inspection, but exception message should be descriptive
-  try {ActuatorHandle(ActuatorStateHandle(name, &pos, &vel, &eff), 0);}
+  try {ActuatorHandle(ActuatorStateHandle(name, &pos, &vel, &eff), nullptr);}
   catch(const HardwareInterfaceException& e) {ROS_ERROR_STREAM(e.what());}
 }
 
@@ -135,4 +135,3 @@ int main(int argc, char** argv)
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-

--- a/hardware_interface/test/actuator_state_interface_test.cpp
+++ b/hardware_interface/test/actuator_state_interface_test.cpp
@@ -40,19 +40,19 @@ TEST(ActuatorStateHandleTest, HandleConstruction)
   string name = "name1";
   double pos, vel, eff;
   EXPECT_NO_THROW(ActuatorStateHandle(name, &pos, &vel, &eff));
-  EXPECT_THROW(ActuatorStateHandle(name, 0, &vel, &eff), HardwareInterfaceException);
-  EXPECT_THROW(ActuatorStateHandle(name, &pos, 0, &eff), HardwareInterfaceException);
-  EXPECT_THROW(ActuatorStateHandle(name, &pos, &vel, 0), HardwareInterfaceException);
+  EXPECT_THROW(ActuatorStateHandle(name, nullptr, &vel, &eff), HardwareInterfaceException);
+  EXPECT_THROW(ActuatorStateHandle(name, &pos, nullptr, &eff), HardwareInterfaceException);
+  EXPECT_THROW(ActuatorStateHandle(name, &pos, &vel, nullptr), HardwareInterfaceException);
 
   // Print error messages
   // Requires manual output inspection, but exception message should be descriptive
-  try {ActuatorStateHandle(name, 0, &vel, &eff);}
+  try {ActuatorStateHandle(name, nullptr, &vel, &eff);}
   catch(const HardwareInterfaceException& e) {ROS_ERROR_STREAM(e.what());}
 
-  try {ActuatorStateHandle(name, &pos, 0, &eff);}
+  try {ActuatorStateHandle(name, &pos, nullptr, &eff);}
   catch(const HardwareInterfaceException& e) {ROS_ERROR_STREAM(e.what());}
 
-  try {ActuatorStateHandle(name, &pos, &vel, 0);}
+  try {ActuatorStateHandle(name, &pos, &vel, nullptr);}
   catch(const HardwareInterfaceException& e) {ROS_ERROR_STREAM(e.what());}
 }
 
@@ -130,4 +130,3 @@ int main(int argc, char** argv)
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-

--- a/hardware_interface/test/force_torque_sensor_interface_test.cpp
+++ b/hardware_interface/test/force_torque_sensor_interface_test.cpp
@@ -44,8 +44,8 @@ TEST(ForceTorqueSensorHandleTest, HandleConstruction)
     ForceTorqueSensorHandle handle;
     EXPECT_EQ("", handle.getName());
     EXPECT_EQ("", handle.getFrameId());
-    EXPECT_TRUE(0 == handle.getForce());
-    EXPECT_TRUE(0 == handle.getTorque());
+    EXPECT_TRUE(nullptr == handle.getForce());
+    EXPECT_TRUE(nullptr == handle.getTorque());
   }
 
   // Valid handle
@@ -65,7 +65,7 @@ public:
       name1("name_1"), name2("name_2"),
       frame_id1("frame_1"), frame_id2("frame_2"),
       h1(name1, frame_id1, force1, torque1),
-      h2(name2, frame_id2, 0, torque2) // Torque-only sensor
+      h2(name2, frame_id2, nullptr, torque2) // Torque-only sensor
   {
     force1[0] = 1.0;
     force1[1] = 2.0;
@@ -106,8 +106,8 @@ TEST_F(ForceTorqueSensorInterfaceTest, ExcerciseApi)
   ForceTorqueSensorHandle h1_tmp = iface.getHandle(name1);
   EXPECT_EQ(name1, h1_tmp.getName());
   EXPECT_EQ(frame_id1, h1_tmp.getFrameId());
-  EXPECT_TRUE(0 != h1_tmp.getForce());
-  EXPECT_TRUE(0 != h1_tmp.getTorque());
+  EXPECT_TRUE(nullptr != h1_tmp.getForce());
+  EXPECT_TRUE(nullptr != h1_tmp.getTorque());
   EXPECT_DOUBLE_EQ(force1[0], h1_tmp.getForce()[0]);
   EXPECT_DOUBLE_EQ(force1[1], h1_tmp.getForce()[1]);
   EXPECT_DOUBLE_EQ(force1[2], h1_tmp.getForce()[2]);
@@ -118,8 +118,8 @@ TEST_F(ForceTorqueSensorInterfaceTest, ExcerciseApi)
   ForceTorqueSensorHandle h2_tmp = iface.getHandle(name2);
   EXPECT_EQ(name2, h2_tmp.getName());
   EXPECT_EQ(frame_id2, h2_tmp.getFrameId());
-  EXPECT_TRUE(0 == h2_tmp.getForce());
-  EXPECT_TRUE(0 != h2_tmp.getTorque());
+  EXPECT_TRUE(nullptr == h2_tmp.getForce());
+  EXPECT_TRUE(nullptr != h2_tmp.getTorque());
   EXPECT_DOUBLE_EQ(torque2[0], h2_tmp.getTorque()[0]);
   EXPECT_DOUBLE_EQ(torque2[1], h2_tmp.getTorque()[1]);
   EXPECT_DOUBLE_EQ(torque2[2], h2_tmp.getTorque()[2]);

--- a/hardware_interface/test/imu_sensor_interface_test.cpp
+++ b/hardware_interface/test/imu_sensor_interface_test.cpp
@@ -44,12 +44,12 @@ TEST(ImuSensorHandleTest, HandleConstruction)
     ImuSensorHandle handle;
     EXPECT_EQ("", handle.getName());
     EXPECT_EQ("", handle.getFrameId());
-    EXPECT_TRUE(0 == handle.getOrientation());
-    EXPECT_TRUE(0 == handle.getOrientationCovariance());
-    EXPECT_TRUE(0 == handle.getAngularVelocity());
-    EXPECT_TRUE(0 == handle.getAngularVelocityCovariance());
-    EXPECT_TRUE(0 == handle.getLinearAcceleration());
-    EXPECT_TRUE(0 == handle.getLinearAccelerationCovariance());
+    EXPECT_TRUE(nullptr == handle.getOrientation());
+    EXPECT_TRUE(nullptr == handle.getOrientationCovariance());
+    EXPECT_TRUE(nullptr == handle.getAngularVelocity());
+    EXPECT_TRUE(nullptr == handle.getAngularVelocityCovariance());
+    EXPECT_TRUE(nullptr == handle.getLinearAcceleration());
+    EXPECT_TRUE(nullptr == handle.getLinearAccelerationCovariance());
   }
 
   // Valid handle
@@ -80,7 +80,7 @@ public:
     : name1("name_1"), name2("name_2"),
       frame_id1("frame_1"), frame_id2("frame_2")
   {
-    srand(time(NULL)); // Seed random number generator
+    srand(time(nullptr)); // Seed random number generator
 
     // Populate raw data
     for (unsigned int i = 0; i < 4; ++i)
@@ -153,12 +153,12 @@ TEST_F(ImuSensorInterfaceTest, ExcerciseApi)
   EXPECT_EQ(name1, h1_tmp.getName());
   EXPECT_EQ(frame_id1, h1_tmp.getFrameId());
 
-  EXPECT_TRUE(0 != h1_tmp.getOrientation());
-  EXPECT_TRUE(0 != h1_tmp.getOrientationCovariance());
-  EXPECT_TRUE(0 != h1_tmp.getAngularVelocity());
-  EXPECT_TRUE(0 != h1_tmp.getAngularVelocityCovariance());
-  EXPECT_TRUE(0 != h1_tmp.getLinearAcceleration());
-  EXPECT_TRUE(0 != h1_tmp.getLinearAccelerationCovariance());
+  EXPECT_TRUE(nullptr != h1_tmp.getOrientation());
+  EXPECT_TRUE(nullptr != h1_tmp.getOrientationCovariance());
+  EXPECT_TRUE(nullptr != h1_tmp.getAngularVelocity());
+  EXPECT_TRUE(nullptr != h1_tmp.getAngularVelocityCovariance());
+  EXPECT_TRUE(nullptr != h1_tmp.getLinearAcceleration());
+  EXPECT_TRUE(nullptr != h1_tmp.getLinearAccelerationCovariance());
 
   for (unsigned int i = 0; i < 4; ++i)
   {
@@ -182,12 +182,12 @@ TEST_F(ImuSensorInterfaceTest, ExcerciseApi)
   EXPECT_EQ(name2, h2_tmp.getName());
   EXPECT_EQ(frame_id2, h2_tmp.getFrameId());
 
-  EXPECT_TRUE(0 != h2_tmp.getOrientation());
-  EXPECT_TRUE(0 == h2_tmp.getOrientationCovariance());
-  EXPECT_TRUE(0 == h2_tmp.getAngularVelocity());
-  EXPECT_TRUE(0 == h2_tmp.getAngularVelocityCovariance());
-  EXPECT_TRUE(0 == h2_tmp.getLinearAcceleration());
-  EXPECT_TRUE(0 == h2_tmp.getLinearAccelerationCovariance());
+  EXPECT_TRUE(nullptr != h2_tmp.getOrientation());
+  EXPECT_TRUE(nullptr == h2_tmp.getOrientationCovariance());
+  EXPECT_TRUE(nullptr == h2_tmp.getAngularVelocity());
+  EXPECT_TRUE(nullptr == h2_tmp.getAngularVelocityCovariance());
+  EXPECT_TRUE(nullptr == h2_tmp.getLinearAcceleration());
+  EXPECT_TRUE(nullptr == h2_tmp.getLinearAccelerationCovariance());
 
   for (unsigned int i = 0; i < 4; ++i)
   {

--- a/hardware_interface/test/joint_command_interface_test.cpp
+++ b/hardware_interface/test/joint_command_interface_test.cpp
@@ -41,11 +41,11 @@ TEST(JointCommandHandleTest, HandleConstruction)
   double pos, vel, eff;
   double cmd;
   EXPECT_NO_THROW(JointHandle tmp(JointStateHandle(name, &pos, &vel, &eff), &cmd));
-  EXPECT_THROW(JointHandle tmp(JointStateHandle(name, &pos, &vel, &eff), 0), HardwareInterfaceException);
+  EXPECT_THROW(JointHandle tmp(JointStateHandle(name, &pos, &vel, &eff), nullptr), HardwareInterfaceException);
 
   // Print error messages
   // Requires manual output inspection, but exception message should be descriptive
-  try {JointHandle tmp(JointStateHandle(name, &pos, &vel, &eff), 0);}
+  try {JointHandle tmp(JointStateHandle(name, &pos, &vel, &eff), nullptr);}
   catch(const HardwareInterfaceException& e) {ROS_ERROR_STREAM(e.what());}
 }
 
@@ -130,4 +130,3 @@ int main(int argc, char** argv)
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-

--- a/hardware_interface/test/joint_state_interface_test.cpp
+++ b/hardware_interface/test/joint_state_interface_test.cpp
@@ -40,19 +40,19 @@ TEST(JointStateHandleTest, HandleConstruction)
   string name = "name1";
   double pos, vel, eff;
   EXPECT_NO_THROW(JointStateHandle tmp(name, &pos, &vel, &eff));
-  EXPECT_THROW(JointStateHandle(name, 0, &vel, &eff), HardwareInterfaceException);
-  EXPECT_THROW(JointStateHandle(name, &pos, 0, &eff), HardwareInterfaceException);
-  EXPECT_THROW(JointStateHandle(name, &pos, &vel, 0), HardwareInterfaceException);
+  EXPECT_THROW(JointStateHandle(name, nullptr, &vel, &eff), HardwareInterfaceException);
+  EXPECT_THROW(JointStateHandle(name, &pos, nullptr, &eff), HardwareInterfaceException);
+  EXPECT_THROW(JointStateHandle(name, &pos, &vel, nullptr), HardwareInterfaceException);
 
   // Print error messages
   // Requires manual output inspection, but exception message should be descriptive
-  try {JointStateHandle(name, 0, &vel, &eff);}
+  try {JointStateHandle(name, nullptr, &vel, &eff);}
   catch(const HardwareInterfaceException& e) {ROS_ERROR_STREAM(e.what());}
 
-  try {JointStateHandle(name, &pos, 0, &eff);}
+  try {JointStateHandle(name, &pos, nullptr, &eff);}
   catch(const HardwareInterfaceException& e) {ROS_ERROR_STREAM(e.what());}
 
-  try {JointStateHandle(name, &pos, &vel, 0);}
+  try {JointStateHandle(name, &pos, &vel, nullptr);}
   catch(const HardwareInterfaceException& e) {ROS_ERROR_STREAM(e.what());}
 
 }

--- a/hardware_interface/test/posvel_command_interface_test.cpp
+++ b/hardware_interface/test/posvel_command_interface_test.cpp
@@ -41,12 +41,12 @@ TEST(PosVelCommandHandleTest, HandleConstruction)
   double pos, vel, eff;
   double cmd_pos, cmd_vel;
   EXPECT_NO_THROW(PosVelJointHandle tmp(JointStateHandle(name, &pos, &vel, &eff), &cmd_pos, &cmd_vel));
-  EXPECT_THROW(PosVelJointHandle tmp(JointStateHandle(name, &pos, &vel, &eff), 0, &cmd_vel), HardwareInterfaceException);
-  EXPECT_THROW(PosVelJointHandle tmp(JointStateHandle(name, &pos, &vel, &eff), &cmd_pos, 0), HardwareInterfaceException);
+  EXPECT_THROW(PosVelJointHandle tmp(JointStateHandle(name, &pos, &vel, &eff), nullptr, &cmd_vel), HardwareInterfaceException);
+  EXPECT_THROW(PosVelJointHandle tmp(JointStateHandle(name, &pos, &vel, &eff), &cmd_pos, nullptr), HardwareInterfaceException);
 
   // Print error messages
   // Requires manual output inspection, but exception message should be descriptive
-  try {PosVelJointHandle tmp(JointStateHandle(name, &pos, &vel, &eff), 0, 0);}
+  try {PosVelJointHandle tmp(JointStateHandle(name, &pos, &vel, &eff), nullptr, nullptr);}
   catch(const HardwareInterfaceException& e) {ROS_ERROR_STREAM(e.what());}
 }
 
@@ -141,4 +141,3 @@ int main(int argc, char** argv)
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-

--- a/hardware_interface/test/posvelacc_command_interface_test.cpp
+++ b/hardware_interface/test/posvelacc_command_interface_test.cpp
@@ -41,13 +41,13 @@ TEST(PosVelAccCommandHandleTest, HandleConstruction)
   double pos, vel, eff;
   double cmd_pos, cmd_vel, cmd_acc;
   EXPECT_NO_THROW(PosVelAccJointHandle tmp(JointStateHandle(name, &pos, &vel, &eff), &cmd_pos, &cmd_vel, &cmd_acc));
-  EXPECT_THROW(PosVelAccJointHandle tmp(JointStateHandle(name, &pos, &vel, &eff), 0, &cmd_vel, &cmd_acc), HardwareInterfaceException);
-  EXPECT_THROW(PosVelAccJointHandle tmp(JointStateHandle(name, &pos, &vel, &eff), &cmd_pos, 0, &cmd_acc), HardwareInterfaceException);
-  EXPECT_THROW(PosVelAccJointHandle tmp(JointStateHandle(name, &pos, &vel, &eff), &cmd_pos, &cmd_vel, 0), HardwareInterfaceException);
+  EXPECT_THROW(PosVelAccJointHandle tmp(JointStateHandle(name, &pos, &vel, &eff), nullptr, &cmd_vel, &cmd_acc), HardwareInterfaceException);
+  EXPECT_THROW(PosVelAccJointHandle tmp(JointStateHandle(name, &pos, &vel, &eff), &cmd_pos, nullptr, &cmd_acc), HardwareInterfaceException);
+  EXPECT_THROW(PosVelAccJointHandle tmp(JointStateHandle(name, &pos, &vel, &eff), &cmd_pos, &cmd_vel, nullptr), HardwareInterfaceException);
 
   // Print error messages
   // Requires manual output inspection, but exception message should be descriptive
-  try {PosVelAccJointHandle tmp(JointStateHandle(name, &pos, &vel, &eff), 0, 0, 0);}
+  try {PosVelAccJointHandle tmp(JointStateHandle(name, &pos, &vel, &eff), nullptr, nullptr, nullptr);}
   catch(const HardwareInterfaceException& e) {ROS_ERROR_STREAM(e.what());}
 }
 
@@ -147,4 +147,3 @@ int main(int argc, char** argv)
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-

--- a/joint_limits_interface/include/joint_limits_interface/joint_limits_interface.h
+++ b/joint_limits_interface/include/joint_limits_interface/joint_limits_interface.h
@@ -295,16 +295,16 @@ public:
     {
       const double pos = jh_.getPosition();
       if (pos < limits_.min_position)
-        min_eff = 0;
+        min_eff = 0.0;
       else if (pos > limits_.max_position)
-        max_eff = 0;
+        max_eff = 0.0;
     }
 
     const double vel = jh_.getVelocity();
     if (vel < -limits_.max_velocity)
-      min_eff = 0;
+      min_eff = 0.0;
     else if (vel > limits_.max_velocity)
-      max_eff = 0;
+      max_eff = 0.0;
 
     jh_.setCommand(internal::saturate(jh_.getCommand(), min_eff, max_eff));
   }

--- a/transmission_interface/include/transmission_interface/transmission_interface_loader.h
+++ b/transmission_interface/include/transmission_interface/transmission_interface_loader.h
@@ -162,8 +162,8 @@ struct InverseTransmissionInterfaces
 struct TransmissionLoaderData
 {
   TransmissionLoaderData()
-    : robot_hw(0),
-      robot_transmissions(0)
+    : robot_hw(nullptr),
+      robot_transmissions(nullptr)
   {}
 
   hardware_interface::RobotHW*  robot_hw;            ///< Lifecycle is externally controlled (ie. hardware abstraction)

--- a/transmission_interface/src/transmission_parser.cpp
+++ b/transmission_interface/src/transmission_parser.cpp
@@ -53,7 +53,7 @@ bool TransmissionParser::parse(const std::string& urdf, std::vector<Transmission
   TiXmlElement *root = doc.RootElement();
 
   // Constructs the transmissions by parsing custom xml.
-  TiXmlElement *trans_it = NULL;
+  TiXmlElement *trans_it = nullptr;
   for (trans_it = root->FirstChildElement("transmission"); trans_it;
        trans_it = trans_it->NextSiblingElement("transmission"))
   {
@@ -123,7 +123,7 @@ bool TransmissionParser::parse(const std::string& urdf, std::vector<Transmission
 bool TransmissionParser::parseJoints(TiXmlElement *trans_it, std::vector<JointInfo>& joints)
 {
   // Loop through each available joint
-  TiXmlElement *joint_it = NULL;
+  TiXmlElement *joint_it = nullptr;
   for (joint_it = trans_it->FirstChildElement("joint"); joint_it;
        joint_it = joint_it->NextSiblingElement("joint"))
   {
@@ -153,7 +153,7 @@ bool TransmissionParser::parseJoints(TiXmlElement *trans_it, std::vector<JointIn
     }
 
     // Hardware interfaces (required)
-    TiXmlElement *hw_iface_it = NULL;
+    TiXmlElement *hw_iface_it = nullptr;
     for (hw_iface_it = joint_it->FirstChildElement("hardwareInterface"); hw_iface_it;
          hw_iface_it = hw_iface_it->NextSiblingElement("hardwareInterface"))
     {
@@ -195,7 +195,7 @@ bool TransmissionParser::parseJoints(TiXmlElement *trans_it, std::vector<JointIn
 bool TransmissionParser::parseActuators(TiXmlElement *trans_it, std::vector<ActuatorInfo>& actuators)
 {
   // Loop through each available actuator
-  TiXmlElement *actuator_it = NULL;
+  TiXmlElement *actuator_it = nullptr;
   for (actuator_it = trans_it->FirstChildElement("actuator"); actuator_it;
        actuator_it = actuator_it->NextSiblingElement("actuator"))
   {
@@ -219,7 +219,7 @@ bool TransmissionParser::parseActuators(TiXmlElement *trans_it, std::vector<Actu
     }
 
     // Hardware interfaces (optional)
-    TiXmlElement *hw_iface_it = NULL;
+    TiXmlElement *hw_iface_it = nullptr;
     for (hw_iface_it = actuator_it->FirstChildElement("hardwareInterface"); hw_iface_it;
          hw_iface_it = hw_iface_it->NextSiblingElement("hardwareInterface"))
     {

--- a/transmission_interface/test/differential_transmission_loader_test.cpp
+++ b/transmission_interface/test/differential_transmission_loader_test.cpp
@@ -46,16 +46,16 @@ TEST(DifferentialTransmissionLoaderTest, FullSpec)
   // Transmission loader
   TransmissionPluginLoader loader;
   TransmissionLoaderSharedPtr transmission_loader = loader.create(infos.front().type_);
-  ASSERT_TRUE(0 != transmission_loader);
+  ASSERT_TRUE(nullptr != transmission_loader);
 
   TransmissionSharedPtr transmission;
   const TransmissionInfo& info = infos.front();
   transmission = transmission_loader->load(info);
-  ASSERT_TRUE(0 != transmission);
+  ASSERT_TRUE(nullptr != transmission);
 
   // Validate transmission
   DifferentialTransmission* differential_transmission = dynamic_cast<DifferentialTransmission*>(transmission.get());
-  ASSERT_TRUE(0 != differential_transmission);
+  ASSERT_TRUE(nullptr != differential_transmission);
 
   const std::vector<double>& actuator_reduction = differential_transmission->getActuatorReduction();
   EXPECT_EQ( 50.0, actuator_reduction[0]);
@@ -79,12 +79,12 @@ TEST(DifferentialTransmissionLoaderTest, MinimalSpec)
   // Transmission loader
   TransmissionPluginLoader loader;
   TransmissionLoaderSharedPtr transmission_loader = loader.create(infos.front().type_);
-  ASSERT_TRUE(0 != transmission_loader);
+  ASSERT_TRUE(nullptr != transmission_loader);
 
   TransmissionSharedPtr transmission;
   const TransmissionInfo& info = infos.front();
   transmission = transmission_loader->load(info);
-  ASSERT_TRUE(0 != transmission);
+  ASSERT_TRUE(nullptr != transmission);
 
   // Validate transmission
   DifferentialTransmission* differential_transmission = dynamic_cast<DifferentialTransmission*>(transmission.get());
@@ -111,13 +111,13 @@ TEST(DifferentialTransmissionLoaderTest, InvalidSpec)
   // Transmission loader
   TransmissionPluginLoader loader;
   TransmissionLoaderSharedPtr transmission_loader = loader.create(infos.front().type_);
-  ASSERT_TRUE(0 != transmission_loader);
+  ASSERT_TRUE(nullptr != transmission_loader);
 
   for (const TransmissionInfo& info : infos)
   {
     TransmissionSharedPtr transmission;
     transmission = transmission_loader->load(info);
-    ASSERT_TRUE(0 == transmission);
+    ASSERT_TRUE(nullptr == transmission);
   }
 }
 

--- a/transmission_interface/test/four_bar_linkage_transmission_loader_test.cpp
+++ b/transmission_interface/test/four_bar_linkage_transmission_loader_test.cpp
@@ -46,17 +46,17 @@ TEST(FourBarLinkageTransmissionLoaderTest, FullSpec)
   // Transmission loader
   TransmissionPluginLoader loader;
   TransmissionLoaderSharedPtr transmission_loader = loader.create(infos.front().type_);
-  ASSERT_TRUE(0 != transmission_loader);
+  ASSERT_TRUE(nullptr != transmission_loader);
 
   TransmissionSharedPtr transmission;
   const TransmissionInfo& info = infos.front();
   transmission = transmission_loader->load(info);
-  ASSERT_TRUE(0 != transmission);
+  ASSERT_TRUE(nullptr != transmission);
 
   // Validate transmission
   FourBarLinkageTransmission* four_bar_linkage_transmission =
   dynamic_cast<FourBarLinkageTransmission*>(transmission.get());
-  ASSERT_TRUE(0 != four_bar_linkage_transmission);
+  ASSERT_TRUE(nullptr != four_bar_linkage_transmission);
 
   const std::vector<double>& actuator_reduction = four_bar_linkage_transmission->getActuatorReduction();
   EXPECT_EQ( 50.0, actuator_reduction[0]);
@@ -80,12 +80,12 @@ TEST(FourBarLinkageTransmissionLoaderTest, MinimalSpec)
   // Transmission loader
   TransmissionPluginLoader loader;
   TransmissionLoaderSharedPtr transmission_loader = loader.create(infos.front().type_);
-  ASSERT_TRUE(0 != transmission_loader);
+  ASSERT_TRUE(nullptr != transmission_loader);
 
   TransmissionSharedPtr transmission;
   const TransmissionInfo& info = infos.front();
   transmission = transmission_loader->load(info);
-  ASSERT_TRUE(0 != transmission);
+  ASSERT_TRUE(nullptr != transmission);
 
   // Validate transmission
   FourBarLinkageTransmission* four_bar_linkage_transmission =
@@ -113,13 +113,13 @@ TEST(FourBarLinkageTransmissionLoaderTest, InvalidSpec)
   // Transmission loader
   TransmissionPluginLoader loader;
   TransmissionLoaderSharedPtr transmission_loader = loader.create(infos.front().type_);
-  ASSERT_TRUE(0 != transmission_loader);
+  ASSERT_TRUE(nullptr != transmission_loader);
 
   for (const TransmissionInfo& info : infos)
   {
     TransmissionSharedPtr transmission;
     transmission = transmission_loader->load(info);
-    ASSERT_TRUE(0 == transmission);
+    ASSERT_TRUE(nullptr == transmission);
   }
 }
 

--- a/transmission_interface/test/random_generator_utils.h
+++ b/transmission_interface/test/random_generator_utils.h
@@ -44,7 +44,7 @@ struct RandomDoubleGenerator
 public:
   RandomDoubleGenerator(double min_val, double max_val)
     : min_val_(min_val),
-      max_val_(max_val) {srand(time(NULL));}
+      max_val_(max_val) {srand(time(nullptr));}
   double operator()()
   {
     const double range = max_val_ - min_val_;

--- a/transmission_interface/test/simple_transmission_loader_test.cpp
+++ b/transmission_interface/test/simple_transmission_loader_test.cpp
@@ -46,17 +46,17 @@ TEST(SimpleTransmissionLoaderTest, FullSpec)
   // Transmission loader
   TransmissionPluginLoader loader;
   TransmissionLoaderSharedPtr transmission_loader = loader.create(infos.front().type_);
-  ASSERT_TRUE(0 != transmission_loader);
+  ASSERT_TRUE(nullptr != transmission_loader);
 
   TransmissionSharedPtr transmission;
   const TransmissionInfo& info = infos.front();
   transmission = transmission_loader->load(info);
-  ASSERT_TRUE(0 != transmission);
+  ASSERT_TRUE(nullptr != transmission);
   ASSERT_STREQ(infos.front().joints_.front().role_.c_str(),"");
 
   // Validate transmission
   SimpleTransmission* simple_transmission = dynamic_cast<SimpleTransmission*>(transmission.get());
-  ASSERT_TRUE(0 != simple_transmission);
+  ASSERT_TRUE(nullptr != simple_transmission);
   EXPECT_EQ(50.0, simple_transmission->getActuatorReduction());
   EXPECT_EQ( 0.5, simple_transmission->getJointOffset());
 }
@@ -70,16 +70,16 @@ TEST(SimpleTransmissionLoaderTest, MinimalSpec)
   // Transmission loader
   TransmissionPluginLoader loader;
   TransmissionLoaderSharedPtr transmission_loader = loader.create(infos.front().type_);
-  ASSERT_TRUE(0 != transmission_loader);
+  ASSERT_TRUE(nullptr != transmission_loader);
 
   TransmissionSharedPtr transmission;
   const TransmissionInfo& info = infos.front();
   transmission = transmission_loader->load(info);
-  ASSERT_TRUE(0 != transmission);
+  ASSERT_TRUE(nullptr != transmission);
 
   // Validate transmission
   SimpleTransmission* simple_transmission = dynamic_cast<SimpleTransmission*>(transmission.get());
-  ASSERT_TRUE(0 != simple_transmission);
+  ASSERT_TRUE(nullptr != simple_transmission);
   EXPECT_EQ(50.0, simple_transmission->getActuatorReduction());
   EXPECT_EQ( 0.0, simple_transmission->getJointOffset());
 }
@@ -93,13 +93,13 @@ TEST(SimpleTransmissionLoaderTest, InvalidSpec)
   // Transmission loader
   TransmissionPluginLoader loader;
   TransmissionLoaderSharedPtr transmission_loader = loader.create(infos.front().type_);
-  ASSERT_TRUE(0 != transmission_loader);
+  ASSERT_TRUE(nullptr != transmission_loader);
 
   for (const TransmissionInfo& info : infos)
   {
     TransmissionSharedPtr transmission;
     transmission = transmission_loader->load(info);
-    ASSERT_TRUE(0 == transmission);
+    ASSERT_TRUE(nullptr == transmission);
   }
 }
 

--- a/transmission_interface/test/transmission_interface_loader_test.cpp
+++ b/transmission_interface/test/transmission_interface_loader_test.cpp
@@ -118,8 +118,8 @@ protected:
 
 TEST_F(TransmissionInterfaceLoaderTest, InvalidConstruction)
 {
-  EXPECT_THROW(TransmissionInterfaceLoader(0, &robot_transmissions), std::invalid_argument);
-  EXPECT_THROW(TransmissionInterfaceLoader(&robot_hw, 0), std::invalid_argument);
+  EXPECT_THROW(TransmissionInterfaceLoader(nullptr, &robot_transmissions), std::invalid_argument);
+  EXPECT_THROW(TransmissionInterfaceLoader(&robot_hw, nullptr), std::invalid_argument);
 }
 
 TEST_F(TransmissionInterfaceLoaderTest, UnsupportedTransmissionType)
@@ -220,7 +220,7 @@ TEST_F(TransmissionInterfaceLoaderTest, AccessorValidation)
 
   // Validate raw data accessor
   TransmissionLoaderData* loader_data_ptr = trans_iface_loader.getData();
-  ASSERT_TRUE(0 != loader_data_ptr);
+  ASSERT_TRUE(nullptr != loader_data_ptr);
   ASSERT_TRUE(&robot_hw == loader_data_ptr->robot_hw);
   ASSERT_TRUE(&robot_transmissions == loader_data_ptr->robot_transmissions);
   ASSERT_EQ(3, loader_data_ptr->raw_joint_data_map.size());
@@ -271,28 +271,27 @@ TEST_F(TransmissionInterfaceLoaderTest, SuccessfulLoad)
   PositionActuatorInterface* act_pos_cmd_iface = robot_hw.get<PositionActuatorInterface>();
   VelocityActuatorInterface* act_vel_cmd_iface = robot_hw.get<VelocityActuatorInterface>();
   EffortActuatorInterface*   act_eff_cmd_iface = robot_hw.get<EffortActuatorInterface>();
-  ASSERT_TRUE(0 != act_pos_cmd_iface);
-  ASSERT_TRUE(0 != act_vel_cmd_iface);
-  ASSERT_TRUE(0 != act_eff_cmd_iface);
+  ASSERT_TRUE(nullptr != act_pos_cmd_iface);
+  ASSERT_TRUE(nullptr != act_vel_cmd_iface);
+  ASSERT_TRUE(nullptr != act_eff_cmd_iface);
 
   // Joint interfaces
   PositionJointInterface* pos_jnt_iface = robot_hw.get<PositionJointInterface>();
   VelocityJointInterface* vel_jnt_iface = robot_hw.get<VelocityJointInterface>();
   EffortJointInterface*   eff_jnt_iface = robot_hw.get<EffortJointInterface>();
-  ASSERT_TRUE(0 != pos_jnt_iface);
-  ASSERT_TRUE(0 != vel_jnt_iface);
-  ASSERT_TRUE(0 != eff_jnt_iface);
+  ASSERT_TRUE(nullptr != pos_jnt_iface);
+  ASSERT_TRUE(nullptr != vel_jnt_iface);
+  ASSERT_TRUE(nullptr != eff_jnt_iface);
 
   // Transmission interfaces
   ActuatorToJointStateInterface*    act_to_jnt_state   = robot_transmissions.get<ActuatorToJointStateInterface>();
   JointToActuatorPositionInterface* jnt_to_act_pos_cmd = robot_transmissions.get<JointToActuatorPositionInterface>();
   JointToActuatorVelocityInterface* jnt_to_act_vel_cmd = robot_transmissions.get<JointToActuatorVelocityInterface>();
   JointToActuatorEffortInterface*   jnt_to_act_eff_cmd = robot_transmissions.get<JointToActuatorEffortInterface>();
-
-  ASSERT_TRUE(0 != act_to_jnt_state);
-  ASSERT_TRUE(0 != jnt_to_act_pos_cmd);
-  ASSERT_TRUE(0 != jnt_to_act_vel_cmd);
-  ASSERT_TRUE(0 != jnt_to_act_eff_cmd);
+  ASSERT_TRUE(nullptr != act_to_jnt_state);
+  ASSERT_TRUE(nullptr != jnt_to_act_pos_cmd);
+  ASSERT_TRUE(nullptr != jnt_to_act_vel_cmd);
+  ASSERT_TRUE(nullptr != jnt_to_act_eff_cmd);
 
   // Actuator handles
   ASSERT_NO_THROW(act_pos_cmd_iface->getHandle(info_red.actuators_.front().name_));
@@ -419,41 +418,39 @@ TEST_F(TransmissionInterfaceLoaderTest, SuccessfulLoadReversible)
   VelocityActuatorInterface* act_vel_cmd_iface = robot_hw.get<VelocityActuatorInterface>();
   EffortActuatorInterface*   act_eff_cmd_iface = robot_hw.get<EffortActuatorInterface>();
   ActuatorStateInterface*    act_state_iface   = robot_hw.get<ActuatorStateInterface>();
-  ASSERT_TRUE(0 != act_pos_cmd_iface);
-  ASSERT_TRUE(0 != act_vel_cmd_iface);
-  ASSERT_TRUE(0 != act_eff_cmd_iface);
-  ASSERT_TRUE(0 != act_state_iface);
+  ASSERT_TRUE(nullptr != act_pos_cmd_iface);
+  ASSERT_TRUE(nullptr != act_vel_cmd_iface);
+  ASSERT_TRUE(nullptr != act_eff_cmd_iface);
+  ASSERT_TRUE(nullptr != act_state_iface);
 
   // Joint interfaces
   PositionJointInterface* pos_jnt_iface = robot_hw.get<PositionJointInterface>();
   VelocityJointInterface* vel_jnt_iface = robot_hw.get<VelocityJointInterface>();
   EffortJointInterface*   eff_jnt_iface = robot_hw.get<EffortJointInterface>();
   JointStateInterface*    state_jnt_iface = robot_hw.get<JointStateInterface>();
-  ASSERT_TRUE(0 != pos_jnt_iface);
-  ASSERT_TRUE(0 != vel_jnt_iface);
-  ASSERT_TRUE(0 != eff_jnt_iface);
+  ASSERT_TRUE(nullptr != pos_jnt_iface);
+  ASSERT_TRUE(nullptr != vel_jnt_iface);
+  ASSERT_TRUE(nullptr != eff_jnt_iface);
 
   // Forward Transmission interfaces
   ActuatorToJointStateInterface*    act_to_jnt_state   = robot_transmissions.get<ActuatorToJointStateInterface>();
   JointToActuatorPositionInterface* jnt_to_act_pos_cmd = robot_transmissions.get<JointToActuatorPositionInterface>();
   JointToActuatorVelocityInterface* jnt_to_act_vel_cmd = robot_transmissions.get<JointToActuatorVelocityInterface>();
   JointToActuatorEffortInterface*   jnt_to_act_eff_cmd = robot_transmissions.get<JointToActuatorEffortInterface>();
+  ASSERT_TRUE(nullptr != act_to_jnt_state);
+  ASSERT_TRUE(nullptr != jnt_to_act_pos_cmd);
+  ASSERT_TRUE(nullptr != jnt_to_act_vel_cmd);
+  ASSERT_TRUE(nullptr != jnt_to_act_eff_cmd);
 
   // Inverse Transmission interfaces
   JointToActuatorStateInterface*    jnt_to_act_state   = robot_transmissions.get<JointToActuatorStateInterface>();
   ActuatorToJointPositionInterface* act_to_jnt_pos_cmd = robot_transmissions.get<ActuatorToJointPositionInterface>();
   ActuatorToJointVelocityInterface* act_to_jnt_vel_cmd = robot_transmissions.get<ActuatorToJointVelocityInterface>();
   ActuatorToJointEffortInterface*   act_to_jnt_eff_cmd = robot_transmissions.get<ActuatorToJointEffortInterface>();
-
-  ASSERT_TRUE(0 != act_to_jnt_state);
-  ASSERT_TRUE(0 != jnt_to_act_pos_cmd);
-  ASSERT_TRUE(0 != jnt_to_act_vel_cmd);
-  ASSERT_TRUE(0 != jnt_to_act_eff_cmd);
-
-  ASSERT_TRUE(0 != jnt_to_act_state);
-  ASSERT_TRUE(0 != act_to_jnt_pos_cmd);
-  ASSERT_TRUE(0 != act_to_jnt_vel_cmd);
-  ASSERT_TRUE(0 != act_to_jnt_eff_cmd);
+  ASSERT_TRUE(nullptr != jnt_to_act_state);
+  ASSERT_TRUE(nullptr != act_to_jnt_pos_cmd);
+  ASSERT_TRUE(nullptr != act_to_jnt_vel_cmd);
+  ASSERT_TRUE(nullptr != act_to_jnt_eff_cmd);
 
   // Actuator handles
   ASSERT_NO_THROW(act_pos_cmd_iface->getHandle(info_red.actuators_.front().name_));

--- a/transmission_interface/test/transmission_interface_test.cpp
+++ b/transmission_interface/test/transmission_interface_test.cpp
@@ -167,7 +167,7 @@ TEST(HandlePreconditionsTest, BadTransmissionPointer)
   a_data.position = good_vec;
   j_data.position = good_vec;
 
-  EXPECT_THROW(DummyHandle("trans", 0, a_data, j_data), TransmissionInterfaceException);
+  EXPECT_THROW(DummyHandle("trans", nullptr, a_data, j_data), TransmissionInterfaceException);
 }
 
 TEST(HandlePreconditionsTest, BadDataPointer)


### PR DESCRIPTION
Part of #403.

Use `nullptr` instead of 0 or `NULL` for null pointers.

Replacements were done using `clang-tidy` and good-ol' ctrl-f. Found 166 replacements :)
