### PR TITLE
Use #pragma once

### DIFF
--- a/combined_robot_hw/include/combined_robot_hw/combined_robot_hw.h
+++ b/combined_robot_hw/include/combined_robot_hw/combined_robot_hw.h
@@ -25,8 +25,8 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //////////////////////////////////////////////////////////////////////////////
 
-#ifndef COMBINED_ROBOT_HW_COMBINED_ROBOT_HW_H
-#define COMBINED_ROBOT_HW_COMBINED_ROBOT_HW_H
+#pragma once
+
 
 #include <list>
 #include <map>
@@ -117,5 +117,3 @@ protected:
 };
 
 }
-
-#endif

--- a/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_1.h
+++ b/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_1.h
@@ -25,10 +25,8 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //////////////////////////////////////////////////////////////////////////////
 
+#pragma once
 
-
-#ifndef CONTROLLER_MANAGER_TESTS_MY_ROBOT_HW_1_H
-#define CONTROLLER_MANAGER_TESTS_MY_ROBOT_HW_1_H
 
 #include <hardware_interface/joint_command_interface.h>
 #include <hardware_interface/robot_hw.h>
@@ -65,6 +63,3 @@ private:
   std::vector<std::string> joint_name_;
 };
 }
-
-
-#endif

--- a/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_2.h
+++ b/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_2.h
@@ -25,10 +25,8 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //////////////////////////////////////////////////////////////////////////////
 
+#pragma once
 
-
-#ifndef CONTROLLER_MANAGER_TESTS_MY_ROBOT_HW_2_H
-#define CONTROLLER_MANAGER_TESTS_MY_ROBOT_HW_2_H
 
 #include <hardware_interface/joint_command_interface.h>
 #include <hardware_interface/robot_hw.h>
@@ -65,6 +63,3 @@ private:
   std::vector<std::string> joint_name_;
 };
 }
-
-
-#endif

--- a/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_3.h
+++ b/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_3.h
@@ -25,10 +25,8 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //////////////////////////////////////////////////////////////////////////////
 
+#pragma once
 
-
-#ifndef CONTROLLER_MANAGER_TESTS_MY_ROBOT_HW_3_H
-#define CONTROLLER_MANAGER_TESTS_MY_ROBOT_HW_3_H
 
 #include <hardware_interface/joint_command_interface.h>
 #include <hardware_interface/robot_hw.h>
@@ -61,6 +59,3 @@ private:
   std::vector<std::string> joint_name_;
 };
 }
-
-
-#endif

--- a/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_4.h
+++ b/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_4.h
@@ -25,10 +25,8 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //////////////////////////////////////////////////////////////////////////////
 
+#pragma once
 
-
-#ifndef CONTROLLER_MANAGER_TESTS_MY_ROBOT_HW_4_H
-#define CONTROLLER_MANAGER_TESTS_MY_ROBOT_HW_4_H
 
 #include <hardware_interface/force_torque_sensor_interface.h>
 #include <hardware_interface/robot_hw.h>
@@ -62,6 +60,3 @@ private:
   std::string frame_id_;
 };
 }
-
-
-#endif

--- a/controller_interface/include/controller_interface/controller.h
+++ b/controller_interface/include/controller_interface/controller.h
@@ -29,8 +29,8 @@
  * Author: Wim Meeussen
  */
 
-#ifndef CONTROLLER_INTERFACE_CONTROLLER_H
-#define CONTROLLER_INTERFACE_CONTROLLER_H
+#pragma once
+
 
 #include <controller_interface/controller_base.h>
 #include <hardware_interface/internal/demangle_symbol.h>
@@ -145,5 +145,3 @@ private:
 };
 
 }
-
-#endif

--- a/controller_interface/include/controller_interface/controller_base.h
+++ b/controller_interface/include/controller_interface/controller_base.h
@@ -29,9 +29,8 @@
  * Author: Wim Meeussen
  */
 
+#pragma once
 
-#ifndef CONTROLLER_INTERFACE_CONTROLLER_BASE_H
-#define CONTROLLER_INTERFACE_CONTROLLER_BASE_H
 
 #include <ros/node_handle.h>
 #include <hardware_interface/robot_hw.h>
@@ -250,6 +249,3 @@ private:
 typedef std::shared_ptr<ControllerBase> ControllerBaseSharedPtr;
 
 }
-
-
-#endif

--- a/controller_interface/include/controller_interface/internal/robothw_interfaces.h
+++ b/controller_interface/include/controller_interface/internal/robothw_interfaces.h
@@ -28,8 +28,8 @@
 
 /** \author Adolfo Rodríguez Tsouroukdissian */
 
-#ifndef CONTROLLER_INTERFACE_INTERNAL_ROBOTHW_INTERFACES_H
-#define CONTROLLER_INTERFACE_INTERNAL_ROBOTHW_INTERFACES_H
+#pragma once
+
 
 #include <algorithm>
 #include <sstream>
@@ -146,5 +146,3 @@ inline void populateClaimedResources(hardware_interface::RobotHW*      robot_hw,
 /** \endcond */
 
 } // namespace
-
-#endif  // CONTROLLER_INTERFACE_INTERNAL_ROBOTHW_INTERFACES_H

--- a/controller_interface/include/controller_interface/multi_interface_controller.h
+++ b/controller_interface/include/controller_interface/multi_interface_controller.h
@@ -27,8 +27,8 @@
 
 /** \author Adolfo Rodríguez Tsouroukdissian */
 
-#ifndef CONTROLLER_INTERFACE_MULTI_INTERFACE_CONTROLLER_H
-#define CONTROLLER_INTERFACE_MULTI_INTERFACE_CONTROLLER_H
+#pragma once
+
 
 #include <controller_interface/controller_base.h>
 #include <controller_interface/internal/robothw_interfaces.h>
