### PR TITLE
Add test nodes to CMake target "tests"

### DIFF
--- a/combined_robot_hw_tests/CMakeLists.txt
+++ b/combined_robot_hw_tests/CMakeLists.txt
@@ -36,6 +36,7 @@ if(CATKIN_ENABLE_TESTING)
 
   add_executable(combined_robot_hw_dummy_app EXCLUDE_FROM_ALL src/dummy_app.cpp)
   target_link_libraries(combined_robot_hw_dummy_app ${PROJECT_NAME} ${catkin_LIBRARIES})
+  add_dependencies(tests combined_robot_hw_dummy_app)
 
   add_rostest_gtest(combined_robot_hw_test
     test/combined_robot_hw_test.test
@@ -56,8 +57,7 @@ endif()
 ## Install ##
 #############
 
-# NOTE: Libraries and plugins required for tests are installed since CI
-# runs tests out of the install space rather than the devel space
+# NOTE: Plugins required for tests must be installed
 
 if(CATKIN_ENABLE_TESTING)
 

--- a/combined_robot_hw_tests/CMakeLists.txt
+++ b/combined_robot_hw_tests/CMakeLists.txt
@@ -48,7 +48,7 @@ if(CATKIN_ENABLE_TESTING)
     test/cm_test.test
     test/cm_test.cpp
   )
-  add_dependencies(combined_robot_hw_cm_test combined_robot_hw_dummy_app ${catkin_EXPORTED_TARGETS})
+  add_dependencies(combined_robot_hw_cm_test ${catkin_EXPORTED_TARGETS})
   target_link_libraries(combined_robot_hw_cm_test ${PROJECT_NAME} ${catkin_LIBRARIES})
 endif()
 

--- a/controller_manager_tests/CMakeLists.txt
+++ b/controller_manager_tests/CMakeLists.txt
@@ -40,10 +40,12 @@ if(CATKIN_ENABLE_TESTING)
   add_executable(dummy_app EXCLUDE_FROM_ALL src/dummy_app.cpp)
   add_dependencies(dummy_app ${catkin_EXPORTED_TARGETS})
   target_link_libraries(dummy_app ${PROJECT_NAME} ${catkin_LIBRARIES})
+  add_dependencies(tests dummy_app)
 
   add_executable(cm_test EXCLUDE_FROM_ALL test/cm_test.cpp)
   add_dependencies(cm_test ${catkin_EXPORTED_TARGETS})
   target_link_libraries(cm_test ${catkin_LIBRARIES} ${GTEST_LIBRARIES})
+  add_dependencies(tests cm_test)
 
   catkin_add_nosetests(test)
 
@@ -59,8 +61,7 @@ endif()
 ## Install ##
 #############
 
-# NOTE: Libraries and plugins required for tests are installed since CI
-# runs tests out of the install space rather than the devel space
+# NOTE: Plugins required for tests must be installed
 
 if(CATKIN_ENABLE_TESTING)
 

--- a/controller_manager_tests/CMakeLists.txt
+++ b/controller_manager_tests/CMakeLists.txt
@@ -49,11 +49,11 @@ if(CATKIN_ENABLE_TESTING)
 
   catkin_add_nosetests(test)
 
-  add_rostest(test/cm_test.test DEPENDENCIES dummy_app cm_test)
+  add_rostest(test/cm_test.test)
 
   add_rostest(test/cm_msgs_utils_rostest.test)
 
-  add_rostest(test/controller_manager_scripts.test DEPENDENCIES dummy_app)
+  add_rostest(test/controller_manager_scripts.test)
 endif()
 
 


### PR DESCRIPTION
This resolves the `colcon` test failure brought up by @ipa-mdl here: https://github.com/ros-controls/ros_control/issues/410#issuecomment-574397248

See https://github.com/ros-controls/ros_control/pull/404#discussion_r366604167 for full discussion on this change. In short, targets have either got to be part of the `all` or `tests` targets, and #404 removed some targets from `all` without adding them to `tests`.