### PR TITLE
Replace internal::is_permutation with std

### DIFF
--- a/transmission_interface/include/transmission_interface/transmission_interface_loader.h
+++ b/transmission_interface/include/transmission_interface/transmission_interface_loader.h
@@ -63,38 +63,6 @@
 namespace transmission_interface
 {
 
-namespace internal
-{
-// NOTE: Adapted to C++03 from http://www.cplusplus.com/reference/algorithm/is_permutation
-// TODO: Use Boost's or C++11's implementation, once they become widespread
-template<class ForwardIt1, class ForwardIt2>
-bool is_permutation(ForwardIt1 first, ForwardIt1 last,
-                    ForwardIt2 d_first)
-{
-  // skip common prefix
-  std::pair<ForwardIt1, ForwardIt2> pair = std::mismatch(first, last, d_first);
-  first = pair.first; d_first = pair.second;
-
-  // iterate over the rest, counting how many times each element
-  // from [first, last) appears in [d_first, d_last)
-  if (first != last) {
-    ForwardIt2 d_last = d_first;
-    std::advance(d_last, std::distance(first, last));
-    for (ForwardIt1 i = first; i != last; ++i) {
-      if (i != std::find(first, i, *i)) continue; // already counted this *i
-
-      int m = std::count(d_first, d_last, *i);
-      if (m==0 || std::count(i, last, *i) != m) {
-          return false;
-      }
-    }
-  }
-  return true;
-}
-
-} // namespace
-
-
 /**
  * \brief Raw data for a set of joints.
  *

--- a/transmission_interface/src/transmission_interface_loader.cpp
+++ b/transmission_interface/src/transmission_interface_loader.cpp
@@ -26,6 +26,7 @@
 //////////////////////////////////////////////////////////////////////////////
 
 // C++ standard
+#include <algorithm>
 #include <cassert>
 #include <stdexcept>
 
@@ -154,7 +155,7 @@ bool TransmissionInterfaceLoader::load(const TransmissionInfo& transmission_info
   {
     // Error out if at least one joint has a different set of hardware interfaces
     if (hw_ifaces_ref.size() != jnt_info.hardware_interfaces_.size() ||
-        !internal::is_permutation(hw_ifaces_ref.begin(), hw_ifaces_ref.end(),
+        !std::is_permutation(hw_ifaces_ref.begin(), hw_ifaces_ref.end(),
                                   jnt_info.hardware_interfaces_.begin()))
     {
       ROS_ERROR_STREAM_NAMED("parser",

--- a/transmission_interface/test/transmission_interface_loader_test.cpp
+++ b/transmission_interface/test/transmission_interface_loader_test.cpp
@@ -27,6 +27,8 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
+#include <algorithm>
+
 #include <gtest/gtest.h>
 #include <hardware_interface/robot_hw.h>
 #include <hardware_interface/actuator_state_interface.h>
@@ -58,11 +60,11 @@ TEST(IsPermutationTest, IsPermutation)
 
   std::vector<int> d(3, 1);
 
-  EXPECT_TRUE(internal::is_permutation(a.begin(),  a.end(), a.begin()));
-  EXPECT_TRUE(internal::is_permutation(a.begin(),  a.end(), b.begin()));
-  EXPECT_FALSE(internal::is_permutation(a.begin(), a.end(), c.begin()));
-  EXPECT_FALSE(internal::is_permutation(a.begin(), a.end(), d.begin()));
-  EXPECT_FALSE(internal::is_permutation(d.begin(), d.end(), a.begin()));
+  EXPECT_TRUE(std::is_permutation(a.begin(),  a.end(), a.begin()));
+  EXPECT_TRUE(std::is_permutation(a.begin(),  a.end(), b.begin()));
+  EXPECT_FALSE(std::is_permutation(a.begin(), a.end(), c.begin()));
+  EXPECT_FALSE(std::is_permutation(a.begin(), a.end(), d.begin()));
+  EXPECT_FALSE(std::is_permutation(d.begin(), d.end(), a.begin()));
 }
 
 class TransmissionInterfaceLoaderTest : public ::testing::Test


### PR DESCRIPTION
Somewhat related to #403.

Since Melodic requires >=C++14, we can replace this custom `is_permutation` with C++11's `std::is_permutation`.

According to http://www.cplusplus.com/reference/algorithm/is_permutation, the standard is equivalent to what Adolfo wrote 6 years ago, so this shouldn't change any behaviour.