@@ -347,5 +347,3 @@ private:
 };
 
 } // namespace
-
-#endif

--- a/controller_manager/include/controller_manager/controller_loader.h
+++ b/controller_manager/include/controller_manager/controller_loader.h
@@ -25,8 +25,8 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //////////////////////////////////////////////////////////////////////////////
 
-#ifndef CONRTOLLER_MANAGER_CONTROLLER_LOADER_H
-#define CONRTOLLER_MANAGER_CONTROLLER_LOADER_H
+#pragma once
+
 
 #include <pluginlib/class_loader.hpp>
 #include <controller_manager/controller_loader_interface.h>
@@ -78,5 +78,3 @@ private:
 };
 
 }
-
-#endif

--- a/controller_manager/include/controller_manager/controller_loader_interface.h
+++ b/controller_manager/include/controller_manager/controller_loader_interface.h
@@ -25,8 +25,8 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //////////////////////////////////////////////////////////////////////////////
 
-#ifndef CONRTOLLER_MANAGER_CONTROLLER_LOADER_INTERFACE_H
-#define CONRTOLLER_MANAGER_CONTROLLER_LOADER_INTERFACE_H
+#pragma once
+
 
 #include <vector>
 #include <string>
@@ -59,5 +59,3 @@ private:
 typedef std::shared_ptr<ControllerLoaderInterface> ControllerLoaderInterfaceSharedPtr;
 
 }
-
-#endif

--- a/controller_manager/include/controller_manager/controller_manager.h
+++ b/controller_manager/include/controller_manager/controller_manager.h
@@ -29,9 +29,8 @@
  * Author: Wim Meeussen
  */
 
+#pragma once
 
-#ifndef CONTROLLER_MANAGER_CONTROLLER_MANAGER_H
-#define CONTROLLER_MANAGER_CONTROLLER_MANAGER_H
 
 #include "controller_manager/controller_spec.h"
 #include <cstdio>
@@ -252,4 +251,3 @@ private:
 };
 
 }
-#endif

--- a/controller_manager/include/controller_manager/controller_spec.h
+++ b/controller_manager/include/controller_manager/controller_spec.h
@@ -29,11 +29,9 @@
  * Author: Wim Meeussen
  */
 
-
-#ifndef CONTROLLER_MANAGER_CONTROLLER_SPEC_H
-#define CONTROLLER_MANAGER_CONTROLLER_SPEC_H
-
+#pragma once
 #pragma GCC diagnostic ignored "-Wextra"
+
 
 #include <map>
 #include <string>
@@ -57,6 +55,3 @@ struct ControllerSpec
 };
 
 }
-
-#endif
-

--- a/controller_manager_tests/include/controller_manager_tests/effort_test_controller.h
+++ b/controller_manager_tests/include/controller_manager_tests/effort_test_controller.h
@@ -25,8 +25,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //////////////////////////////////////////////////////////////////////////////
 
-#ifndef CONTROLLER_MANAGER_TESTS_EFFORT_TEST_CONTROLLER_H
-#define CONTROLLER_MANAGER_TESTS_EFFORT_TEST_CONTROLLER_H
+#pragma once
 
 
 #include <controller_interface/controller.h>
@@ -55,5 +54,3 @@ private:
 };
 
 }
-
-#endif

--- a/controller_manager_tests/include/controller_manager_tests/extensible_controllers.h
+++ b/controller_manager_tests/include/controller_manager_tests/extensible_controllers.h
@@ -25,8 +25,8 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //////////////////////////////////////////////////////////////////////////////
 
-#ifndef CONTROLLER_MANAGER_TESTS_EXTENSIBLE_CONTROLLERS_H
-#define CONTROLLER_MANAGER_TESTS_EXTENSIBLE_CONTROLLERS_H
+#pragma once
+
 
 #include <controller_interface/multi_interface_controller.h>
 #include <hardware_interface/joint_command_interface.h>
@@ -65,5 +65,3 @@ public:
 };
 
 }  // namespace controller_manager_tests
-
-#endif  // CONTROLLER_MANAGER_TESTS_EXTENSIBLE_CONTROLLERS_H

--- a/controller_manager_tests/include/controller_manager_tests/my_dummy_controller.h
+++ b/controller_manager_tests/include/controller_manager_tests/my_dummy_controller.h
@@ -27,8 +27,8 @@
 
 //! \author Vijay Pradeep
 
-#ifndef CONTROLLER_MANAGER_TESTS_MY_DUMMY_CONTROLLER_H
-#define CONTROLLER_MANAGER_TESTS_MY_DUMMY_CONTROLLER_H
+#pragma once
+
 
 #include <controller_interface/controller.h>
 #include <hardware_interface/hardware_interface.h>
@@ -59,5 +59,3 @@ public:
 };
 
 }
-
-#endif

--- a/controller_manager_tests/include/controller_manager_tests/my_robot_hw.h
+++ b/controller_manager_tests/include/controller_manager_tests/my_robot_hw.h
@@ -29,9 +29,8 @@
  * Author: Wim Meeussen
  */
 
+#pragma once
 
-#ifndef CONTROLLER_MANAGER_TESTS_MY_ROBOT_HW_H
-#define CONTROLLER_MANAGER_TESTS_MY_ROBOT_HW_H
 
 #include <hardware_interface/joint_command_interface.h>
 #include <hardware_interface/robot_hw.h>
@@ -62,6 +61,3 @@ private:
   std::vector<std::string> joint_name_;
 };
 }
-
-
-#endif

