### PR TITLE
Use default member initializers

### DIFF
--- a/combined_robot_hw/include/combined_robot_hw/combined_robot_hw.h
+++ b/combined_robot_hw/include/combined_robot_hw/combined_robot_hw.h
@@ -52,8 +52,6 @@ namespace combined_robot_hw
 class CombinedRobotHW : public hardware_interface::RobotHW
 {
 public:
-  CombinedRobotHW();
-
   virtual ~CombinedRobotHW(){}
 
   /** \brief The init function is called to initialize the RobotHW from a
@@ -103,7 +101,7 @@ public:
 protected:
   ros::NodeHandle root_nh_;
   ros::NodeHandle robot_hw_nh_;
-  pluginlib::ClassLoader<hardware_interface::RobotHW> robot_hw_loader_;
+  pluginlib::ClassLoader<hardware_interface::RobotHW> robot_hw_loader_ = {"hardware_interface", "hardware_interface::RobotHW"};
   std::vector<hardware_interface::RobotHWSharedPtr> robot_hw_list_;
 
   virtual bool loadRobotHW(const std::string& name);

--- a/combined_robot_hw/src/combined_robot_hw.cpp
+++ b/combined_robot_hw/src/combined_robot_hw.cpp
@@ -30,10 +30,6 @@
 
 namespace combined_robot_hw
 {
-  CombinedRobotHW::CombinedRobotHW() :
-    robot_hw_loader_("hardware_interface", "hardware_interface::RobotHW")
-  {}
-
   bool CombinedRobotHW::init(ros::NodeHandle& root_nh, ros::NodeHandle &robot_hw_nh)
   {
     root_nh_ = root_nh;

--- a/controller_interface/include/controller_interface/controller.h
+++ b/controller_interface/include/controller_interface/controller.h
@@ -52,7 +52,7 @@ template <class T>
 class Controller: public virtual ControllerBase
 {
 public:
-  Controller()  {state_ = CONSTRUCTED;}
+  Controller() {}
   virtual ~Controller<T>(){}
 
   /** \brief The init function is called to initialize the controller from a

--- a/controller_interface/include/controller_interface/controller_base.h
+++ b/controller_interface/include/controller_interface/controller_base.h
@@ -48,7 +48,7 @@ namespace controller_interface
 class ControllerBase
 {
 public:
-  ControllerBase(): state_(CONSTRUCTED){}
+  ControllerBase() {}
   virtual ~ControllerBase(){}
 
   /** \name Real-Time Safe Functions
@@ -237,7 +237,7 @@ public:
   /*\}*/
 
   /// The current execution state of the controller
-  enum {CONSTRUCTED, INITIALIZED, RUNNING, STOPPED, WAITING, ABORTED} state_;
+  enum {CONSTRUCTED, INITIALIZED, RUNNING, STOPPED, WAITING, ABORTED} state_ = CONSTRUCTED;
 
 
 private:

--- a/controller_interface/include/controller_interface/controller_base.h
+++ b/controller_interface/include/controller_interface/controller_base.h
@@ -237,7 +237,7 @@ public:
   /*\}*/
 
   /// The current execution state of the controller
-  enum {CONSTRUCTED, INITIALIZED, RUNNING, STOPPED, WAITING, ABORTED} state_ = CONSTRUCTED;
+  enum {CONSTRUCTED, INITIALIZED, RUNNING, STOPPED, WAITING, ABORTED} state_ = {CONSTRUCTED};
 
 
 private:

--- a/controller_interface/include/controller_interface/multi_interface_controller.h
+++ b/controller_interface/include/controller_interface/multi_interface_controller.h
@@ -156,7 +156,7 @@ public:
    */
   MultiInterfaceController(bool allow_optional_interfaces = false)
     : allow_optional_interfaces_(allow_optional_interfaces)
-  {state_ = CONSTRUCTED;}
+  {}
 
   virtual ~MultiInterfaceController() {}
 

--- a/controller_manager/include/controller_manager/controller_manager.h
+++ b/controller_manager/include/controller_manager/controller_manager.h
@@ -191,24 +191,14 @@ private:
 
   struct SwitchParams
   {
-    SwitchParams()
-      : do_switch(false)
-      , started(false)
-      , init_time(ros::TIME_MAX)
-      , strictness(0)
-      , start_asap(false)
-      , timeout(0.0)
-    {
-    }
+    bool do_switch      = false;
+    bool started        = false;
+    ros::Time init_time = ros::TIME_MAX;
 
-    bool do_switch;
-    bool started;
-    ros::Time init_time;
-
-    // switch options
-    int strictness;
-    bool start_asap;
-    double timeout;
+    // Switch options
+    int strictness  = 0;
+    bool start_asap = false;
+    double timeout  = 0.0;
   };
 
   SwitchParams switch_params_;
@@ -224,9 +214,9 @@ private:
   /// Double-buffered controllers list
   std::vector<ControllerSpec> controllers_lists_[2];
   /// The index of the current controllers list
-  int current_controllers_list_;
+  int current_controllers_list_ = 0;
   /// The index of the controllers list being used in the real-time thread.
-  int used_by_realtime_;
+  int used_by_realtime_ = -1;
   /*\}*/
 
 

--- a/controller_manager/include/controller_manager/controller_manager.h
+++ b/controller_manager/include/controller_manager/controller_manager.h
@@ -191,14 +191,14 @@ private:
 
   struct SwitchParams
   {
-    bool do_switch      = false;
-    bool started        = false;
-    ros::Time init_time = ros::TIME_MAX;
+    bool do_switch      = {false};
+    bool started        = {false};
+    ros::Time init_time = {ros::TIME_MAX};
 
     // Switch options
-    int strictness  = 0;
-    bool start_asap = false;
-    double timeout  = 0.0;
+    int strictness  = {0};
+    bool start_asap = {false};
+    double timeout  = {0.0};
   };
 
   SwitchParams switch_params_;
@@ -214,9 +214,9 @@ private:
   /// Double-buffered controllers list
   std::vector<ControllerSpec> controllers_lists_[2];
   /// The index of the current controllers list
-  int current_controllers_list_ = 0;
+  int current_controllers_list_ = {0};
   /// The index of the controllers list being used in the real-time thread.
-  int used_by_realtime_ = -1;
+  int used_by_realtime_ = {-1};
   /*\}*/
 
 

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -46,12 +46,7 @@ namespace controller_manager
 ControllerManager::ControllerManager(hardware_interface::RobotHW *robot_hw, const ros::NodeHandle& nh) :
   robot_hw_(robot_hw),
   root_nh_(nh),
-  cm_node_(nh, "controller_manager"),
-  start_request_(0),
-  stop_request_(0),
-  switch_params_(),
-  current_controllers_list_(0),
-  used_by_realtime_(-1)
+  cm_node_(nh, "controller_manager")
 {
   // create controller loader
   controller_loaders_.push_back(

--- a/controller_manager/test/hwi_switch_test.cpp
+++ b/controller_manager/test/hwi_switch_test.cpp
@@ -76,7 +76,7 @@ class SwitchBot : public hardware_interface::RobotHW
         std::string current_;
         hardware_interface::JointStateHandle jsh_;
     public:
-        Joint(const std::string &n, hardware_interface::JointStateInterface &iface): jsh_(n, &dummy_, &dummy_, &dummy_)
+        Joint(const std::string &n, hardware_interface::JointStateInterface &iface) : jsh_(n, &dummy_, &dummy_, &dummy_)
         {
             iface.registerHandle(jsh_);
         }

--- a/hardware_interface/include/hardware_interface/actuator_command_interface.h
+++ b/hardware_interface/include/hardware_interface/actuator_command_interface.h
@@ -61,7 +61,7 @@ public:
   double* getCommandPtr() {return cmd_;}
 
 private:
-  double* cmd_ = nullptr;
+  double* cmd_ = {nullptr};
 };
 
 /** \brief Hardware interface to support commanding an array of actuators.

--- a/hardware_interface/include/hardware_interface/actuator_command_interface.h
+++ b/hardware_interface/include/hardware_interface/actuator_command_interface.h
@@ -40,7 +40,7 @@ namespace hardware_interface
 class ActuatorHandle : public ActuatorStateHandle
 {
 public:
-  ActuatorHandle() : ActuatorStateHandle(), cmd_(nullptr) {}
+  ActuatorHandle() {}
 
   /**
    * \param as This actuator's state handle
@@ -61,7 +61,7 @@ public:
   double* getCommandPtr() {return cmd_;}
 
 private:
-  double* cmd_;
+  double* cmd_ = nullptr;
 };
 
 /** \brief Hardware interface to support commanding an array of actuators.

--- a/hardware_interface/include/hardware_interface/actuator_state_interface.h
+++ b/hardware_interface/include/hardware_interface/actuator_state_interface.h
@@ -45,7 +45,7 @@ namespace hardware_interface
 class ActuatorStateHandle
 {
 public:
-  ActuatorStateHandle() : name_(), pos_(nullptr), vel_(nullptr), eff_(nullptr), absolute_pos_(nullptr), torque_sensor_(nullptr) {}
+  ActuatorStateHandle() {}
 
   /**
    * \param name The name of the actuator
@@ -54,7 +54,7 @@ public:
    * \param eff A pointer to the storage for this actuator's effort (force or torque)
    */
   ActuatorStateHandle(const std::string& name, const double* pos, const double* vel, const double* eff)
-    : name_(name), pos_(pos), vel_(vel), eff_(eff), absolute_pos_(nullptr), torque_sensor_(nullptr)
+    : name_(name), pos_(pos), vel_(vel), eff_(eff)
   {
     if (!pos)
     {
@@ -114,7 +114,7 @@ public:
    */
   ActuatorStateHandle(const std::string& name, const double* pos, const double* vel, const double* eff,
                       const double* absolute_pos)
-    : name_(name), pos_(pos), vel_(vel), eff_(eff), absolute_pos_(absolute_pos), torque_sensor_(nullptr)
+    : name_(name), pos_(pos), vel_(vel), eff_(eff), absolute_pos_(absolute_pos)
   {
     if (!pos)
     {
@@ -144,7 +144,7 @@ public:
    */
   ActuatorStateHandle(const std::string& name, const double* pos, const double* vel, const double* eff,
                       const double* torque_sensor, bool)
-    : name_(name), pos_(pos), vel_(vel), eff_(eff), absolute_pos_(nullptr), torque_sensor_(torque_sensor)
+    : name_(name), pos_(pos), vel_(vel), eff_(eff), torque_sensor_(torque_sensor)
   {
     if (!pos)
     {
@@ -214,11 +214,11 @@ public:
 
 private:
   std::string name_;
-  const double* pos_;
-  const double* vel_;
-  const double* eff_;
-  const double* absolute_pos_;
-  const double* torque_sensor_;
+  const double* pos_           = nullptr;
+  const double* vel_           = nullptr;
+  const double* eff_           = nullptr;
+  const double* absolute_pos_  = nullptr;
+  const double* torque_sensor_ = nullptr;
 };
 
 /** \brief Hardware interface to support reading the state of an array of actuators

--- a/hardware_interface/include/hardware_interface/actuator_state_interface.h
+++ b/hardware_interface/include/hardware_interface/actuator_state_interface.h
@@ -214,11 +214,11 @@ public:
 
 private:
   std::string name_;
-  const double* pos_           = nullptr;
-  const double* vel_           = nullptr;
-  const double* eff_           = nullptr;
-  const double* absolute_pos_  = nullptr;
-  const double* torque_sensor_ = nullptr;
+  const double* pos_           = {nullptr};
+  const double* vel_           = {nullptr};
+  const double* eff_           = {nullptr};
+  const double* absolute_pos_  = {nullptr};
+  const double* torque_sensor_ = {nullptr};
 };
 
 /** \brief Hardware interface to support reading the state of an array of actuators

--- a/hardware_interface/include/hardware_interface/force_torque_sensor_interface.h
+++ b/hardware_interface/include/hardware_interface/force_torque_sensor_interface.h
@@ -40,7 +40,7 @@ namespace hardware_interface
 class ForceTorqueSensorHandle
 {
 public:
-  ForceTorqueSensorHandle() : name_(""), frame_id_(""), force_(nullptr), torque_(nullptr) {}
+  ForceTorqueSensorHandle() {}
 
   /**
    * \param name The name of the sensor
@@ -78,8 +78,8 @@ public:
 private:
   std::string name_;
   std::string frame_id_;
-  const double* force_;
-  const double* torque_;
+  const double* force_  = nullptr;
+  const double* torque_ = nullptr;
 };
 
 /** \brief Hardware interface to support reading the state of a force-torque sensor. */

--- a/hardware_interface/include/hardware_interface/force_torque_sensor_interface.h
+++ b/hardware_interface/include/hardware_interface/force_torque_sensor_interface.h
@@ -78,8 +78,8 @@ public:
 private:
   std::string name_;
   std::string frame_id_;
-  const double* force_  = nullptr;
-  const double* torque_ = nullptr;
+  const double* force_  = {nullptr};
+  const double* torque_ = {nullptr};
 };
 
 /** \brief Hardware interface to support reading the state of a force-torque sensor. */

--- a/hardware_interface/include/hardware_interface/imu_sensor_interface.h
+++ b/hardware_interface/include/hardware_interface/imu_sensor_interface.h
@@ -46,24 +46,16 @@ class ImuSensorHandle
 public:
   struct Data
   {
-    Data()
-      : name(),
-        frame_id(),
-        orientation(nullptr),
-        orientation_covariance(nullptr),
-        angular_velocity(nullptr),
-        angular_velocity_covariance(nullptr),
-        linear_acceleration(nullptr),
-        linear_acceleration_covariance(nullptr) {}
+    Data() {};
 
-    std::string name;                       ///< The name of the sensor
-    std::string frame_id;                   ///< The reference frame to which this sensor is associated
-    double* orientation;                    ///< A pointer to the storage of the orientation value: a quaternion (x,y,z,w)
-    double* orientation_covariance;         ///< A pointer to the storage of the orientation covariance value: a row major 3x3 matrix about (x,y,z)
-    double* angular_velocity;               ///< A pointer to the storage of the angular velocity value: a triplet (x,y,z)
-    double* angular_velocity_covariance;    ///< A pointer to the storage of the angular velocity covariance value: a row major 3x3 matrix about (x,y,z)
-    double* linear_acceleration;            ///< A pointer to the storage of the linear acceleration value: a triplet (x,y,z)
-    double* linear_acceleration_covariance; ///< A pointer to the storage of the linear acceleration covariance value: a row major 3x3 matrix about (x,y,z)
+    std::string name;                                 ///< The name of the sensor
+    std::string frame_id;                             ///< The reference frame to which this sensor is associated
+    double* orientation                    = nullptr; ///< A pointer to the storage of the orientation value: a quaternion (x,y,z,w)
+    double* orientation_covariance         = nullptr; ///< A pointer to the storage of the orientation covariance value: a row major 3x3 matrix about (x,y,z)
+    double* angular_velocity               = nullptr; ///< A pointer to the storage of the angular velocity value: a triplet (x,y,z)
+    double* angular_velocity_covariance    = nullptr; ///< A pointer to the storage of the angular velocity covariance value: a row major 3x3 matrix about (x,y,z)
+    double* linear_acceleration            = nullptr; ///< A pointer to the storage of the linear acceleration value: a triplet (x,y,z)
+    double* linear_acceleration_covariance = nullptr; ///< A pointer to the storage of the linear acceleration covariance value: a row major 3x3 matrix about (x,y,z)
   };
 
   ImuSensorHandle(const Data& data = Data())

--- a/hardware_interface/include/hardware_interface/imu_sensor_interface.h
+++ b/hardware_interface/include/hardware_interface/imu_sensor_interface.h
@@ -48,17 +48,17 @@ public:
   {
     Data() {};
 
-    std::string name;                                 ///< The name of the sensor
-    std::string frame_id;                             ///< The reference frame to which this sensor is associated
-    double* orientation                    = nullptr; ///< A pointer to the storage of the orientation value: a quaternion (x,y,z,w)
-    double* orientation_covariance         = nullptr; ///< A pointer to the storage of the orientation covariance value: a row major 3x3 matrix about (x,y,z)
-    double* angular_velocity               = nullptr; ///< A pointer to the storage of the angular velocity value: a triplet (x,y,z)
-    double* angular_velocity_covariance    = nullptr; ///< A pointer to the storage of the angular velocity covariance value: a row major 3x3 matrix about (x,y,z)
-    double* linear_acceleration            = nullptr; ///< A pointer to the storage of the linear acceleration value: a triplet (x,y,z)
-    double* linear_acceleration_covariance = nullptr; ///< A pointer to the storage of the linear acceleration covariance value: a row major 3x3 matrix about (x,y,z)
+    std::string name;                                   ///< The name of the sensor
+    std::string frame_id;                               ///< The reference frame to which this sensor is associated
+    double* orientation                    = {nullptr}; ///< A pointer to the storage of the orientation value: a quaternion (x,y,z,w)
+    double* orientation_covariance         = {nullptr}; ///< A pointer to the storage of the orientation covariance value: a row major 3x3 matrix about (x,y,z)
+    double* angular_velocity               = {nullptr}; ///< A pointer to the storage of the angular velocity value: a triplet (x,y,z)
+    double* angular_velocity_covariance    = {nullptr}; ///< A pointer to the storage of the angular velocity covariance value: a row major 3x3 matrix about (x,y,z)
+    double* linear_acceleration            = {nullptr}; ///< A pointer to the storage of the linear acceleration value: a triplet (x,y,z)
+    double* linear_acceleration_covariance = {nullptr}; ///< A pointer to the storage of the linear acceleration covariance value: a row major 3x3 matrix about (x,y,z)
   };
 
-  ImuSensorHandle(const Data& data = Data())
+  ImuSensorHandle(const Data& data = {})
     : name_(data.name),
       frame_id_(data.frame_id),
       orientation_(data.orientation),

--- a/hardware_interface/include/hardware_interface/joint_command_interface.h
+++ b/hardware_interface/include/hardware_interface/joint_command_interface.h
@@ -62,7 +62,7 @@ public:
   const double* getCommandPtr() const {assert(cmd_); return cmd_;}
 
 private:
-  double* cmd_ = nullptr;
+  double* cmd_ = {nullptr};
 };
 
 /** \brief Hardware interface to support commanding an array of joints.

--- a/hardware_interface/include/hardware_interface/joint_command_interface.h
+++ b/hardware_interface/include/hardware_interface/joint_command_interface.h
@@ -42,7 +42,7 @@ namespace hardware_interface
 class JointHandle : public JointStateHandle
 {
 public:
-  JointHandle() : JointStateHandle(), cmd_(nullptr) {}
+  JointHandle() {}
 
   /**
    * \param js This joint's state handle
@@ -62,7 +62,7 @@ public:
   const double* getCommandPtr() const {assert(cmd_); return cmd_;}
 
 private:
-  double* cmd_;
+  double* cmd_ = nullptr;
 };
 
 /** \brief Hardware interface to support commanding an array of joints.

--- a/hardware_interface/include/hardware_interface/joint_mode_interface.h
+++ b/hardware_interface/include/hardware_interface/joint_mode_interface.h
@@ -108,7 +108,7 @@ namespace hardware_interface
     }
 
   private:
-    JointCommandModes* mode_ = nullptr;
+    JointCommandModes* mode_ = {nullptr};
     std::string name_;
   };
 

--- a/hardware_interface/include/hardware_interface/joint_mode_interface.h
+++ b/hardware_interface/include/hardware_interface/joint_mode_interface.h
@@ -63,8 +63,7 @@ namespace hardware_interface
   {
   public:
 
-    JointModeHandle():
-      name_(), mode_(nullptr){}
+    JointModeHandle() {}
 
     /** \param mode Which mode to start in */
     JointModeHandle(std::string name, JointCommandModes* mode)
@@ -109,7 +108,7 @@ namespace hardware_interface
     }
 
   private:
-    JointCommandModes* mode_;
+    JointCommandModes* mode_ = nullptr;
     std::string name_;
   };
 

--- a/hardware_interface/include/hardware_interface/joint_state_interface.h
+++ b/hardware_interface/include/hardware_interface/joint_state_interface.h
@@ -213,11 +213,11 @@ public:
 
 private:
   std::string name_;
-  const double* pos_           = nullptr;
-  const double* vel_           = nullptr;
-  const double* eff_           = nullptr;
-  const double* absolute_pos_  = nullptr;
-  const double* torque_sensor_ = nullptr;
+  const double* pos_           = {nullptr};
+  const double* vel_           = {nullptr};
+  const double* eff_           = {nullptr};
+  const double* absolute_pos_  = {nullptr};
+  const double* torque_sensor_ = {nullptr};
 };
 
 /** \brief Hardware interface to support reading the state of an array of joints

--- a/hardware_interface/include/hardware_interface/joint_state_interface.h
+++ b/hardware_interface/include/hardware_interface/joint_state_interface.h
@@ -45,7 +45,7 @@ namespace hardware_interface
 class JointStateHandle
 {
 public:
-  JointStateHandle() : name_(), pos_(nullptr), vel_(nullptr), eff_(nullptr), absolute_pos_(nullptr), torque_sensor_(nullptr) {}
+  JointStateHandle() {}
 
   /**
    * \param name The name of the joint
@@ -54,7 +54,7 @@ public:
    * \param eff A pointer to the storage for this joint's effort (force or torque)
    */
   JointStateHandle(const std::string& name, const double* pos, const double* vel, const double* eff)
-    : name_(name), pos_(pos), vel_(vel), eff_(eff), absolute_pos_(nullptr), torque_sensor_(nullptr)
+    : name_(name), pos_(pos), vel_(vel), eff_(eff)
   {
     if (!pos)
     {
@@ -113,7 +113,7 @@ public:
    */
   JointStateHandle(const std::string& name, const double* pos, const double* vel, const double* eff,
                    const double* absolute_pos)
-    : name_(name), pos_(pos), vel_(vel), eff_(eff), absolute_pos_(absolute_pos), torque_sensor_(nullptr)
+    : name_(name), pos_(pos), vel_(vel), eff_(eff), absolute_pos_(absolute_pos)
   {
     if (!pos)
     {
@@ -143,7 +143,7 @@ public:
    */
   JointStateHandle(const std::string& name, const double* pos, const double* vel, const double* eff,
                    const double* torque_sensor, bool)
-    : name_(name), pos_(pos), vel_(vel), eff_(eff), absolute_pos_(nullptr), torque_sensor_(torque_sensor)
+    : name_(name), pos_(pos), vel_(vel), eff_(eff), torque_sensor_(torque_sensor)
   {
     if (!pos)
     {
@@ -213,11 +213,11 @@ public:
 
 private:
   std::string name_;
-  const double* pos_;
-  const double* vel_;
-  const double* eff_;
-  const double* absolute_pos_;
-  const double* torque_sensor_;
+  const double* pos_           = nullptr;
+  const double* vel_           = nullptr;
+  const double* eff_           = nullptr;
+  const double* absolute_pos_  = nullptr;
+  const double* torque_sensor_ = nullptr;
 };
 
 /** \brief Hardware interface to support reading the state of an array of joints

--- a/hardware_interface/include/hardware_interface/posvel_command_interface.h
+++ b/hardware_interface/include/hardware_interface/posvel_command_interface.h
@@ -42,7 +42,7 @@ namespace hardware_interface
 class PosVelJointHandle : public JointStateHandle
 {
 public:
-  PosVelJointHandle() : JointStateHandle(), cmd_pos_(nullptr), cmd_vel_(nullptr) {}
+  PosVelJointHandle() {}
 
   /**
    * \param js This joint's state handle
@@ -75,8 +75,8 @@ public:
   double getCommandVelocity()     const {assert(cmd_vel_); return *cmd_vel_;}
 
 private:
-  double* cmd_pos_;
-  double* cmd_vel_;
+  double* cmd_pos_ = nullptr;
+  double* cmd_vel_ = nullptr;
 };
 
 /** \brief Hardware interface to support commanding an array of joints.

--- a/hardware_interface/include/hardware_interface/posvel_command_interface.h
+++ b/hardware_interface/include/hardware_interface/posvel_command_interface.h
@@ -75,8 +75,8 @@ public:
   double getCommandVelocity()     const {assert(cmd_vel_); return *cmd_vel_;}
 
 private:
-  double* cmd_pos_ = nullptr;
-  double* cmd_vel_ = nullptr;
+  double* cmd_pos_ = {nullptr};
+  double* cmd_vel_ = {nullptr};
 };
 
 /** \brief Hardware interface to support commanding an array of joints.

--- a/hardware_interface/include/hardware_interface/posvelacc_command_interface.h
+++ b/hardware_interface/include/hardware_interface/posvelacc_command_interface.h
@@ -70,7 +70,7 @@ public:
   double getCommandAcceleration() const {assert(cmd_acc_); return *cmd_acc_;}
 
 private:
-  double* cmd_acc_ = nullptr;
+  double* cmd_acc_ = {nullptr};
 };
 
 

--- a/hardware_interface/include/hardware_interface/posvelacc_command_interface.h
+++ b/hardware_interface/include/hardware_interface/posvelacc_command_interface.h
@@ -42,7 +42,7 @@ namespace hardware_interface
 class PosVelAccJointHandle : public PosVelJointHandle
 {
 public:
-  PosVelAccJointHandle() : PosVelJointHandle(), cmd_acc_(nullptr) {}
+  PosVelAccJointHandle() {}
 
   /**
    * \param js This joint's state handle
@@ -70,7 +70,7 @@ public:
   double getCommandAcceleration() const {assert(cmd_acc_); return *cmd_acc_;}
 
 private:
-  double* cmd_acc_;
+  double* cmd_acc_ = nullptr;
 };
 
 

--- a/hardware_interface/test/actuator_command_interface_test.cpp
+++ b/hardware_interface/test/actuator_command_interface_test.cpp
@@ -65,25 +65,15 @@ TEST(ActuatorStateHandleTest, AssertionTriggering)
 
 class ActuatorCommandInterfaceTest : public ::testing::Test
 {
-public:
-  ActuatorCommandInterfaceTest()
-    : pos1(1.0), vel1(2.0), eff1(3.0), cmd1(0.0),
-      pos2(4.0), vel2(5.0), eff2(6.0), cmd2(0.0),
-      name1("name_1"),
-      name2("name_2"),
-      hs1(name1, &pos1, &vel1, &eff1),
-      hs2(name2, &pos2, &vel2, &eff2),
-      hc1(hs1, &cmd1),
-      hc2(hs2, &cmd2)
-  {}
-
 protected:
-  double pos1, vel1, eff1, cmd1;
-  double pos2, vel2, eff2, cmd2;
-  string name1;
-  string name2;
-  ActuatorStateHandle hs1, hs2;
-  ActuatorHandle hc1, hc2;
+  double pos1 = 1.0, vel1 = 2.0, eff1 = 3.0, cmd1 = 0.0;
+  double pos2 = 4.0, vel2 = 5.0, eff2 = 6.0, cmd2 = 0.0;
+  string name1 = "name_1";
+  string name2 = "name_2";
+  ActuatorStateHandle hs1 = ActuatorStateHandle(name1, &pos1, &vel1, &eff1);
+  ActuatorStateHandle hs2 = ActuatorStateHandle(name2, &pos2, &vel2, &eff2);
+  ActuatorHandle hc1 = ActuatorHandle(hs1, &cmd1);
+  ActuatorHandle hc2 = ActuatorHandle(hs2, &cmd2);
 };
 
 TEST_F(ActuatorCommandInterfaceTest, ExcerciseApi)

--- a/hardware_interface/test/actuator_command_interface_test.cpp
+++ b/hardware_interface/test/actuator_command_interface_test.cpp
@@ -66,14 +66,14 @@ TEST(ActuatorStateHandleTest, AssertionTriggering)
 class ActuatorCommandInterfaceTest : public ::testing::Test
 {
 protected:
-  double pos1 = 1.0, vel1 = 2.0, eff1 = 3.0, cmd1 = 0.0;
-  double pos2 = 4.0, vel2 = 5.0, eff2 = 6.0, cmd2 = 0.0;
-  string name1 = "name_1";
-  string name2 = "name_2";
-  ActuatorStateHandle hs1 = ActuatorStateHandle(name1, &pos1, &vel1, &eff1);
-  ActuatorStateHandle hs2 = ActuatorStateHandle(name2, &pos2, &vel2, &eff2);
-  ActuatorHandle hc1 = ActuatorHandle(hs1, &cmd1);
-  ActuatorHandle hc2 = ActuatorHandle(hs2, &cmd2);
+  double pos1 = {1.0}, vel1 = {2.0}, eff1 = {3.0}, cmd1 = {0.0};
+  double pos2 = {4.0}, vel2 = {5.0}, eff2 = {6.0}, cmd2 = {0.0};
+  string name1 = {"name_1"};
+  string name2 = {"name_2"};
+  ActuatorStateHandle hs1 = {name1, &pos1, &vel1, &eff1};
+  ActuatorStateHandle hs2 = {name2, &pos2, &vel2, &eff2};
+  ActuatorHandle hc1 = {hs1, &cmd1};
+  ActuatorHandle hc2 = {hs2, &cmd2};
 };
 
 TEST_F(ActuatorCommandInterfaceTest, ExcerciseApi)

--- a/hardware_interface/test/actuator_state_interface_test.cpp
+++ b/hardware_interface/test/actuator_state_interface_test.cpp
@@ -71,12 +71,12 @@ TEST(ActuatorStateHandleTest, AssertionTriggering)
 class ActuatorStateInterfaceTest : public ::testing::Test
 {
 protected:
-  double pos1 = 1.0, vel1 = 2.0, eff1 = 3.0;
-  double pos2 = 4.0, vel2 = 5.0, eff2 = 6.0;
-  string name1 = "name_1";
-  string name2 = "name_2";
-  ActuatorStateHandle h1 = ActuatorStateHandle(name1, &pos1, &vel1, &eff1);
-  ActuatorStateHandle h2 = ActuatorStateHandle(name2, &pos2, &vel2, &eff2);
+  double pos1 = {1.0}, vel1 = {2.0}, eff1 = {3.0};
+  double pos2 = {4.0}, vel2 = {5.0}, eff2 = {6.0};
+  string name1 = {"name_1"};
+  string name2 = {"name_2"};
+  ActuatorStateHandle h1 = {name1, &pos1, &vel1, &eff1};
+  ActuatorStateHandle h2 = {name2, &pos2, &vel2, &eff2};
 };
 
 TEST_F(ActuatorStateInterfaceTest, ExcerciseApi)

--- a/hardware_interface/test/actuator_state_interface_test.cpp
+++ b/hardware_interface/test/actuator_state_interface_test.cpp
@@ -70,22 +70,13 @@ TEST(ActuatorStateHandleTest, AssertionTriggering)
 
 class ActuatorStateInterfaceTest : public ::testing::Test
 {
-public:
-  ActuatorStateInterfaceTest()
-    : pos1(1.0), vel1(2.0), eff1(3.0),
-      pos2(4.0), vel2(5.0), eff2(6.0),
-      name1("name_1"),
-      name2("name_2"),
-      h1(name1, &pos1, &vel1, &eff1),
-      h2(name2, &pos2, &vel2, &eff2)
-  {}
-
 protected:
-  double pos1, vel1, eff1;
-  double pos2, vel2, eff2;
-  string name1;
-  string name2;
-  ActuatorStateHandle h1, h2;
+  double pos1 = 1.0, vel1 = 2.0, eff1 = 3.0;
+  double pos2 = 4.0, vel2 = 5.0, eff2 = 6.0;
+  string name1 = "name_1";
+  string name2 = "name_2";
+  ActuatorStateHandle h1 = ActuatorStateHandle(name1, &pos1, &vel1, &eff1);
+  ActuatorStateHandle h2 = ActuatorStateHandle(name2, &pos2, &vel2, &eff2);
 };
 
 TEST_F(ActuatorStateInterfaceTest, ExcerciseApi)

--- a/hardware_interface/test/force_torque_sensor_interface_test.cpp
+++ b/hardware_interface/test/force_torque_sensor_interface_test.cpp
@@ -63,10 +63,10 @@ protected:
   double force2[3] = {4.0, 5.0, 6.0};
   double torque1[3] = {-force1[0], -force1[1], -force1[2]};
   double torque2[3] = {-force2[0], -force2[1], -force2[2]};
-  string name1 = "name_1", name2 = "name_2";
-  string frame_id1 = "frame_1", frame_id2 = "frame_2";
-  ForceTorqueSensorHandle h1 = ForceTorqueSensorHandle(name1, frame_id1, force1, torque1);
-  ForceTorqueSensorHandle h2 = ForceTorqueSensorHandle(name2, frame_id2, nullptr, torque2); // Torque-only sensor
+  string name1 = {"name_1"}, name2 = {"name_2"};
+  string frame_id1 = {"frame_1"}, frame_id2 = {"frame_2"};
+  ForceTorqueSensorHandle h1 = {name1, frame_id1, force1, torque1};
+  ForceTorqueSensorHandle h2 = {name2, frame_id2, nullptr, torque2}; // Torque-only sensor
 };
 
 TEST_F(ForceTorqueSensorInterfaceTest, ExcerciseApi)

--- a/hardware_interface/test/force_torque_sensor_interface_test.cpp
+++ b/hardware_interface/test/force_torque_sensor_interface_test.cpp
@@ -58,39 +58,15 @@ TEST(ForceTorqueSensorHandleTest, HandleConstruction)
 
 class ForceTorqueSensorInterfaceTest : public ::testing::Test
 {
-public:
-  ForceTorqueSensorInterfaceTest()
-    : force1(), force2(),
-      torque1(), torque2(),
-      name1("name_1"), name2("name_2"),
-      frame_id1("frame_1"), frame_id2("frame_2"),
-      h1(name1, frame_id1, force1, torque1),
-      h2(name2, frame_id2, nullptr, torque2) // Torque-only sensor
-  {
-    force1[0] = 1.0;
-    force1[1] = 2.0;
-    force1[2] = 3.0;
-
-    torque1[0] = -force1[0];
-    torque1[1] = -force1[1];
-    torque1[2] = -force1[2];
-
-    force2[0] = 4.0;
-    force2[1] = 5.0;
-    force2[2] = 6.0;
-
-    torque2[0] = -force2[0];
-    torque2[1] = -force2[1];
-    torque2[2] = -force2[2];
-  }
-
 protected:
-  double force1[3], force2[3];
-  double torque1[3], torque2[3];
-  string name1, name2;
-  string frame_id1, frame_id2;
-  ForceTorqueSensorHandle h1;
-  ForceTorqueSensorHandle h2;
+  double force1[3] = {1.0, 2.0, 3.0};
+  double force2[3] = {4.0, 5.0, 6.0};
+  double torque1[3] = {-force1[0], -force1[1], -force1[2]};
+  double torque2[3] = {-force2[0], -force2[1], -force2[2]};
+  string name1 = "name_1", name2 = "name_2";
+  string frame_id1 = "frame_1", frame_id2 = "frame_2";
+  ForceTorqueSensorHandle h1 = ForceTorqueSensorHandle(name1, frame_id1, force1, torque1);
+  ForceTorqueSensorHandle h2 = ForceTorqueSensorHandle(name2, frame_id2, nullptr, torque2); // Torque-only sensor
 };
 
 TEST_F(ForceTorqueSensorInterfaceTest, ExcerciseApi)

--- a/hardware_interface/test/hardware_resource_manager_test.cpp
+++ b/hardware_interface/test/hardware_resource_manager_test.cpp
@@ -57,8 +57,8 @@ private:
 class HardwareResourceManagerTest : public ::testing::Test
 {
 protected:
-  HandleType h1 = HandleType("resource1", 1);
-  HandleType h2 = HandleType("resource2", 2);
+  HandleType h1 = {"resource1", 1};
+  HandleType h2 = {"resource2", 2};
 };
 
 TEST_F(HardwareResourceManagerTest, ExcerciseApi)

--- a/hardware_interface/test/hardware_resource_manager_test.cpp
+++ b/hardware_interface/test/hardware_resource_manager_test.cpp
@@ -56,12 +56,9 @@ private:
 
 class HardwareResourceManagerTest : public ::testing::Test
 {
-public:
-  HardwareResourceManagerTest()
-    : h1("resource1", 1),
-      h2("resource2", 2) {}
 protected:
-  HandleType h1, h2;
+  HandleType h1 = HandleType("resource1", 1);
+  HandleType h2 = HandleType("resource2", 2);
 };
 
 TEST_F(HardwareResourceManagerTest, ExcerciseApi)

--- a/hardware_interface/test/imu_sensor_interface_test.cpp
+++ b/hardware_interface/test/imu_sensor_interface_test.cpp
@@ -125,8 +125,8 @@ protected:
   double angular_velocity_covariance1[9];
   double linear_acceleration1[3];
   double linear_acceleration_covariance1[9];
-  string name1 = "name_1", name2 = "name_2";
-  string frame_id1 = "frame_1", frame_id2 = "frame_2";
+  string name1 = {"name_1"}, name2 = {"name_2"};
+  string frame_id1 = {"frame_1"}, frame_id2 = {"frame_2"};
   ImuSensorHandle h1;
   ImuSensorHandle h2;
 

--- a/hardware_interface/test/imu_sensor_interface_test.cpp
+++ b/hardware_interface/test/imu_sensor_interface_test.cpp
@@ -77,8 +77,6 @@ class ImuSensorInterfaceTest : public ::testing::Test
 {
 public:
   ImuSensorInterfaceTest()
-    : name1("name_1"), name2("name_2"),
-      frame_id1("frame_1"), frame_id2("frame_2")
   {
     srand(time(nullptr)); // Seed random number generator
 
@@ -127,8 +125,8 @@ protected:
   double angular_velocity_covariance1[9];
   double linear_acceleration1[3];
   double linear_acceleration_covariance1[9];
-  string name1, name2;
-  string frame_id1, frame_id2;
+  string name1 = "name_1", name2 = "name_2";
+  string frame_id1 = "frame_1", frame_id2 = "frame_2";
   ImuSensorHandle h1;
   ImuSensorHandle h2;
 

--- a/hardware_interface/test/interface_manager_test.cpp
+++ b/hardware_interface/test/interface_manager_test.cpp
@@ -34,7 +34,7 @@ using namespace hardware_interface;
 
 struct FooInterface
 {
-  FooInterface(int foo): foo(foo) {}
+  FooInterface(int foo) : foo(foo) {}
   int foo;
 };
 

--- a/hardware_interface/test/joint_command_interface_test.cpp
+++ b/hardware_interface/test/joint_command_interface_test.cpp
@@ -65,25 +65,15 @@ TEST(JointStateHandleTest, AssertionTriggering)
 
 class JointCommandInterfaceTest : public ::testing::Test
 {
-public:
-  JointCommandInterfaceTest()
-    : pos1(1.0), vel1(2.0), eff1(3.0), cmd1(0.0),
-      pos2(4.0), vel2(5.0), eff2(6.0), cmd2(0.0),
-      name1("name_1"),
-      name2("name_2"),
-      hs1(name1, &pos1, &vel1, &eff1),
-      hs2(name2, &pos2, &vel2, &eff2),
-      hc1(hs1, &cmd1),
-      hc2(hs2, &cmd2)
-  {}
-
 protected:
-  double pos1, vel1, eff1, cmd1;
-  double pos2, vel2, eff2, cmd2;
-  string name1;
-  string name2;
-  JointStateHandle hs1, hs2;
-  JointHandle hc1, hc2;
+  double pos1 = 1.0, vel1 = 2.0, eff1 = 3.0, cmd1 = 0.0;
+  double pos2 = 4.0, vel2 = 5.0, eff2 = 6.0, cmd2 = 0.0;
+  string name1 = "name_1";
+  string name2 = "name_2";
+  JointStateHandle hs1 = JointStateHandle(name1, &pos1, &vel1, &eff1);
+  JointStateHandle hs2 = JointStateHandle(name2, &pos2, &vel2, &eff2);
+  JointHandle hc1 = JointHandle(hs1, &cmd1);
+  JointHandle hc2 = JointHandle(hs2, &cmd2);
 };
 
 TEST_F(JointCommandInterfaceTest, ExcerciseApi)

--- a/hardware_interface/test/joint_command_interface_test.cpp
+++ b/hardware_interface/test/joint_command_interface_test.cpp
@@ -66,14 +66,14 @@ TEST(JointStateHandleTest, AssertionTriggering)
 class JointCommandInterfaceTest : public ::testing::Test
 {
 protected:
-  double pos1 = 1.0, vel1 = 2.0, eff1 = 3.0, cmd1 = 0.0;
-  double pos2 = 4.0, vel2 = 5.0, eff2 = 6.0, cmd2 = 0.0;
-  string name1 = "name_1";
-  string name2 = "name_2";
-  JointStateHandle hs1 = JointStateHandle(name1, &pos1, &vel1, &eff1);
-  JointStateHandle hs2 = JointStateHandle(name2, &pos2, &vel2, &eff2);
-  JointHandle hc1 = JointHandle(hs1, &cmd1);
-  JointHandle hc2 = JointHandle(hs2, &cmd2);
+  double pos1 = {1.0}, vel1 = {2.0}, eff1 = {3.0}, cmd1 = {0.0};
+  double pos2 = {4.0}, vel2 = {5.0}, eff2 = {6.0}, cmd2 = {0.0};
+  string name1 = {"name_1"};
+  string name2 = {"name_2"};
+  JointStateHandle hs1 = {name1, &pos1, &vel1, &eff1};
+  JointStateHandle hs2 = {name2, &pos2, &vel2, &eff2};
+  JointHandle hc1 = {hs1, &cmd1};
+  JointHandle hc2 = {hs2, &cmd2};
 };
 
 TEST_F(JointCommandInterfaceTest, ExcerciseApi)

--- a/hardware_interface/test/joint_state_interface_test.cpp
+++ b/hardware_interface/test/joint_state_interface_test.cpp
@@ -72,12 +72,12 @@ TEST(JointStateHandleTest, AssertionTriggering)
 class JointStateInterfaceTest : public ::testing::Test
 {
 protected:
-  double pos1 = 1.0, vel1 = 2.0, eff1 = 3.0;
-  double pos2 = 4.0, vel2 = 5.0, eff2 = 6.0;
-  string name1 = "name_1";
-  string name2 = "name_2";
-  JointStateHandle h1 = JointStateHandle(name1, &pos1, &vel1, &eff1);
-  JointStateHandle h2 = JointStateHandle(name2, &pos2, &vel2, &eff2);
+  double pos1 = {1.0}, vel1 = {2.0}, eff1 = {3.0};
+  double pos2 = {4.0}, vel2 = {5.0}, eff2 = {6.0};
+  string name1 = {"name_1"};
+  string name2 = {"name_2"};
+  JointStateHandle h1 = {name1, &pos1, &vel1, &eff1};
+  JointStateHandle h2 = {name2, &pos2, &vel2, &eff2};
 };
 
 TEST_F(JointStateInterfaceTest, ExcerciseApi)

--- a/hardware_interface/test/joint_state_interface_test.cpp
+++ b/hardware_interface/test/joint_state_interface_test.cpp
@@ -71,22 +71,13 @@ TEST(JointStateHandleTest, AssertionTriggering)
 
 class JointStateInterfaceTest : public ::testing::Test
 {
-public:
-  JointStateInterfaceTest()
-    : pos1(1.0), vel1(2.0), eff1(3.0),
-      pos2(4.0), vel2(5.0), eff2(6.0),
-      name1("name_1"),
-      name2("name_2"),
-      h1(name1, &pos1, &vel1, &eff1),
-      h2(name2, &pos2, &vel2, &eff2)
-  {}
-
 protected:
-  double pos1, vel1, eff1;
-  double pos2, vel2, eff2;
-  string name1;
-  string name2;
-  JointStateHandle h1, h2;
+  double pos1 = 1.0, vel1 = 2.0, eff1 = 3.0;
+  double pos2 = 4.0, vel2 = 5.0, eff2 = 6.0;
+  string name1 = "name_1";
+  string name2 = "name_2";
+  JointStateHandle h1 = JointStateHandle(name1, &pos1, &vel1, &eff1);
+  JointStateHandle h2 = JointStateHandle(name2, &pos2, &vel2, &eff2);
 };
 
 TEST_F(JointStateInterfaceTest, ExcerciseApi)

--- a/hardware_interface/test/posvel_command_interface_test.cpp
+++ b/hardware_interface/test/posvel_command_interface_test.cpp
@@ -69,27 +69,15 @@ TEST(JointStateHandleTest, AssertionTriggering)
 
 class PosVelCommandInterfaceTest : public ::testing::Test
 {
-public:
-  PosVelCommandInterfaceTest()
-    : pos1(1.0), vel1(2.0), eff1(3.0),
-      cmd_pos1(0.0), cmd_vel1(0.0),
-      pos2(4.0), vel2(5.0), eff2(6.0),
-      cmd_pos2(0.0), cmd_vel2(0.0),
-      name1("name_1"),
-      name2("name_2"),
-      hs1(name1, &pos1, &vel1, &eff1),
-      hs2(name2, &pos2, &vel2, &eff2),
-      hc1(hs1, &cmd_pos1, &cmd_vel1),
-      hc2(hs2, &cmd_pos2, &cmd_vel2)
-  {}
-
 protected:
-  double pos1, vel1, eff1, cmd_pos1, cmd_vel1;
-  double pos2, vel2, eff2, cmd_pos2, cmd_vel2;
-  string name1;
-  string name2;
-  JointStateHandle hs1, hs2;
-  PosVelJointHandle hc1, hc2;
+  double pos1 = 1.0, vel1 = 2.0, eff1 = 3.0, cmd_pos1 = 0.0, cmd_vel1 = 0.0;
+  double pos2 = 4.0, vel2 = 5.0, eff2 = 6.0, cmd_pos2 = 0.0, cmd_vel2 = 0.0;
+  string name1 = "name_1";
+  string name2 = "name_2";
+  JointStateHandle hs1 = JointStateHandle(name1, &pos1, &vel1, &eff1);
+  JointStateHandle hs2 = JointStateHandle(name2, &pos2, &vel2, &eff2);
+  PosVelJointHandle hc1 = PosVelJointHandle(hs1, &cmd_pos1, &cmd_vel1);
+  PosVelJointHandle hc2 = PosVelJointHandle(hs2, &cmd_pos2, &cmd_vel2);
 };
 
 TEST_F(PosVelCommandInterfaceTest, ExcerciseApi)

--- a/hardware_interface/test/posvel_command_interface_test.cpp
+++ b/hardware_interface/test/posvel_command_interface_test.cpp
@@ -70,14 +70,14 @@ TEST(JointStateHandleTest, AssertionTriggering)
 class PosVelCommandInterfaceTest : public ::testing::Test
 {
 protected:
-  double pos1 = 1.0, vel1 = 2.0, eff1 = 3.0, cmd_pos1 = 0.0, cmd_vel1 = 0.0;
-  double pos2 = 4.0, vel2 = 5.0, eff2 = 6.0, cmd_pos2 = 0.0, cmd_vel2 = 0.0;
-  string name1 = "name_1";
-  string name2 = "name_2";
-  JointStateHandle hs1 = JointStateHandle(name1, &pos1, &vel1, &eff1);
-  JointStateHandle hs2 = JointStateHandle(name2, &pos2, &vel2, &eff2);
-  PosVelJointHandle hc1 = PosVelJointHandle(hs1, &cmd_pos1, &cmd_vel1);
-  PosVelJointHandle hc2 = PosVelJointHandle(hs2, &cmd_pos2, &cmd_vel2);
+  double pos1 = {1.0}, vel1 = {2.0}, eff1 = {3.0}, cmd_pos1 = {0.0}, cmd_vel1 = {0.0};
+  double pos2 = {4.0}, vel2 = {5.0}, eff2 = {6.0}, cmd_pos2 = {0.0}, cmd_vel2 = {0.0};
+  string name1 = {"name_1"};
+  string name2 = {"name_2"};
+  JointStateHandle hs1 = {name1, &pos1, &vel1, &eff1};
+  JointStateHandle hs2 = {name2, &pos2, &vel2, &eff2};
+  PosVelJointHandle hc1 = {hs1, &cmd_pos1, &cmd_vel1};
+  PosVelJointHandle hc2 = {hs2, &cmd_pos2, &cmd_vel2};
 };
 
 TEST_F(PosVelCommandInterfaceTest, ExcerciseApi)

--- a/hardware_interface/test/posvelacc_command_interface_test.cpp
+++ b/hardware_interface/test/posvelacc_command_interface_test.cpp
@@ -73,14 +73,14 @@ TEST(JointStateHandleTest, AssertionTriggering)
 class PosVelAccCommandInterfaceTest : public ::testing::Test
 {
 protected:
-  double pos1 = 1.0, vel1 = 2.0, eff1 = 3.0, cmd_pos1 = 0.0, cmd_vel1 = 0.0, cmd_acc1 = 0.0;
-  double pos2 = 4.0, vel2 = 5.0, eff2 = 6.0, cmd_pos2 = 0.0, cmd_vel2 = 0.0, cmd_acc2 = 0.0;
-  string name1 = "name_1";
-  string name2 = "name_2";
-  JointStateHandle hs1 = JointStateHandle(name1, &pos1, &vel1, &eff1);
-  JointStateHandle hs2 = JointStateHandle(name2, &pos2, &vel2, &eff2);
-  PosVelAccJointHandle hc1 = PosVelAccJointHandle(hs1, &cmd_pos1, &cmd_vel1, &cmd_acc1);
-  PosVelAccJointHandle hc2 = PosVelAccJointHandle(hs2, &cmd_pos2, &cmd_vel2, &cmd_acc2);
+  double pos1 = {1.0}, vel1 = {2.0}, eff1 = {3.0}, cmd_pos1 = {0.0}, cmd_vel1 = {0.0}, cmd_acc1 = {0.0};
+  double pos2 = {4.0}, vel2 = {5.0}, eff2 = {6.0}, cmd_pos2 = {0.0}, cmd_vel2 = {0.0}, cmd_acc2 = {0.0};
+  string name1 = {"name_1"};
+  string name2 = {"name_2"};
+  JointStateHandle hs1 = {name1, &pos1, &vel1, &eff1};
+  JointStateHandle hs2 = {name2, &pos2, &vel2, &eff2};
+  PosVelAccJointHandle hc1 = {hs1, &cmd_pos1, &cmd_vel1, &cmd_acc1};
+  PosVelAccJointHandle hc2 = {hs2, &cmd_pos2, &cmd_vel2, &cmd_acc2};
 };
 
 TEST_F(PosVelAccCommandInterfaceTest, ExcerciseApi)

--- a/hardware_interface/test/posvelacc_command_interface_test.cpp
+++ b/hardware_interface/test/posvelacc_command_interface_test.cpp
@@ -72,27 +72,15 @@ TEST(JointStateHandleTest, AssertionTriggering)
 
 class PosVelAccCommandInterfaceTest : public ::testing::Test
 {
-public:
-  PosVelAccCommandInterfaceTest()
-    : pos1(1.0), vel1(2.0), eff1(3.0),
-      cmd_pos1(0.0), cmd_vel1(0.0), cmd_acc1(0.0),
-      pos2(4.0), vel2(5.0), eff2(6.0),
-      cmd_pos2(0.0), cmd_vel2(0.0), cmd_acc2(0.0),
-      name1("name_1"),
-      name2("name_2"),
-      hs1(name1, &pos1, &vel1, &eff1),
-      hs2(name2, &pos2, &vel2, &eff2),
-      hc1(hs1, &cmd_pos1, &cmd_vel1, &cmd_acc1),
-      hc2(hs2, &cmd_pos2, &cmd_vel2, &cmd_acc2)
-  {}
-
 protected:
-  double pos1, vel1, eff1, cmd_pos1, cmd_vel1, cmd_acc1;
-  double pos2, vel2, eff2, cmd_pos2, cmd_vel2, cmd_acc2;
-  string name1;
-  string name2;
-  JointStateHandle hs1, hs2;
-  PosVelAccJointHandle hc1, hc2;
+  double pos1 = 1.0, vel1 = 2.0, eff1 = 3.0, cmd_pos1 = 0.0, cmd_vel1 = 0.0, cmd_acc1 = 0.0;
+  double pos2 = 4.0, vel2 = 5.0, eff2 = 6.0, cmd_pos2 = 0.0, cmd_vel2 = 0.0, cmd_acc2 = 0.0;
+  string name1 = "name_1";
+  string name2 = "name_2";
+  JointStateHandle hs1 = JointStateHandle(name1, &pos1, &vel1, &eff1);
+  JointStateHandle hs2 = JointStateHandle(name2, &pos2, &vel2, &eff2);
+  PosVelAccJointHandle hc1 = PosVelAccJointHandle(hs1, &cmd_pos1, &cmd_vel1, &cmd_acc1);
+  PosVelAccJointHandle hc2 = PosVelAccJointHandle(hs2, &cmd_pos2, &cmd_vel2, &cmd_acc2);
 };
 
 TEST_F(PosVelAccCommandInterfaceTest, ExcerciseApi)

--- a/hardware_interface/test/robot_hw_test.cpp
+++ b/hardware_interface/test/robot_hw_test.cpp
@@ -40,25 +40,15 @@ using namespace hardware_interface;
 
 class RobotHWTest : public ::testing::Test
 {
-public:
-  RobotHWTest()
-    : pos1(1.0), vel1(2.0), eff1(3.0), cmd1(0.0),
-      pos2(4.0), vel2(5.0), eff2(6.0), cmd2(0.0),
-      name1("name_1"),
-      name2("name_2"),
-      hs1(name1, &pos1, &vel1, &eff1),
-      hs2(name2, &pos2, &vel2, &eff2),
-      hc1(hs1, &cmd1),
-      hc2(hs2, &cmd2)
-  {}
-
 protected:
-  double pos1, vel1, eff1, cmd1;
-  double pos2, vel2, eff2, cmd2;
-  string name1;
-  string name2;
-  JointStateHandle hs1, hs2;
-  JointHandle hc1, hc2;
+  double pos1 = 1.0, vel1 = 2.0, eff1 = 3.0, cmd1 = 0.0;
+  double pos2 = 4.0, vel2 = 5.0, eff2 = 6.0, cmd2 = 0.0;
+  string name1 = "name_1";
+  string name2 = "name_2";
+  JointStateHandle hs1 = JointStateHandle(name1, &pos1, &vel1, &eff1);
+  JointStateHandle hs2 = JointStateHandle(name2, &pos2, &vel2, &eff2);
+  JointHandle hc1 = JointHandle(hs1, &cmd1);
+  JointHandle hc2 = JointHandle(hs2, &cmd2);
 };
 
 TEST_F(RobotHWTest, InterfaceRegistration)
@@ -359,4 +349,3 @@ int main(int argc, char** argv)
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-

--- a/hardware_interface/test/robot_hw_test.cpp
+++ b/hardware_interface/test/robot_hw_test.cpp
@@ -41,14 +41,14 @@ using namespace hardware_interface;
 class RobotHWTest : public ::testing::Test
 {
 protected:
-  double pos1 = 1.0, vel1 = 2.0, eff1 = 3.0, cmd1 = 0.0;
-  double pos2 = 4.0, vel2 = 5.0, eff2 = 6.0, cmd2 = 0.0;
-  string name1 = "name_1";
-  string name2 = "name_2";
-  JointStateHandle hs1 = JointStateHandle(name1, &pos1, &vel1, &eff1);
-  JointStateHandle hs2 = JointStateHandle(name2, &pos2, &vel2, &eff2);
-  JointHandle hc1 = JointHandle(hs1, &cmd1);
-  JointHandle hc2 = JointHandle(hs2, &cmd2);
+  double pos1 = {1.0}, vel1 = {2.0}, eff1 = {3.0}, cmd1 = {0.0};
+  double pos2 = {4.0}, vel2 = {5.0}, eff2 = {6.0}, cmd2 = {0.0};
+  string name1 = {"name_1"};
+  string name2 = {"name_2"};
+  JointStateHandle hs1 = {name1, &pos1, &vel1, &eff1};
+  JointStateHandle hs2 = {name2, &pos2, &vel2, &eff2};
+  JointHandle hc1 = {hs1, &cmd1};
+  JointHandle hc2 = {hs2, &cmd2};
 };
 
 TEST_F(RobotHWTest, InterfaceRegistration)

--- a/joint_limits_interface/include/joint_limits_interface/joint_limits.h
+++ b/joint_limits_interface/include/joint_limits_interface/joint_limits.h
@@ -35,27 +35,27 @@ namespace joint_limits_interface
 
 struct JointLimits
 {
-  double min_position     = 0.0;
-  double max_position     = 0.0;
-  double max_velocity     = 0.0;
-  double max_acceleration = 0.0;
-  double max_jerk         = 0.0;
-  double max_effort       = 0.0;
+  double min_position     = {0.0};
+  double max_position     = {0.0};
+  double max_velocity     = {0.0};
+  double max_acceleration = {0.0};
+  double max_jerk         = {0.0};
+  double max_effort       = {0.0};
 
-  bool   has_position_limits     = false;
-  bool   has_velocity_limits     = false;
-  bool   has_acceleration_limits = false;
-  bool   has_jerk_limits         = false;
-  bool   has_effort_limits       = false;
-  bool   angle_wraparound        = false;
+  bool   has_position_limits     = {false};
+  bool   has_velocity_limits     = {false};
+  bool   has_acceleration_limits = {false};
+  bool   has_jerk_limits         = {false};
+  bool   has_effort_limits       = {false};
+  bool   angle_wraparound        = {false};
 };
 
 struct SoftJointLimits
 {
-  double min_position = 0.0;
-  double max_position = 0.0;
-  double k_position   = 0.0;
-  double k_velocity   = 0.0;
+  double min_position = {0.0};
+  double max_position = {0.0};
+  double k_position   = {0.0};
+  double k_velocity   = {0.0};
 };
 
 }

--- a/joint_limits_interface/include/joint_limits_interface/joint_limits.h
+++ b/joint_limits_interface/include/joint_limits_interface/joint_limits.h
@@ -35,49 +35,27 @@ namespace joint_limits_interface
 
 struct JointLimits
 {
-  JointLimits()
-    : min_position(0.0),
-      max_position(0.0),
-      max_velocity(0.0),
-      max_acceleration(0.0),
-      max_jerk(0.0),
-      max_effort(0.0),
-      has_position_limits(false),
-      has_velocity_limits(false),
-      has_acceleration_limits(false),
-      has_jerk_limits(false),
-      has_effort_limits(false),
-      angle_wraparound(false)
-  {}
+  double min_position     = 0.0;
+  double max_position     = 0.0;
+  double max_velocity     = 0.0;
+  double max_acceleration = 0.0;
+  double max_jerk         = 0.0;
+  double max_effort       = 0.0;
 
-  double min_position;
-  double max_position;
-  double max_velocity;
-  double max_acceleration;
-  double max_jerk;
-  double max_effort;
-
-  bool   has_position_limits;
-  bool   has_velocity_limits;
-  bool   has_acceleration_limits;
-  bool   has_jerk_limits;
-  bool   has_effort_limits;
-  bool   angle_wraparound;
+  bool   has_position_limits     = false;
+  bool   has_velocity_limits     = false;
+  bool   has_acceleration_limits = false;
+  bool   has_jerk_limits         = false;
+  bool   has_effort_limits       = false;
+  bool   angle_wraparound        = false;
 };
 
 struct SoftJointLimits
 {
-  SoftJointLimits()
-    : min_position(0.0),
-      max_position(0.0),
-      k_position(0.0),
-      k_velocity(0.0)
-  {}
-
-  double min_position;
-  double max_position;
-  double k_position;
-  double k_velocity;
+  double min_position = 0.0;
+  double max_position = 0.0;
+  double k_position   = 0.0;
+  double k_velocity   = 0.0;
 };
 
 }

--- a/joint_limits_interface/include/joint_limits_interface/joint_limits_interface.h
+++ b/joint_limits_interface/include/joint_limits_interface/joint_limits_interface.h
@@ -123,7 +123,7 @@ private:
   JointLimits limits_;
   double min_pos_limit_, max_pos_limit_;
 
-  double prev_cmd_ = std::numeric_limits<double>::quiet_NaN();
+  double prev_cmd_ = {std::numeric_limits<double>::quiet_NaN()};
 };
 
 /**
@@ -252,7 +252,7 @@ private:
   JointLimits limits_;
   SoftJointLimits soft_limits_;
 
-  double prev_cmd_ = std::numeric_limits<double>::quiet_NaN();
+  double prev_cmd_ = {std::numeric_limits<double>::quiet_NaN()};
 };
 
 /** \brief A handle used to enforce position, velocity, and effort limits of an effort-controlled joint that does not
@@ -458,7 +458,7 @@ private:
   hardware_interface::JointHandle jh_;
   JointLimits limits_;
 
-  double prev_cmd_ = 0.0;
+  double prev_cmd_ = {0.0};
 };
 
 /** \brief A handle used to enforce position, velocity, and acceleration limits of a velocity-controlled joint. */
@@ -467,10 +467,10 @@ class VelocityJointSoftLimitsHandle
 public:
   VelocityJointSoftLimitsHandle(const hardware_interface::JointHandle& jh, const JointLimits& limits,
                                 const SoftJointLimits& soft_limits)
+      : jh_(jh)
+      , limits_(limits)
+      , soft_limits_(soft_limits)
   {
-    jh_ = jh;
-    limits_ = limits;
-    soft_limits_ = soft_limits;
     if (limits.has_velocity_limits)
       max_vel_limit_ = limits.max_velocity;
     else

--- a/joint_limits_interface/include/joint_limits_interface/joint_limits_interface.h
+++ b/joint_limits_interface/include/joint_limits_interface/joint_limits_interface.h
@@ -78,8 +78,6 @@ public:
       min_pos_limit_ = -std::numeric_limits<double>::max();
       max_pos_limit_ = std::numeric_limits<double>::max();
     }
-
-    prev_cmd_ = std::numeric_limits<double>::quiet_NaN();
   }
 
   /** \return Joint name. */
@@ -124,7 +122,8 @@ private:
   hardware_interface::JointHandle jh_;
   JointLimits limits_;
   double min_pos_limit_, max_pos_limit_;
-  double prev_cmd_;
+
+  double prev_cmd_ = std::numeric_limits<double>::quiet_NaN();
 };
 
 /**
@@ -161,17 +160,14 @@ private:
 class PositionJointSoftLimitsHandle
 {
 public:
-  PositionJointSoftLimitsHandle()
-    : prev_cmd_(std::numeric_limits<double>::quiet_NaN())
-  {}
+  PositionJointSoftLimitsHandle() {}
 
   PositionJointSoftLimitsHandle(const hardware_interface::JointHandle& jh,
                                 const JointLimits&                     limits,
                                 const SoftJointLimits&                 soft_limits)
     : jh_(jh),
       limits_(limits),
-      soft_limits_(soft_limits),
-      prev_cmd_(std::numeric_limits<double>::quiet_NaN())
+      soft_limits_(soft_limits)
   {
     if (!limits.has_velocity_limits)
     {
@@ -256,7 +252,7 @@ private:
   JointLimits limits_;
   SoftJointLimits soft_limits_;
 
-  double prev_cmd_;
+  double prev_cmd_ = std::numeric_limits<double>::quiet_NaN();
 };
 
 /** \brief A handle used to enforce position, velocity, and effort limits of an effort-controlled joint that does not
@@ -406,14 +402,11 @@ private:
 class VelocityJointSaturationHandle
 {
 public:
-  VelocityJointSaturationHandle ()
-    : prev_cmd_(0.0)
-  {}
+  VelocityJointSaturationHandle() {}
 
   VelocityJointSaturationHandle(const hardware_interface::JointHandle& jh, const JointLimits& limits)
     : jh_(jh)
     , limits_(limits)
-    , prev_cmd_(0.0)
   {
     if (!limits.has_velocity_limits)
     {
@@ -465,7 +458,7 @@ private:
   hardware_interface::JointHandle jh_;
   JointLimits limits_;
 
-  double prev_cmd_;
+  double prev_cmd_ = 0.0;
 };
 
 /** \brief A handle used to enforce position, velocity, and acceleration limits of a velocity-controlled joint. */

--- a/joint_limits_interface/test/joint_limits_interface_test.cpp
+++ b/joint_limits_interface/test/joint_limits_interface_test.cpp
@@ -70,10 +70,6 @@ class JointLimitsTest
 {
 public:
   JointLimitsTest()
-    : pos(0.0), vel(0.0), eff(0.0), cmd(0.0),
-      name("joint_name"),
-      period(0.1),
-      cmd_handle(JointStateHandle(name, &pos, &vel, &eff), &cmd)
   {
     limits.has_position_limits = true;
     limits.min_position = -1.0;
@@ -92,10 +88,10 @@ public:
   }
 
 protected:
-  double pos, vel, eff, cmd;
-  string name;
-  ros::Duration period;
-  JointHandle cmd_handle;
+  double pos = 0.0, vel = 0.0, eff = 0.0, cmd = 0.0;
+  string name = "joint_name";
+  ros::Duration period = ros::Duration(0.1);
+  JointHandle cmd_handle = JointHandle(JointStateHandle(name, &pos, &vel, &eff), &cmd);
   JointLimits limits;
   SoftJointLimits soft_limits;
 };
@@ -419,18 +415,10 @@ TEST_F(VelocityJointSaturationHandleTest, EnforceAccelerationBounds)
 
 class JointLimitsInterfaceTest :public JointLimitsTest, public ::testing::Test
 {
-public:
-  JointLimitsInterfaceTest()
-    : JointLimitsTest(),
-      pos2(0.0), vel2(0.0), eff2(0.0), cmd2(0.0),
-      name2("joint2_name"),
-      cmd_handle2(JointStateHandle(name2, &pos2, &vel2, &eff2), &cmd2)
-  {}
-
 protected:
-  double pos2, vel2, eff2, cmd2;
-  string name2;
-  JointHandle cmd_handle2;
+  double pos2 = 0.0, vel2 = 0.0, eff2 = 0.0, cmd2 = 0.0;
+  string name2 = "joint2_name";
+  JointHandle cmd_handle2 = JointHandle(JointStateHandle(name2, &pos2, &vel2, &eff2), &cmd2);
 };
 
 TEST_F(JointLimitsInterfaceTest, InterfaceRegistration)

--- a/joint_limits_interface/test/joint_limits_interface_test.cpp
+++ b/joint_limits_interface/test/joint_limits_interface_test.cpp
@@ -88,10 +88,10 @@ public:
   }
 
 protected:
-  double pos = 0.0, vel = 0.0, eff = 0.0, cmd = 0.0;
-  string name = "joint_name";
-  ros::Duration period = ros::Duration(0.1);
-  JointHandle cmd_handle = JointHandle(JointStateHandle(name, &pos, &vel, &eff), &cmd);
+  double pos = {0.0}, vel = {0.0}, eff = {0.0}, cmd = {0.0};
+  string name = {"joint_name"};
+  ros::Duration period = ros::Duration{0.1};
+  JointHandle cmd_handle = {JointStateHandle(name, &pos, &vel, &eff), &cmd};
   JointLimits limits;
   SoftJointLimits soft_limits;
 };
@@ -416,9 +416,9 @@ TEST_F(VelocityJointSaturationHandleTest, EnforceAccelerationBounds)
 class JointLimitsInterfaceTest :public JointLimitsTest, public ::testing::Test
 {
 protected:
-  double pos2 = 0.0, vel2 = 0.0, eff2 = 0.0, cmd2 = 0.0;
-  string name2 = "joint2_name";
-  JointHandle cmd_handle2 = JointHandle(JointStateHandle(name2, &pos2, &vel2, &eff2), &cmd2);
+  double pos2 = {0.0}, vel2 = {0.0}, eff2 = {0.0}, cmd2 = {0.0};
+  string name2 = {"joint2_name"};
+  JointHandle cmd_handle2 = {JointStateHandle(name2, &pos2, &vel2, &eff2), &cmd2};
 };
 
 TEST_F(JointLimitsInterfaceTest, InterfaceRegistration)

--- a/transmission_interface/include/transmission_interface/differential_transmission.h
+++ b/transmission_interface/include/transmission_interface/differential_transmission.h
@@ -130,7 +130,7 @@ public:
   /**
    * \param actuator_reduction Reduction ratio of actuators.
    * \param joint_reduction    Reduction ratio of joints.
-   * \param ignore_transmission_for_absolute_encoders Whether to take the data directly from absolute encoders instead of calculating through transmission. 
+   * \param ignore_transmission_for_absolute_encoders Whether to take the data directly from absolute encoders instead of calculating through transmission.
    * \param joint_offset       Joint position offset used in the position mappings.
    * \pre Nonzero actuator and joint reduction values.
    */
@@ -245,8 +245,7 @@ inline DifferentialTransmission::DifferentialTransmission(const std::vector<doub
                                                           const std::vector<double>& joint_reduction,
                                                           const bool ignore_transmission_for_absolute_encoders,
                                                           const std::vector<double>& joint_offset)
-  : Transmission(),
-    act_reduction_(actuator_reduction),
+  : act_reduction_(actuator_reduction),
     jnt_reduction_(joint_reduction),
     jnt_offset_(joint_offset),
     ignore_transmission_for_absolute_encoders_(ignore_transmission_for_absolute_encoders)

--- a/transmission_interface/include/transmission_interface/four_bar_linkage_transmission.h
+++ b/transmission_interface/include/transmission_interface/four_bar_linkage_transmission.h
@@ -156,7 +156,7 @@ public:
    */
   void actuatorToJointPosition(const ActuatorData& act_data,
                                      JointData&    jnt_data);
-  
+
   /**
    * \brief Transform \e absolute encoder values from actuator to joint space.
    * \param[in]  act_data Actuator-space variables.
@@ -224,8 +224,7 @@ protected:
 inline FourBarLinkageTransmission::FourBarLinkageTransmission(const std::vector<double>& actuator_reduction,
                                                               const std::vector<double>& joint_reduction,
                                                               const std::vector<double>& joint_offset)
-  : Transmission(),
-    act_reduction_(actuator_reduction),
+  : act_reduction_(actuator_reduction),
     jnt_reduction_(joint_reduction),
     jnt_offset_(joint_offset)
 {
@@ -295,7 +294,7 @@ void FourBarLinkageTransmission::actuatorToJointAbsolutePosition(const ActuatorD
   const std::vector<double>& jr = jnt_reduction_;
 
   *jnt_data.absolute_position[0] = *act_data.absolute_position[0] /(jr[0] * ar[0]) + jnt_offset_[0];
-  *jnt_data.absolute_position[1] = (*act_data.absolute_position[1] / ar[1] - *act_data.absolute_position[0] / (jr[0] * ar[0])) / 
+  *jnt_data.absolute_position[1] = (*act_data.absolute_position[1] / ar[1] - *act_data.absolute_position[0] / (jr[0] * ar[0])) /
                                     jr[1] + jnt_offset_[1];
 }
 

--- a/transmission_interface/include/transmission_interface/simple_transmission.h
+++ b/transmission_interface/include/transmission_interface/simple_transmission.h
@@ -185,8 +185,7 @@ private:
 
 inline SimpleTransmission::SimpleTransmission(const double reduction,
                                               const double joint_offset)
-  : Transmission(),
-    reduction_(reduction),
+  : reduction_(reduction),
     jnt_offset_(joint_offset)
 {
   if (0.0 == reduction_)

--- a/transmission_interface/include/transmission_interface/transmission_interface_loader.h
+++ b/transmission_interface/include/transmission_interface/transmission_interface_loader.h
@@ -104,17 +104,17 @@ bool is_permutation(ForwardIt1 first, ForwardIt1 last,
 // TODO: Don't assume interfaces?
 struct RawJointData
 {
-  double position          = std::numeric_limits<double>::quiet_NaN();
-  double velocity          = std::numeric_limits<double>::quiet_NaN();
-  double effort            = std::numeric_limits<double>::quiet_NaN();
-  double position_cmd      = std::numeric_limits<double>::quiet_NaN();
-  double velocity_cmd      = std::numeric_limits<double>::quiet_NaN();
-  double effort_cmd        = std::numeric_limits<double>::quiet_NaN();
-  double absolute_position = std::numeric_limits<double>::quiet_NaN();
-  double torque_sensor     = std::numeric_limits<double>::quiet_NaN();
+  double position          = {std::numeric_limits<double>::quiet_NaN()};
+  double velocity          = {std::numeric_limits<double>::quiet_NaN()};
+  double effort            = {std::numeric_limits<double>::quiet_NaN()};
+  double position_cmd      = {std::numeric_limits<double>::quiet_NaN()};
+  double velocity_cmd      = {std::numeric_limits<double>::quiet_NaN()};
+  double effort_cmd        = {std::numeric_limits<double>::quiet_NaN()};
+  double absolute_position = {std::numeric_limits<double>::quiet_NaN()};
+  double torque_sensor     = {std::numeric_limits<double>::quiet_NaN()};
 
-  bool hasAbsolutePosition = true;
-  bool hasTorqueSensor     = true;
+  bool hasAbsolutePosition = {true};
+  bool hasTorqueSensor     = {true};
 };
 
 typedef std::map<std::string, RawJointData> RawJointDataMap;
@@ -148,8 +148,8 @@ struct InverseTransmissionInterfaces
 
 struct TransmissionLoaderData
 {
-  hardware_interface::RobotHW*  robot_hw            = nullptr; ///< Lifecycle is externally controlled (ie. hardware abstraction)
-  RobotTransmissions*           robot_transmissions = nullptr; ///< Lifecycle is externally controlled (ie. hardware abstraction)
+  hardware_interface::RobotHW*  robot_hw            = {nullptr}; ///< Lifecycle is externally controlled (ie. hardware abstraction)
+  RobotTransmissions*           robot_transmissions = {nullptr}; ///< Lifecycle is externally controlled (ie. hardware abstraction)
   JointInterfaces               joint_interfaces;
   RawJointDataMap               raw_joint_data_map;
   ForwardTransmissionInterfaces transmission_interfaces;

--- a/transmission_interface/include/transmission_interface/transmission_interface_loader.h
+++ b/transmission_interface/include/transmission_interface/transmission_interface_loader.h
@@ -104,30 +104,17 @@ bool is_permutation(ForwardIt1 first, ForwardIt1 last,
 // TODO: Don't assume interfaces?
 struct RawJointData
 {
-  RawJointData()
-    : position(std::numeric_limits<double>::quiet_NaN()),
-      velocity(std::numeric_limits<double>::quiet_NaN()),
-      effort(std::numeric_limits<double>::quiet_NaN()),
-      position_cmd(std::numeric_limits<double>::quiet_NaN()),
-      velocity_cmd(std::numeric_limits<double>::quiet_NaN()),
-      effort_cmd(std::numeric_limits<double>::quiet_NaN()),
-      absolute_position(std::numeric_limits<double>::quiet_NaN()),
-      torque_sensor(std::numeric_limits<double>::quiet_NaN()),
-      hasAbsolutePosition(true),
-      hasTorqueSensor(true)
-  {}
+  double position          = std::numeric_limits<double>::quiet_NaN();
+  double velocity          = std::numeric_limits<double>::quiet_NaN();
+  double effort            = std::numeric_limits<double>::quiet_NaN();
+  double position_cmd      = std::numeric_limits<double>::quiet_NaN();
+  double velocity_cmd      = std::numeric_limits<double>::quiet_NaN();
+  double effort_cmd        = std::numeric_limits<double>::quiet_NaN();
+  double absolute_position = std::numeric_limits<double>::quiet_NaN();
+  double torque_sensor     = std::numeric_limits<double>::quiet_NaN();
 
-  double position;
-  double velocity;
-  double effort;
-  double position_cmd;
-  double velocity_cmd;
-  double effort_cmd;
-  double absolute_position;
-  double torque_sensor;
-
-  bool hasAbsolutePosition;
-  bool hasTorqueSensor;
+  bool hasAbsolutePosition = true;
+  bool hasTorqueSensor     = true;
 };
 
 typedef std::map<std::string, RawJointData> RawJointDataMap;
@@ -161,13 +148,8 @@ struct InverseTransmissionInterfaces
 
 struct TransmissionLoaderData
 {
-  TransmissionLoaderData()
-    : robot_hw(nullptr),
-      robot_transmissions(nullptr)
-  {}
-
-  hardware_interface::RobotHW*  robot_hw;            ///< Lifecycle is externally controlled (ie. hardware abstraction)
-  RobotTransmissions*           robot_transmissions; ///< Lifecycle is externally controlled (ie. hardware abstraction)
+  hardware_interface::RobotHW*  robot_hw            = nullptr; ///< Lifecycle is externally controlled (ie. hardware abstraction)
+  RobotTransmissions*           robot_transmissions = nullptr; ///< Lifecycle is externally controlled (ie. hardware abstraction)
   JointInterfaces               joint_interfaces;
   RawJointDataMap               raw_joint_data_map;
   ForwardTransmissionInterfaces transmission_interfaces;

--- a/transmission_interface/test/differential_transmission_test.cpp
+++ b/transmission_interface/test/differential_transmission_test.cpp
@@ -199,25 +199,12 @@ TEST(PreconditionsTest, AccessorValidation)
 
 class TransmissionSetup : public ::testing::Test
 {
-public:
-  TransmissionSetup()
-    : a_val(),
-      j_val(),
-      a_vec(vector<double*>(2)),
-      j_vec(vector<double*>(2))
-   {
-     a_vec[0] = &a_val[0];
-     a_vec[1] = &a_val[1];
-     j_vec[0] = &j_val[0];
-     j_vec[1] = &j_val[1];
-   }
-
 protected:
   // Input/output transmission data
   double a_val[2];
   double j_val[2];
-  vector<double*> a_vec;
-  vector<double*> j_vec;
+  vector<double*> a_vec = {&a_val[0], &a_val[1]};
+  vector<double*> j_vec = {&j_val[0], &j_val[1]};
 };
 
 /// \brief Exercises the actuator->joint->actuator roundtrip, which should yield the identity map.

--- a/transmission_interface/test/four_bar_linkage_transmission_test.cpp
+++ b/transmission_interface/test/four_bar_linkage_transmission_test.cpp
@@ -199,25 +199,12 @@ TEST(PreconditionsTest, AccessorValidation)
 
 class TransmissionSetup : public ::testing::Test
 {
-public:
-  TransmissionSetup()
-    : a_val(),
-      j_val(),
-      a_vec(vector<double*>(2)),
-      j_vec(vector<double*>(2))
-   {
-     a_vec[0] = &a_val[0];
-     a_vec[1] = &a_val[1];
-     j_vec[0] = &j_val[0];
-     j_vec[1] = &j_val[1];
-   }
-
 protected:
   // Input/output transmission data
   double a_val[2];
   double j_val[2];
-  vector<double*> a_vec;
-  vector<double*> j_vec;
+  vector<double*> a_vec = {&a_val[0], &a_val[1]};
+  vector<double*> j_vec = {&j_val[0], &j_val[1]};
 };
 
 /// \brief Exercises the actuator->joint->actuator roundtrip, which should yield the identity map.

--- a/transmission_interface/test/loader_utils.h
+++ b/transmission_interface/test/loader_utils.h
@@ -39,14 +39,8 @@ using namespace transmission_interface;
 
 struct TransmissionPluginLoader
 {
-  TransmissionPluginLoader()
-    :class_loader_("transmission_interface", "transmission_interface::TransmissionLoader")
-  {
-  }
-
   TransmissionLoaderSharedPtr create(const std::string& type)
   {
-
     try
     {
       return class_loader_.createUniqueInstance(type);
@@ -56,5 +50,5 @@ struct TransmissionPluginLoader
 
 private:
   //must keep it alive because instance destroyers need it
-  pluginlib::ClassLoader<TransmissionLoader> class_loader_;
+  pluginlib::ClassLoader<TransmissionLoader> class_loader_ = {"transmission_interface", "transmission_interface::TransmissionLoader"};
 };

--- a/transmission_interface/test/simple_transmission_test.cpp
+++ b/transmission_interface/test/simple_transmission_test.cpp
@@ -153,8 +153,8 @@ class TransmissionSetup
 {
 protected:
   // Input/output transmission data
-  double a_val = 0.0;
-  double j_val = 0.0;
+  double a_val = {0.0};
+  double j_val = {0.0};
   vector<double*> a_vec = {&a_val};
   vector<double*> j_vec = {&j_val};
 };

--- a/transmission_interface/test/simple_transmission_test.cpp
+++ b/transmission_interface/test/simple_transmission_test.cpp
@@ -151,19 +151,12 @@ TEST(PreconditionsTest, AccessorValidation)
 
 class TransmissionSetup
 {
-public:
-  TransmissionSetup()
-    : a_val(),
-      j_val(),
-      a_vec(vector<double*>(1, &a_val)),
-      j_vec(vector<double*>(1, &j_val)) {}
-
 protected:
   // Input/output transmission data
-  double a_val;
-  double j_val;
-  vector<double*> a_vec;
-  vector<double*> j_vec;
+  double a_val = 0.0;
+  double j_val = 0.0;
+  vector<double*> a_vec = {&a_val};
+  vector<double*> j_vec = {&j_val};
 };
 
 // NOTE: I tried to make the above a proper gtest fixture and below inherit from

--- a/transmission_interface/test/transmission_interface_loader_test.cpp
+++ b/transmission_interface/test/transmission_interface_loader_test.cpp
@@ -70,10 +70,6 @@ class TransmissionInterfaceLoaderTest : public ::testing::Test
 public:
   TransmissionInterfaceLoaderTest()
   {
-    act_names[0] = "foo_actuator";
-    act_names[1] = "bar_actuator";
-    act_names[2] = "baz_actuator";
-
     // Populate actuators interface
     for (unsigned int i = 0; i < dim; ++i)
     {
@@ -96,14 +92,14 @@ public:
   }
 
 protected:
-  const unsigned int       dim         = 3;
-  std::vector<std::string> act_names   = std::vector<std::string>(dim);
-  std::vector<double>      act_pos     = std::vector<double>(dim, 0.0);
-  std::vector<double>      act_vel     = std::vector<double>(dim, 0.0);
-  std::vector<double>      act_eff     = std::vector<double>(dim, 0.0);
-  std::vector<double>      act_pos_cmd = std::vector<double>(dim, 0.0);
-  std::vector<double>      act_vel_cmd = std::vector<double>(dim, 0.0);
-  std::vector<double>      act_eff_cmd = std::vector<double>(dim, 0.0);
+  const unsigned int       dim         = {3};
+  std::vector<std::string> act_names   = {"foo_actuator", "bar_actuator", "baz_actuator"};
+  std::vector<double>      act_pos     = {0.0, 0.0, 0.0};
+  std::vector<double>      act_vel     = {0.0, 0.0, 0.0};
+  std::vector<double>      act_eff     = {0.0, 0.0, 0.0};
+  std::vector<double>      act_pos_cmd = {0.0, 0.0, 0.0};
+  std::vector<double>      act_vel_cmd = {0.0, 0.0, 0.0};
+  std::vector<double>      act_eff_cmd = {0.0, 0.0, 0.0};
 
   hardware_interface::ActuatorStateInterface    act_state_iface;
   hardware_interface::PositionActuatorInterface pos_act_iface;

--- a/transmission_interface/test/transmission_interface_loader_test.cpp
+++ b/transmission_interface/test/transmission_interface_loader_test.cpp
@@ -69,14 +69,6 @@ class TransmissionInterfaceLoaderTest : public ::testing::Test
 {
 public:
   TransmissionInterfaceLoaderTest()
-    : dim(3),
-      act_names(3),
-      act_pos(3, 0.0),
-      act_vel(3, 0.0),
-      act_eff(3, 0.0),
-      act_pos_cmd(3, 0.0),
-      act_vel_cmd(3, 0.0),
-      act_eff_cmd(3, 0.0)
   {
     act_names[0] = "foo_actuator";
     act_names[1] = "bar_actuator";
@@ -104,9 +96,15 @@ public:
   }
 
 protected:
-  unsigned int dim;
-  std::vector<std::string> act_names;
-  std::vector<double> act_pos, act_vel, act_eff, act_pos_cmd, act_vel_cmd, act_eff_cmd;
+  const unsigned int       dim         = 3;
+  std::vector<std::string> act_names   = std::vector<std::string>(dim);
+  std::vector<double>      act_pos     = std::vector<double>(dim, 0.0);
+  std::vector<double>      act_vel     = std::vector<double>(dim, 0.0);
+  std::vector<double>      act_eff     = std::vector<double>(dim, 0.0);
+  std::vector<double>      act_pos_cmd = std::vector<double>(dim, 0.0);
+  std::vector<double>      act_vel_cmd = std::vector<double>(dim, 0.0);
+  std::vector<double>      act_eff_cmd = std::vector<double>(dim, 0.0);
+
   hardware_interface::ActuatorStateInterface    act_state_iface;
   hardware_interface::PositionActuatorInterface pos_act_iface;
   hardware_interface::VelocityActuatorInterface vel_act_iface;

--- a/transmission_interface/test/transmission_interface_test.cpp
+++ b/transmission_interface/test/transmission_interface_test.cpp
@@ -223,8 +223,8 @@ protected:
   double a_cmd_pos[2], a_cmd_vel[2], a_cmd_eff[2];
   double j_cmd_pos[2], j_cmd_vel[2], j_cmd_eff[2];
 
-  SimpleTransmission trans1 = SimpleTransmission( 10.0, 1.0);
-  SimpleTransmission trans2 = SimpleTransmission(-10.0, 1.0);
+  SimpleTransmission trans1 = { 10.0, 1.0};
+  SimpleTransmission trans2 = {-10.0, 1.0};
 };
 
 class HandleWhiteBoxTest : public TransmissionInterfaceSetup {};

--- a/transmission_interface/test/transmission_interface_test.cpp
+++ b/transmission_interface/test/transmission_interface_test.cpp
@@ -215,15 +215,6 @@ TEST(HandlePreconditionsTest, BadDataPointer)
 
 class TransmissionInterfaceSetup : public ::testing::Test
 {
-public:
-  TransmissionInterfaceSetup()
-    : a_curr_pos(), a_curr_vel(), a_curr_eff(),
-      j_curr_pos(), j_curr_vel(), j_curr_eff(),
-      a_cmd_pos(), a_cmd_vel(), a_cmd_eff(),
-      j_cmd_pos(), j_cmd_vel(), j_cmd_eff(),
-      trans1( 10.0, 1.0),
-      trans2(-10.0, 1.0) {}
-
 protected:
   // Input/output transmission data
   double a_curr_pos[2], a_curr_vel[2], a_curr_eff[2];
@@ -232,8 +223,8 @@ protected:
   double a_cmd_pos[2], a_cmd_vel[2], a_cmd_eff[2];
   double j_cmd_pos[2], j_cmd_vel[2], j_cmd_eff[2];
 
-  SimpleTransmission trans1;
-  SimpleTransmission trans2;
+  SimpleTransmission trans1 = SimpleTransmission( 10.0, 1.0);
+  SimpleTransmission trans2 = SimpleTransmission(-10.0, 1.0);
 };
 
 class HandleWhiteBoxTest : public TransmissionInterfaceSetup {};


### PR DESCRIPTION
Part of #403.

When possible, prefer the use of default member initializers. Note that I didn't make an effort to add default initializers for all members, I only focussed on moving initializations out of constructors.

This sets the stage for cleaning up constructors using `= default` and `= delete`. (Follow-up PR containing those changes is ready, I'll rebase and open it once this PR is completed)