### PR TITLE
Improve controller and resource filtering for CombinedRobotHW

### DIFF
--- a/combined_robot_hw/src/combined_robot_hw.cpp
+++ b/combined_robot_hw/src/combined_robot_hw.cpp
@@ -237,10 +237,16 @@ namespace combined_robot_hw
             filtered_resources.insert(resource);
           }
         }
-        filtered_iface_resources.resources = filtered_resources;
-        filtered_controller.claimed_resources.push_back(filtered_iface_resources);
+        if (!filtered_resources.empty())
+        {
+          filtered_iface_resources.resources = filtered_resources;
+          filtered_controller.claimed_resources.push_back(filtered_iface_resources);
+        }
       }
-      filtered_list.push_back(filtered_controller);
+      if (!filtered_controller.claimed_resources.empty())
+      {
+        filtered_list.push_back(filtered_controller);
+      }
     }
   }
 }

--- a/combined_robot_hw_tests/src/my_robot_hw_2.cpp
+++ b/combined_robot_hw_tests/src/my_robot_hw_2.cpp
@@ -88,6 +88,21 @@ bool MyRobotHW2::prepareSwitch(const std::list<hardware_interface::ControllerInf
 {
   for (const auto& controller : start_list)
   {
+    if (controller.name == "ctrl_without_my_robot_hw_2_resources")
+    {
+      ROS_ERROR_STREAM("Controller should have been filtered out: " << controller.name);
+      return false;
+    }
+
+    if (controller.name == "ctrl_without_my_robot_hw_2_resources_in_one_of_two_ifaces")
+    {
+      if (controller.claimed_resources.size() > 1)
+      {
+        ROS_ERROR_STREAM("One of the interfaces should have been filtered out");
+        return false;
+      }
+    }
+
     if (controller.claimed_resources.empty())
     {
       continue;
@@ -123,6 +138,19 @@ void MyRobotHW2::doSwitch(const std::list<hardware_interface::ControllerInfo>& s
 {
   for (const auto& controller : start_list)
   {
+    if (controller.name == "ctrl_without_my_robot_hw_2_resources")
+    {
+      throw hardware_interface::HardwareInterfaceException("Controller " + controller.name + " should have been filtered out");
+    }
+
+    if (controller.name == "ctrl_without_my_robot_hw_2_resources_in_one_of_two_ifaces")
+    {
+      if (controller.claimed_resources.size() > 1)
+      {
+        throw hardware_interface::HardwareInterfaceException("One of the interfaces should have been filtered out");
+      }
+    }
+
     if (controller.claimed_resources.empty())
     {
       continue;

--- a/combined_robot_hw_tests/test/combined_robot_hw_test.cpp
+++ b/combined_robot_hw_tests/test/combined_robot_hw_test.cpp
@@ -193,6 +193,42 @@ TEST(CombinedRobotHWTests, switchOk)
     ASSERT_NO_THROW(robot_hw.doSwitch(start_list, stop_list));
   }
 
+  // Test resource and controller filtering
+  {
+    std::list<hardware_interface::ControllerInfo> start_list;
+    std::list<hardware_interface::ControllerInfo> stop_list;
+    hardware_interface::ControllerInfo controller_1;
+    controller_1.name = "ctrl_without_my_robot_hw_2_resources_in_one_of_two_ifaces";
+    controller_1.type = "some_type";
+    hardware_interface::InterfaceResources iface_res_1;
+    // iface_res_1 should be filtered out when controller_1 is passed to my_robot_hw_2
+    // as none of its resources belongs to my_robot_hw_2
+    iface_res_1.hardware_interface = "hardware_interface::EffortJointInterface";
+    iface_res_1.resources.insert("test_joint1");
+    iface_res_1.resources.insert("test_joint2");
+    iface_res_1.resources.insert("test_joint3");
+    controller_1.claimed_resources.push_back(iface_res_1);
+    hardware_interface::InterfaceResources iface_res_2;
+    iface_res_2.hardware_interface = "hardware_interface::VelocityJointInterface";
+    iface_res_2.resources.insert("test_joint1");
+    iface_res_2.resources.insert("test_joint4");
+    controller_1.claimed_resources.push_back(iface_res_1);
+    start_list.push_back(controller_1);
+
+    hardware_interface::ControllerInfo controller_2;
+    // controller_2 should be filtered out when controller_2 is passed to my_robot_hw_2
+    // as none of its resources belongs to my_robot_hw_2
+    controller_2.name = "ctrl_without_my_robot_hw_2_resources";
+    controller_2.type = "some_type";
+    hardware_interface::InterfaceResources iface_res_3;
+    iface_res_3.hardware_interface = "hardware_interface::VelocityJointInterface";
+    iface_res_3.resources.insert("test_joint1");
+    iface_res_3.resources.insert("test_joint2");
+    controller_2.claimed_resources.push_back(iface_res_3);
+    start_list.push_back(controller_2);
+    ASSERT_TRUE(robot_hw.prepareSwitch(start_list, stop_list));
+    ASSERT_NO_THROW(robot_hw.doSwitch(start_list, stop_list));
+  }
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
This PR improves the filtering that CombinedRobotHW does on controllers, interfaces and resources before it passes the `start_list` and `stop_list` to the underlying `RobotHW`s.
So now:
- If none of the resources in a certain interface (that had some resources) belong to a certain RobotHW instance, then that interface will be filtered out (for that RobotHW instance).
- If none of the resources in the interfaces of a controller belong to a certain RobotHW instance, then that controller will be filtered out (for that RobotHW instance).

Test cases have been added to cover these two cases.