--- a/controller_manager_tests/include/controller_manager_tests/pos_eff_controller.h
+++ b/controller_manager_tests/include/controller_manager_tests/pos_eff_controller.h
@@ -25,8 +25,8 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //////////////////////////////////////////////////////////////////////////////
 
-#ifndef CONTROLLER_MANAGER_TESTS_POS_EFF_CONTROLLER_H
-#define CONTROLLER_MANAGER_TESTS_POS_EFF_CONTROLLER_H
+#pragma once
+
 
 #include <controller_interface/multi_interface_controller.h>
 #include <hardware_interface/joint_command_interface.h>
@@ -53,5 +53,3 @@ private:
 };
 
 }
-
-#endif

--- a/controller_manager_tests/include/controller_manager_tests/pos_eff_opt_controller.h
+++ b/controller_manager_tests/include/controller_manager_tests/pos_eff_opt_controller.h
@@ -25,8 +25,8 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //////////////////////////////////////////////////////////////////////////////
 
-#ifndef CONTROLLER_MANAGER_TESTS_POS_EFF_OPT_CONTROLLER_H
-#define CONTROLLER_MANAGER_TESTS_POS_EFF_OPT_CONTROLLER_H
+#pragma once
+
 
 #include <controller_interface/multi_interface_controller.h>
 #include <hardware_interface/joint_command_interface.h>
@@ -56,5 +56,3 @@ private:
 };
 
 }
-
-#endif

--- a/controller_manager_tests/include/controller_manager_tests/vel_eff_controller.h
+++ b/controller_manager_tests/include/controller_manager_tests/vel_eff_controller.h
@@ -25,8 +25,8 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //////////////////////////////////////////////////////////////////////////////
 
-#ifndef CONTROLLER_MANAGER_TESTS_VEL_EFF_CONTROLLER_H
-#define CONTROLLER_MANAGER_TESTS_VEL_EFF_CONTROLLER_H
+#pragma once
+
 
 #include <controller_interface/multi_interface_controller.h>
 #include <hardware_interface/joint_command_interface.h>
@@ -53,5 +53,3 @@ private:
 };
 
 }
-
-#endif

--- a/hardware_interface/include/hardware_interface/actuator_command_interface.h
+++ b/hardware_interface/include/hardware_interface/actuator_command_interface.h
@@ -26,8 +26,8 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //////////////////////////////////////////////////////////////////////////////
 
-#ifndef HARDWARE_INTERFACE_ACTUATOR_COMMAND_INTERFACE_H
-#define HARDWARE_INTERFACE_ACTUATOR_COMMAND_INTERFACE_H
+#pragma once
+
 
 #include <string>
 #include <hardware_interface/internal/hardware_resource_manager.h>
@@ -85,5 +85,3 @@ class VelocityActuatorInterface : public ActuatorCommandInterface {};
 class PositionActuatorInterface : public ActuatorCommandInterface {};
 
 }
-
-#endif

--- a/hardware_interface/include/hardware_interface/actuator_state_interface.h
+++ b/hardware_interface/include/hardware_interface/actuator_state_interface.h
@@ -28,8 +28,8 @@
 
 /// \author Wim Meeussen
 
-#ifndef HARDWARE_INTERFACE_ACTUATOR_STATE_INTERFACE_H
-#define HARDWARE_INTERFACE_ACTUATOR_STATE_INTERFACE_H
+#pragma once
+
 
 #include <hardware_interface/internal/hardware_resource_manager.h>
 #include <string>
@@ -231,5 +231,3 @@ private:
 class ActuatorStateInterface : public HardwareResourceManager<ActuatorStateHandle> {};
 
 }
-
-#endif

--- a/hardware_interface/include/hardware_interface/controller_info.h
+++ b/hardware_interface/include/hardware_interface/controller_info.h
@@ -25,9 +25,8 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //////////////////////////////////////////////////////////////////////////////
 
+#pragma once
 
-#ifndef HARDWARE_INTERFACE_CONTROLLER_INFO_H
-#define HARDWARE_INTERFACE_CONTROLLER_INFO_H
 
 #include <string>
 #include <vector>
@@ -55,5 +54,3 @@ struct ControllerInfo
 };
 
 }
-
-#endif

--- a/hardware_interface/include/hardware_interface/force_torque_sensor_interface.h
+++ b/hardware_interface/include/hardware_interface/force_torque_sensor_interface.h
@@ -27,8 +27,8 @@
 
 /// \author: Adolfo Rodriguez Tsouroukdissian
 
-#ifndef HARDWARE_INTERFACE_FORCE_CONTROL_SENSOR_INTERFACE_H
-#define HARDWARE_INTERFACE_FORCE_CONTROL_SENSOR_INTERFACE_H
+#pragma once
+
 
 #include <hardware_interface/internal/hardware_resource_manager.h>
 #include <string>
@@ -86,5 +86,3 @@ private:
 class ForceTorqueSensorInterface : public HardwareResourceManager<ForceTorqueSensorHandle> {};
 
 }
-
-#endif // HARDWARE_INTERFACE_FORCE_CONTROL_SENSOR_INTERFACE_H

--- a/hardware_interface/include/hardware_interface/hardware_interface.h
+++ b/hardware_interface/include/hardware_interface/hardware_interface.h
@@ -29,9 +29,8 @@
  * Author: Wim Meeussen
  */
 
+#pragma once
 
-#ifndef HARDWARE_INTERFACE_HARDWARE_INTERFACE_H
-#define HARDWARE_INTERFACE_HARDWARE_INTERFACE_H
 
 #include <exception>
 #include <string>
@@ -87,6 +86,3 @@ private:
   std::string msg;
 };
 }
-
-
-#endif

--- a/hardware_interface/include/hardware_interface/imu_sensor_interface.h
+++ b/hardware_interface/include/hardware_interface/imu_sensor_interface.h
@@ -27,8 +27,8 @@
 
 /// \author: Adolfo Rodriguez Tsouroukdissian
 
-#ifndef HARDWARE_INTERFACE_IMU_SENSOR_INTERFACE_H
-#define HARDWARE_INTERFACE_IMU_SENSOR_INTERFACE_H
+#pragma once
+
 
 #include <hardware_interface/internal/hardware_resource_manager.h>
 #include <string>
@@ -122,5 +122,3 @@ private:
 class ImuSensorInterface : public HardwareResourceManager<ImuSensorHandle> {};
 
 }
-
-#endif // HARDWARE_INTERFACE_IMU_SENSOR_INTERFACE_H

--- a/hardware_interface/include/hardware_interface/interface_resources.h
+++ b/hardware_interface/include/hardware_interface/interface_resources.h
@@ -25,9 +25,8 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //////////////////////////////////////////////////////////////////////////////
 
+#pragma once
 
-#ifndef HARDWARE_INTERFACE_INTERFACE_RESOURCES_H
-#define HARDWARE_INTERFACE_INTERFACE_RESOURCES_H
 
 #include <set>
 #include <string>
@@ -57,5 +56,3 @@ struct InterfaceResources
 };
 
 }
-
-#endif

--- a/hardware_interface/include/hardware_interface/internal/demangle_symbol.h
+++ b/hardware_interface/include/hardware_interface/internal/demangle_symbol.h
@@ -27,8 +27,8 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
-#ifndef HARDWARE_INTERFACE_INTERNAL_DEMANGLE_SYMBOL_H
-#define HARDWARE_INTERFACE_INTERNAL_DEMANGLE_SYMBOL_H
+#pragma once
+
 
 #include <cstdlib>
 #include <string>
@@ -88,5 +88,3 @@ inline std::string demangledTypeName(const T& val)
 }
 
 }
-
-#endif // HARDWARE_INTERFACE_INTERNAL_DEMANGLE_SYMBOL_H

--- a/hardware_interface/include/hardware_interface/internal/hardware_resource_manager.h
+++ b/hardware_interface/include/hardware_interface/internal/hardware_resource_manager.h
@@ -27,8 +27,8 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
-#ifndef HARDWARE_INTERFACE_HARDWARE_RESOURCE_MANAGER_H
-#define HARDWARE_INTERFACE_HARDWARE_RESOURCE_MANAGER_H
+#pragma once
+
 
 #include <string>
 
@@ -126,5 +126,3 @@ struct DontClaimResources
 /** \endcond */
 
 }
-
-#endif // HARDWARE_INTERFACE_HARDWARE_RESOURCE_MANAGER_H

--- a/hardware_interface/include/hardware_interface/internal/interface_manager.h
+++ b/hardware_interface/include/hardware_interface/internal/interface_manager.h
@@ -28,8 +28,8 @@
 
 /// \author Wim Meussen, Adolfo Rodriguez Tsouroukdissian, Kelsey P. Hawkins, Toni Oliver
 
-#ifndef HARDWARE_INTERFACE_INTERFACE_MANAGER_H
-#define HARDWARE_INTERFACE_INTERFACE_MANAGER_H
+#pragma once
+
 
 #include <map>
 #include <string>
@@ -260,5 +260,3 @@ protected:
 };
 
 } // namespace
-
-#endif // header guard

--- a/hardware_interface/include/hardware_interface/internal/resource_manager.h
+++ b/hardware_interface/include/hardware_interface/internal/resource_manager.h
@@ -28,8 +28,8 @@
 
 /// \author Wim Meeussen, Adolfo Rodriguez Tsouroukdissian
 
-#ifndef HARDWARE_INTERFACE_RESOURCE_MANAGER_H
-#define HARDWARE_INTERFACE_RESOURCE_MANAGER_H
+#pragma once
+
 
 #include <stdexcept>
 #include <string>
@@ -154,5 +154,3 @@ protected:
 };
 
 }
-
-#endif // HARDWARE_INTERFACE_RESOURCE_MANAGER_H

--- a/hardware_interface/include/hardware_interface/joint_command_interface.h
+++ b/hardware_interface/include/hardware_interface/joint_command_interface.h
@@ -27,8 +27,8 @@
 
 /// \author Wim Meeussen
 
-#ifndef HARDWARE_INTERFACE_JOINT_COMMAND_INTERFACE_H
-#define HARDWARE_INTERFACE_JOINT_COMMAND_INTERFACE_H
+#pragma once
+
 
 #include <cassert>
 #include <string>
@@ -88,5 +88,3 @@ class VelocityJointInterface : public JointCommandInterface {};
 class PositionJointInterface : public JointCommandInterface {};
 
 }
-
-#endif

--- a/hardware_interface/include/hardware_interface/joint_mode_interface.h
+++ b/hardware_interface/include/hardware_interface/joint_mode_interface.h
@@ -39,6 +39,7 @@
 
 #pragma once
 
+
 #include <cassert>
 #include <hardware_interface/internal/hardware_resource_manager.h>
 

--- a/hardware_interface/include/hardware_interface/joint_state_interface.h
+++ b/hardware_interface/include/hardware_interface/joint_state_interface.h
@@ -27,8 +27,8 @@
 
 /// \author Wim Meeussen
 
-#ifndef HARDWARE_INTERFACE_JOINT_STATE_INTERFACE_H
-#define HARDWARE_INTERFACE_JOINT_STATE_INTERFACE_H
+#pragma once
+
 
 #include <hardware_interface/internal/hardware_resource_manager.h>
 #include <cassert>
@@ -230,5 +230,3 @@ private:
 class JointStateInterface : public HardwareResourceManager<JointStateHandle> {};
 
 }
-
-#endif

--- a/hardware_interface/include/hardware_interface/posvel_command_interface.h
+++ b/hardware_interface/include/hardware_interface/posvel_command_interface.h
@@ -27,8 +27,8 @@
 
 /// \author Igor Kalevatykh
 
-#ifndef HARDWARE_INTERFACE_POSVEL_COMMAND_INTERFACE_H
-#define HARDWARE_INTERFACE_POSVEL_COMMAND_INTERFACE_H
+#pragma once
+
 
 #include <cassert>
 #include <string>
@@ -90,5 +90,3 @@ private:
 class PosVelJointInterface : public HardwareResourceManager<PosVelJointHandle, ClaimResources> {};
 
 }
-
-#endif /*HARDWARE_INTERFACE_POSVEL_COMMAND_INTERFACE_H*/

--- a/hardware_interface/include/hardware_interface/posvelacc_command_interface.h
+++ b/hardware_interface/include/hardware_interface/posvelacc_command_interface.h
@@ -27,8 +27,8 @@
 
 /// \author Igor Kalevatykh
 
-#ifndef HARDWARE_INTERFACE_POSVELACC_COMMAND_INTERFACE_H
-#define HARDWARE_INTERFACE_POSVELACC_COMMAND_INTERFACE_H
+#pragma once
+
 
 #include <cassert>
 #include <string>
@@ -85,5 +85,3 @@ private:
 class PosVelAccJointInterface : public HardwareResourceManager<PosVelAccJointHandle, ClaimResources> {};
 
 }
-
-#endif /*HARDWARE_INTERFACE_POSVELACC_COMMAND_INTERFACE_H*/

--- a/hardware_interface/include/hardware_interface/robot_hw.h
+++ b/hardware_interface/include/hardware_interface/robot_hw.h
@@ -25,8 +25,8 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //////////////////////////////////////////////////////////////////////////////
 
-#ifndef HARDWARE_INTERFACE_ROBOT_HW_H
-#define HARDWARE_INTERFACE_ROBOT_HW_H
+#pragma once
+
 
 #include <list>
 #include <map>
@@ -187,6 +187,3 @@ public:
 typedef std::shared_ptr<RobotHW> RobotHWSharedPtr;
 
 }
-
-#endif
-

--- a/joint_limits_interface/include/joint_limits_interface/joint_limits.h
+++ b/joint_limits_interface/include/joint_limits_interface/joint_limits.h
@@ -27,8 +27,8 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
-#ifndef JOINT_LIMITS_INTERFACE_JOINT_LIMITS_H
-#define JOINT_LIMITS_INTERFACE_JOINT_LIMITS_H
+#pragma once
+
 
 namespace joint_limits_interface
 {
@@ -81,5 +81,3 @@ struct SoftJointLimits
 };
 
 }
-
-#endif

--- a/joint_limits_interface/include/joint_limits_interface/joint_limits_interface.h
+++ b/joint_limits_interface/include/joint_limits_interface/joint_limits_interface.h
@@ -28,8 +28,8 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
-#ifndef JOINT_LIMITS_INTERFACE_JOINT_LIMITS_INTERFACE_H
-#define JOINT_LIMITS_INTERFACE_JOINT_LIMITS_INTERFACE_H
+#pragma once
+
 
 #include <algorithm>
 #include <cassert>
@@ -617,5 +617,3 @@ class VelocityJointSaturationInterface : public JointLimitsInterface<VelocityJoi
 class VelocityJointSoftLimitsInterface : public JointLimitsInterface<VelocityJointSoftLimitsHandle> {};
 
 }
-
-#endif

--- a/joint_limits_interface/include/joint_limits_interface/joint_limits_interface_exception.h
+++ b/joint_limits_interface/include/joint_limits_interface/joint_limits_interface_exception.h
@@ -25,8 +25,8 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //////////////////////////////////////////////////////////////////////////////
 
-#ifndef JOINT_LIMITS_INTERFACE_JOINT_LIMITS_INTERFACE_EXCEPTION_H
-#define JOINT_LIMITS_INTERFACE_JOINT_LIMITS_INTERFACE_EXCEPTION_H
+#pragma once
+
 
 namespace joint_limits_interface
 {
@@ -50,5 +50,3 @@ private:
 };
 
 }
-
-#endif

--- a/joint_limits_interface/include/joint_limits_interface/joint_limits_rosparam.h
+++ b/joint_limits_interface/include/joint_limits_interface/joint_limits_rosparam.h
@@ -27,8 +27,8 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
-#ifndef JOINT_LIMITS_INTERFACE_JOINT_LIMITS_ROSPARAM_H
-#define JOINT_LIMITS_INTERFACE_JOINT_LIMITS_ROSPARAM_H
+#pragma once
+
 
 #include <string>
 
@@ -230,5 +230,3 @@ inline bool getSoftJointLimits(const std::string& joint_name, const ros::NodeHan
 }
 
 }
-
-#endif

--- a/joint_limits_interface/include/joint_limits_interface/joint_limits_urdf.h
+++ b/joint_limits_interface/include/joint_limits_interface/joint_limits_urdf.h
@@ -27,8 +27,8 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
-#ifndef JOINT_LIMITS_INTERFACE_JOINT_LIMITS_URDF_H
-#define JOINT_LIMITS_INTERFACE_JOINT_LIMITS_URDF_H
+#pragma once
+
 
 #include <ros/common.h>
 #include <urdf_model/joint.h>
@@ -97,5 +97,3 @@ inline bool getSoftJointLimits(urdf::JointConstSharedPtr urdf_joint, SoftJointLi
 }
 
 }
-
-#endif

--- a/transmission_interface/include/transmission_interface/bidirectional_effort_joint_interface_provider.h
+++ b/transmission_interface/include/transmission_interface/bidirectional_effort_joint_interface_provider.h
@@ -25,8 +25,8 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //////////////////////////////////////////////////////////////////////////////
 
-#ifndef TRANSMISSION_INTERFACE_BIDIRECTIONAL_EFFORT_JOINT_INTERFACE_PROVIDER_H
-#define TRANSMISSION_INTERFACE_BIDIRECTIONAL_EFFORT_JOINT_INTERFACE_PROVIDER_H
+#pragma once
+
 
 // ros_control
 #include <transmission_interface/transmission_info.h>
@@ -38,11 +38,9 @@ namespace transmission_interface
 class BiDirectionalEffortJointInterfaceProvider : public EffortJointInterfaceProvider
 {
 protected:
-  
-  bool registerTransmission(TransmissionLoaderData& loader_data, 
+
+  bool registerTransmission(TransmissionLoaderData& loader_data,
                             TransmissionHandleData& handle_data);
 };
 
 } // namespace
-
-#endif // header guard

--- a/transmission_interface/include/transmission_interface/bidirectional_position_joint_interface_provider.h
+++ b/transmission_interface/include/transmission_interface/bidirectional_position_joint_interface_provider.h
@@ -25,8 +25,8 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //////////////////////////////////////////////////////////////////////////////
 
-#ifndef TRANSMISSION_INTERFACE_BIDIRECTIONAL_POSITION_JOINT_INTERFACE_PROVIDER_H
-#define TRANSMISSION_INTERFACE_BIDIRECTIONAL_POSITION_JOINT_INTERFACE_PROVIDER_H
+#pragma once
+
 
 // ros_control
 #include <transmission_interface/transmission_info.h>
@@ -39,10 +39,8 @@ class BiDirectionalPositionJointInterfaceProvider : public PositionJointInterfac
 {
 protected:
 
-  bool registerTransmission(TransmissionLoaderData& loader_data, 
+  bool registerTransmission(TransmissionLoaderData& loader_data,
                             TransmissionHandleData& handle_data);
 };
 
 } // namespace
-
-#endif // header guard

--- a/transmission_interface/include/transmission_interface/bidirectional_velocity_joint_interface_provider.h
+++ b/transmission_interface/include/transmission_interface/bidirectional_velocity_joint_interface_provider.h
@@ -25,8 +25,8 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //////////////////////////////////////////////////////////////////////////////
 
-#ifndef TRANSMISSION_INTERFACE_BIDIRECTIONAL_VELOCITY_JOINT_INTERFACE_PROVIDER_H
-#define TRANSMISSION_INTERFACE_BIDIRECTIONAL_VELOCITY_JOINT_INTERFACE_PROVIDER_H
+#pragma once
+
 
 // ros_control
 #include <transmission_interface/transmission_info.h>
@@ -39,10 +39,8 @@ class BiDirectionalVelocityJointInterfaceProvider : public VelocityJointInterfac
 {
 protected:
 
-  bool registerTransmission(TransmissionLoaderData& loader_data, 
+  bool registerTransmission(TransmissionLoaderData& loader_data,
                             TransmissionHandleData& handle_data);
 };
 
 } // namespace
-
-#endif // header guard

--- a/transmission_interface/include/transmission_interface/differential_transmission.h
+++ b/transmission_interface/include/transmission_interface/differential_transmission.h
@@ -27,8 +27,8 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
-#ifndef TRANSMISSION_INTERFACE_DIFFERENTIAL_TRANSMISSION_H
-#define TRANSMISSION_INTERFACE_DIFFERENTIAL_TRANSMISSION_H
+#pragma once
+
 
 #include <cassert>
 #include <string>
@@ -382,5 +382,3 @@ inline void DifferentialTransmission::jointToActuatorPosition(const JointData&  
 }
 
 } // transmission_interface
-
-#endif // TRANSMISSION_INTERFACE_DIFFERENTIAL_TRANSMISSION_H

--- a/transmission_interface/include/transmission_interface/differential_transmission_loader.h
+++ b/transmission_interface/include/transmission_interface/differential_transmission_loader.h
@@ -27,8 +27,8 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
-#ifndef TRANSMISSION_INTERFACE_DIFFERENTIAL_TRANSMISSION_LOADER_H
-#define TRANSMISSION_INTERFACE_DIFFERENTIAL_TRANSMISSION_LOADER_H
+#pragma once
+
 
 // TinyXML
 #include <tinyxml.h>
@@ -58,5 +58,3 @@ private:
 };
 
 } // namespace
-
-#endif // header guard

--- a/transmission_interface/include/transmission_interface/effort_joint_interface_provider.h
+++ b/transmission_interface/include/transmission_interface/effort_joint_interface_provider.h
@@ -27,8 +27,8 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
-#ifndef TRANSMISSION_INTERFACE_EFFORT_JOINT_INTERFACE_PROVIDER_H
-#define TRANSMISSION_INTERFACE_EFFORT_JOINT_INTERFACE_PROVIDER_H
+#pragma once
+
 
 // ros_control
 #include <transmission_interface/transmission_info.h>
@@ -61,5 +61,3 @@ protected:
 };
 
 } // namespace
-
-#endif // header guard

--- a/transmission_interface/include/transmission_interface/four_bar_linkage_transmission.h
+++ b/transmission_interface/include/transmission_interface/four_bar_linkage_transmission.h
@@ -28,8 +28,8 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
-#ifndef TRANSMISSION_INTERFACE_FOUR_BAR_LINKAGE_TRANSMISSION_H
-#define TRANSMISSION_INTERFACE_FOUR_BAR_LINKAGE_TRANSMISSION_H
+#pragma once
+
 
 #include <cassert>
 #include <string>
@@ -356,5 +356,3 @@ inline void FourBarLinkageTransmission::jointToActuatorPosition(const JointData&
 }
 
 } // transmission_interface
-
-#endif // TRANSMISSION_INTERFACE_FOUR_BAR_LINKAGE_TRANSMISSION_H

--- a/transmission_interface/include/transmission_interface/four_bar_linkage_transmission_loader.h
+++ b/transmission_interface/include/transmission_interface/four_bar_linkage_transmission_loader.h
@@ -27,8 +27,8 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
-#ifndef TRANSMISSION_INTERFACE_FOUR_BAR_LINKAGE_TRANSMISSION_LOADER_H
-#define TRANSMISSION_INTERFACE_FOUR_BAR_LINKAGE_TRANSMISSION_LOADER_H
+#pragma once
+
 
 // TinyXML
 #include <tinyxml.h>
@@ -57,5 +57,3 @@ private:
 };
 
 } // namespace
-
-#endif // header guard

--- a/transmission_interface/include/transmission_interface/joint_state_interface_provider.h
+++ b/transmission_interface/include/transmission_interface/joint_state_interface_provider.h
@@ -27,8 +27,8 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
-#ifndef TRANSMISSION_INTERFACE_JOINT_STATE_INTERFACE_PROVIDER_H
-#define TRANSMISSION_INTERFACE_JOINT_STATE_INTERFACE_PROVIDER_H
+#pragma once
+
 
 // ros_control
 #include <transmission_interface/transmission_info.h>
@@ -67,5 +67,3 @@ protected:
 };
 
 } // namespace
-
-#endif // header guard

--- a/transmission_interface/include/transmission_interface/position_joint_interface_provider.h
+++ b/transmission_interface/include/transmission_interface/position_joint_interface_provider.h
@@ -27,8 +27,8 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
-#ifndef TRANSMISSION_INTERFACE_POSITION_JOINT_INTERFACE_PROVIDER_H
-#define TRANSMISSION_INTERFACE_POSITION_JOINT_INTERFACE_PROVIDER_H
+#pragma once
+
 
 // ros_control
 #include <transmission_interface/transmission_info.h>
@@ -61,5 +61,3 @@ protected:
 };
 
 } // namespace
-
-#endif // header guard

--- a/transmission_interface/include/transmission_interface/robot_transmissions.h
+++ b/transmission_interface/include/transmission_interface/robot_transmissions.h
@@ -27,8 +27,8 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
-#ifndef TRANSMISSION_INTERFACE_ROBOT_TRANSMISSIONS_H
-#define TRANSMISSION_INTERFACE_ROBOT_TRANSMISSIONS_H
+#pragma once
+
 
 #include <hardware_interface/internal/interface_manager.h>
 #include <hardware_interface/robot_hw.h>
@@ -48,5 +48,3 @@ namespace transmission_interface
 class RobotTransmissions : public hardware_interface::InterfaceManager {};
 
 } // namespace
-
-#endif // header guard

--- a/transmission_interface/include/transmission_interface/simple_transmission.h
+++ b/transmission_interface/include/transmission_interface/simple_transmission.h
@@ -27,8 +27,8 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
-#ifndef TRANSMISSION_INTERFACE_SIMPLE_TRANSMISSION_H
-#define TRANSMISSION_INTERFACE_SIMPLE_TRANSMISSION_H
+#pragma once
+
 
 #include <cassert>
 #include <string>
@@ -271,5 +271,3 @@ inline void SimpleTransmission::jointToActuatorPosition(const JointData&    jnt_
 }
 
 } // transmission_interface
-
-#endif // TRANSMISSION_INTERFACE_SIMPLE_TRANSMISSION_H

--- a/transmission_interface/include/transmission_interface/simple_transmission_loader.h
+++ b/transmission_interface/include/transmission_interface/simple_transmission_loader.h
@@ -27,8 +27,8 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
-#ifndef TRANSMISSION_INTERFACE_SIMPLE_TRANSMISSION_LOADER_H
-#define TRANSMISSION_INTERFACE_SIMPLE_TRANSMISSION_LOADER_H
+#pragma once
+
 
 // ros_control
 #include <transmission_interface/transmission_loader.h>
@@ -47,5 +47,3 @@ public:
 };
 
 } // namespace
-
-#endif // header guard

--- a/transmission_interface/include/transmission_interface/transmission.h
+++ b/transmission_interface/include/transmission_interface/transmission.h
@@ -27,8 +27,8 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
-#ifndef TRANSMISSION_INTERFACE_TRANSMISSION_H
-#define TRANSMISSION_INTERFACE_TRANSMISSION_H
+#pragma once
+
 
 #include <cstddef>
 #include <string>
@@ -184,5 +184,3 @@ public:
 typedef std::shared_ptr<Transmission> TransmissionSharedPtr;
 
 } // transmission_interface
-
-#endif // TRANSMISSION_INTERFACE_TRANSMISSION_H

--- a/transmission_interface/include/transmission_interface/transmission_info.h
+++ b/transmission_interface/include/transmission_interface/transmission_info.h
@@ -38,8 +38,8 @@
  * \author Dave Coleman
  */
 
-#ifndef TRANSMISSION_INTERFACE_TRANSMISSION_INTERFACE_INFO_H
-#define TRANSMISSION_INTERFACE_TRANSMISSION_INTERFACE_INFO_H
+#pragma once
+
 
 // C++ standard
 #include <vector>
@@ -84,5 +84,3 @@ struct TransmissionInfo
 };
 
 } // namespace
-
-#endif

--- a/transmission_interface/include/transmission_interface/transmission_interface.h
+++ b/transmission_interface/include/transmission_interface/transmission_interface.h
@@ -27,8 +27,8 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
-#ifndef TRANSMISSION_INTERFACE_TRANSMISSION_INTERFACE_H
-#define TRANSMISSION_INTERFACE_TRANSMISSION_INTERFACE_H
+#pragma once
+
 
 #include <map>
 #include <string>
@@ -439,5 +439,3 @@ class JointToActuatorVelocityInterface : public TransmissionInterface<JointToAct
 class JointToActuatorEffortInterface : public TransmissionInterface<JointToActuatorEffortHandle> {};
 
 } // transmission_interface
-
-#endif // TRANSMISSION_INTERFACE_TRANSMISSION_INTERFACE_H

--- a/transmission_interface/include/transmission_interface/transmission_interface_exception.h
+++ b/transmission_interface/include/transmission_interface/transmission_interface_exception.h
@@ -25,8 +25,8 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //////////////////////////////////////////////////////////////////////////////
 
-#ifndef TRANSMISSION_INTERFACE_TRANSMISSION_INTERFACE_EXCEPTION_H
-#define TRANSMISSION_INTERFACE_TRANSMISSION_INTERFACE_EXCEPTION_H
+#pragma once
+
 
 #include <exception>
 
@@ -44,5 +44,3 @@ private:
 };
 
 } // transmission_interface
-
-#endif // TRANSMISSION_INTERFACE_TRANSMISSION_INTERFACE_EXCEPTION_H

--- a/transmission_interface/include/transmission_interface/transmission_interface_loader.h
+++ b/transmission_interface/include/transmission_interface/transmission_interface_loader.h
@@ -27,8 +27,8 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
-#ifndef TRANSMISSION_INTERFACE_TRANSMISSION_INTERFACE_LOADER_H
-#define TRANSMISSION_INTERFACE_TRANSMISSION_INTERFACE_LOADER_H
+#pragma once
+
 
 // C++ standard
 #include <algorithm>
@@ -426,5 +426,3 @@ private:
 };
 
 } // namespace
-
-#endif // header guard

--- a/transmission_interface/include/transmission_interface/transmission_loader.h
+++ b/transmission_interface/include/transmission_interface/transmission_loader.h
@@ -27,8 +27,8 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
-#ifndef TRANSMISSION_INTERFACE_TRANSMISSION_LOADER_H
-#define TRANSMISSION_INTERFACE_TRANSMISSION_LOADER_H
+#pragma once
+
 
 // C++ standard
 #include <algorithm>
@@ -143,5 +143,3 @@ protected:
 typedef std::shared_ptr<TransmissionLoader> TransmissionLoaderSharedPtr;
 
 } // namespace
-
-#endif // header guard

--- a/transmission_interface/include/transmission_interface/transmission_parser.h
+++ b/transmission_interface/include/transmission_interface/transmission_parser.h
@@ -39,8 +39,8 @@
  * \author Dave Coleman
  */
 
-#ifndef TRANSMISSION_INTERFACE_TRANSMISSION_PARSER_H
-#define TRANSMISSION_INTERFACE_TRANSMISSION_PARSER_H
+#pragma once
+
 
 // ros_control
 #include <transmission_interface/transmission_info.h>
@@ -87,5 +87,3 @@ protected:
 }; // class
 
 } // namespace
-
-#endif

--- a/transmission_interface/include/transmission_interface/velocity_joint_interface_provider.h
+++ b/transmission_interface/include/transmission_interface/velocity_joint_interface_provider.h
@@ -27,8 +27,8 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
-#ifndef TRANSMISSION_INTERFACE_VELOCITY_JOINT_INTERFACE_PROVIDER_H
-#define TRANSMISSION_INTERFACE_VELOCITY_JOINT_INTERFACE_PROVIDER_H
+#pragma once
+
 
 // ros_control
 #include <transmission_interface/transmission_info.h>
@@ -61,5 +61,3 @@ protected:
 };
 
 } // namespace
-
-#endif // header guard

--- a/transmission_interface/test/loader_utils.h
+++ b/transmission_interface/test/loader_utils.h
@@ -27,6 +27,9 @@
 
 /// \author Daniel Pinyol
 
+#pragma once
+
+
 #include <pluginlib/class_loader.hpp>
 #include <transmission_interface/simple_transmission.h>
 #include <transmission_interface/transmission_loader.h>

--- a/transmission_interface/test/random_generator_utils.h
+++ b/transmission_interface/test/random_generator_utils.h
@@ -27,8 +27,8 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
-#ifndef RANDOM_GENERATOR_UTILS_H
-#define RANDOM_GENERATOR_UTILS_H
+#pragma once
+
 
 #include <cstdlib>
 #include <ctime>
@@ -63,5 +63,3 @@ vector<double> randomVector(const vector<double>::size_type size, RandomDoubleGe
   for (vector<double>::size_type i = 0; i < size; ++i) {out.push_back(generator());}
   return out;
 }
-
-#endif // RANDOM_GENERATOR_UTILS_H

--- a/transmission_interface/test/read_file.h
+++ b/transmission_interface/test/read_file.h
@@ -27,8 +27,8 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
-#ifndef TRANSMISSION_INTERFACE_READ_FILE_H
-#define TRANSMISSION_INTERFACE_READ_FILE_H
+#pragma once
+
 
 #include <string>
 #include <vector>
@@ -71,5 +71,3 @@ inline std::vector<TransmissionInfo> parseUrdf(const std::string& filename)
 }
 
 } // namespace
-
-#endif // header guard


### PR DESCRIPTION
Part of #403.

Replace all preprocessor header guards with `#pragma once`. Also adds missing header guard to `transmission_interface/test/loader_utils.h`. Every `.h` file now includes `#pragma once`.