### PR TITLE
Replace boost with std

### DIFF
--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -10,9 +10,6 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
 )
 
-# Include Boost.Thread
-find_package(Boost REQUIRED COMPONENTS thread)
-
 catkin_python_setup()
 
 # Declare a catkin package
@@ -27,8 +24,6 @@ catkin_package(
     hardware_interface
     pluginlib
     roscpp
-  DEPENDS
-    Boost
 )
 
 
@@ -37,7 +32,7 @@ catkin_package(
 ###########
 
 # Specify header include paths
-include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME}
   include/controller_manager/controller_loader.h
@@ -46,7 +41,7 @@ add_library(${PROJECT_NAME}
   src/controller_manager.cpp
 )
 add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
 
 #############

--- a/controller_manager/include/controller_manager/controller_manager.h
+++ b/controller_manager/include/controller_manager/controller_manager.h
@@ -35,6 +35,7 @@
 #include "controller_manager/controller_spec.h"
 #include <cstdio>
 #include <map>
+#include <mutex>
 #include <string>
 #include <vector>
 #include <ros/ros.h>
@@ -47,8 +48,6 @@
 #include <controller_manager_msgs/LoadController.h>
 #include <controller_manager_msgs/UnloadController.h>
 #include <controller_manager_msgs/SwitchController.h>
-#include <boost/thread/condition.hpp>
-#include <boost/thread/recursive_mutex.hpp>
 #include <controller_manager/controller_loader_interface.h>
 
 
@@ -220,7 +219,7 @@ private:
    * real-time thread when switching controllers in the non-real-time thread.
    *\{*/
   /// Mutex protecting the current controllers list
-  boost::recursive_mutex controllers_lock_;
+  std::recursive_mutex controllers_lock_;
   /// Double-buffered controllers list
   std::vector<ControllerSpec> controllers_lists_[2];
   /// The index of the current controllers list
@@ -244,7 +243,7 @@ private:
                          controller_manager_msgs::UnloadController::Response &resp);
   bool reloadControllerLibrariesSrv(controller_manager_msgs::ReloadControllerLibraries::Request &req,
                                     controller_manager_msgs::ReloadControllerLibraries::Response &resp);
-  boost::mutex services_lock_;
+  std::mutex services_lock_;
   ros::ServiceServer srv_list_controllers_, srv_list_controller_types_, srv_load_controller_;
   ros::ServiceServer srv_unload_controller_, srv_switch_controller_, srv_reload_libraries_;
   /*\}*/

--- a/controller_manager/package.xml
+++ b/controller_manager/package.xml
@@ -18,7 +18,6 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <depend>boost</depend>
   <depend>roscpp</depend>
 
   <build_depend>controller_interface</build_depend>

--- a/controller_manager/test/hwi_switch_test.cpp
+++ b/controller_manager/test/hwi_switch_test.cpp
@@ -314,7 +314,7 @@ TEST(SwitchInterfacesTest, SwitchInterfaces)
 
     cm.registerControllerLoader(std::make_shared<DummyControllerLoader>());
 
-    ros::Timer timer = nh.createTimer(ros::Duration(0.01), boost::bind(update, boost::ref(cm), _1));
+    ros::Timer timer = nh.createTimer(ros::Duration(0.01), std::bind(&update, std::ref(cm), std::placeholders::_1));
 
     ASSERT_TRUE(cm.loadController("group_pos"));
     ASSERT_TRUE(cm.loadController("another_group_pos"));

--- a/hardware_interface/CMakeLists.txt
+++ b/hardware_interface/CMakeLists.txt
@@ -6,17 +6,12 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
 )
 
-# Include header-only Boost libraries
-find_package(Boost REQUIRED)
-
 # Declare a catkin package
 catkin_package(
   INCLUDE_DIRS
     include
   CATKIN_DEPENDS
     roscpp
-  DEPENDS
-    Boost
 )
 
 
@@ -25,7 +20,7 @@ catkin_package(
 ###########
 
 # Specify header include paths
-include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS})
 
 
 #############

--- a/hardware_interface/include/hardware_interface/internal/interface_manager.h
+++ b/hardware_interface/include/hardware_interface/internal/interface_manager.h
@@ -34,7 +34,6 @@
 #include <map>
 #include <string>
 #include <vector>
-#include <boost/ptr_container/ptr_vector.hpp>
 
 #include <ros/console.h>
 
@@ -84,7 +83,7 @@ struct CheckIsResourceManager {
   { return callGR<T>(resources, iface, nullptr); }
 
   template <typename C>
-  static T* newCI(boost::ptr_vector<ResourceManagerBase> &guards, typename C::resource_manager_type*)
+  static T* newCI(std::vector<ResourceManagerBase*> &guards, typename C::resource_manager_type*)
   {
     T* iface_combo = new T;
     // save the new interface pointer to allow for its correct destruction
@@ -94,7 +93,7 @@ struct CheckIsResourceManager {
 
   // method called if C is not a ResourceManager
   template <typename C>
-  static T* newCI(boost::ptr_vector<ResourceManagerBase> &/*guards*/, ...) {
+  static T* newCI(std::vector<ResourceManagerBase*> &/*guards*/, ...) {
     // it is not a ResourceManager
     ROS_ERROR("You cannot register multiple interfaces of the same type which are "
               "not of type ResourceManager. There is no established protocol "
@@ -102,7 +101,7 @@ struct CheckIsResourceManager {
     return nullptr;
   }
 
-  static T* newCombinedInterface(boost::ptr_vector<ResourceManagerBase> &guards)
+  static T* newCombinedInterface(std::vector<ResourceManagerBase*> &guards)
   {
     return newCI<T>(guards, nullptr);
   }
@@ -251,7 +250,7 @@ protected:
   InterfaceMap interfaces_combo_;
   InterfaceManagerVector interface_managers_;
   SizeMap num_ifaces_registered_;
-  boost::ptr_vector<ResourceManagerBase> interface_destruction_list_;
+  std::vector<ResourceManagerBase*> interface_destruction_list_;
   /// This will allow us to check the resources based on the demangled type name of the interface
   ResourceMap resources_;
 };

--- a/hardware_interface/package.xml
+++ b/hardware_interface/package.xml
@@ -19,8 +19,4 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <depend>roscpp</depend>
-
-  <build_depend>boost</build_depend>
-
-  <build_export_depend>boost</build_export_depend>
 </package>

--- a/joint_limits_interface/mainpage.dox
+++ b/joint_limits_interface/mainpage.dox
@@ -50,7 +50,7 @@ int main(int argc, char** argv)
 {
   // Init node handle and URDF model
   ros::NodeHandle nh;
-  boost::shared_ptr<urdf::ModelInterface> urdf;
+  std::shared_ptr<urdf::ModelInterface> urdf;
   // ...initialize contents of urdf
 
   // Data structures

--- a/transmission_interface/CMakeLists.txt
+++ b/transmission_interface/CMakeLists.txt
@@ -9,9 +9,6 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
 )
 
-# Include header-only Boost libraries
-find_package(Boost REQUIRED)
-
 # Include a custom cmake file for TinyXML
 find_package(TinyXML REQUIRED)
 
@@ -28,7 +25,6 @@ catkin_package(
     pluginlib
     roscpp
   DEPENDS
-    Boost
     TinyXML
 )
 
@@ -38,7 +34,7 @@ catkin_package(
 ###########
 
 # Specify header include paths
-include_directories(include ${catkin_INCLUDE_DIRS} ${TinyXML_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS} ${TinyXML_INCLUDE_DIRS})
 
 # Transmission parser library
 add_library(${PROJECT_NAME}_parser

--- a/transmission_interface/include/transmission_interface/transmission_interface_loader.h
+++ b/transmission_interface/include/transmission_interface/transmission_interface_loader.h
@@ -360,7 +360,7 @@ protected:
  *
  * private:
  *   RobotTransmissions robot_transmissions_;
- *   boost::scoped_ptr<TransmissionInterfaceLoader> transmission_loader_;
+ *   std::unique_ptr<TransmissionInterfaceLoader> transmission_loader_;
  *
  * };
  * \endcode

--- a/transmission_interface/package.xml
+++ b/transmission_interface/package.xml
@@ -20,12 +20,10 @@
   <depend>roscpp</depend>
   <depend>tinyxml</depend>
 
-  <build_depend>boost</build_depend>
   <build_depend>cmake_modules</build_depend>
   <build_depend>hardware_interface</build_depend>
   <build_depend>pluginlib</build_depend>
 
-  <build_export_depend>boost</build_export_depend>
   <build_export_depend>hardware_interface</build_export_depend>
   <build_export_depend>pluginlib</build_export_depend>
 

--- a/transmission_interface/src/transmission_loader.cpp
+++ b/transmission_interface/src/transmission_loader.cpp
@@ -25,9 +25,6 @@
 // POSSIBILITY OF SUCH DAMAGE.
 //////////////////////////////////////////////////////////////////////////////
 
-// Boost
-#include <boost/lexical_cast.hpp>
-
 // ros_control
 #include <transmission_interface/transmission_loader.h>
 
@@ -60,11 +57,11 @@ TransmissionLoader::getActuatorReduction(const TiXmlElement& parent_el,
   }
 
   // Cast to number
-  try {reduction = boost::lexical_cast<double>(reduction_el->GetText());}
-  catch (const boost::bad_lexical_cast&)
+  try {reduction = std::stod(reduction_el->GetText());}
+  catch (const std::logic_error&) // Captures both std::invalid_argument and std::out_of_range
   {
     ROS_ERROR_STREAM_NAMED("parser", "Actuator '" << actuator_name << "' of transmission '" << transmission_name <<
-                           "' specifies the <mechanicalReduction> element, but is not a number.");
+                           "' specifies the <mechanicalReduction> element, but is not a valid number.");
     return BAD_TYPE;
   }
   return SUCCESS;
@@ -95,11 +92,11 @@ TransmissionLoader::getJointReduction(const TiXmlElement& parent_el,
   }
 
   // Cast to number
-  try {reduction = boost::lexical_cast<double>(reduction_el->GetText());}
-  catch (const boost::bad_lexical_cast&)
+  try {reduction = std::stod(reduction_el->GetText());}
+  catch (const std::logic_error&) // Captures both std::invalid_argument and std::out_of_range
   {
     ROS_ERROR_STREAM_NAMED("parser", "Joint '" << joint_name << "' of transmission '" << transmission_name <<
-                           "' specifies the <mechanicalReduction> element, but is not a number.");
+                           "' specifies the <mechanicalReduction> element, but is not a valid number.");
     return BAD_TYPE;
   }
   return SUCCESS;
@@ -130,11 +127,11 @@ TransmissionLoader::getJointOffset(const TiXmlElement& parent_el,
   }
 
   // Cast to number
-  try {offset = boost::lexical_cast<double>(offset_el->GetText());}
-  catch (const boost::bad_lexical_cast&)
+  try {offset = std::stod(offset_el->GetText());}
+  catch (const std::logic_error&) // Captures both std::invalid_argument and std::out_of_range
   {
     ROS_ERROR_STREAM_NAMED("parser", "Joint '" << joint_name << "' of transmission '" << transmission_name <<
-                           "' specifies the <offset> element, but is not a number.");
+                           "' specifies the <offset> element, but is not a valid number.");
     return BAD_TYPE;
   }
   return SUCCESS;


### PR DESCRIPTION
Part of #403.

Replaces all usages of boost w/ std equivalents available since C++11 or C++14.

 - `boost::recursive_mutex` -> `std::recursive_mutex`
 - `boost::mutex` -> `std::mutex`
 - `boost::T::scoped_lock` -> `std::lock_guard<T>` (See note 1)
 - `boost::bind` -> `std::bind`
 - `boost::ptr_vector<T>` -> `std::vector<T*>` (See note 2)
 - `boost::lexical_cast<double>` -> `std::stod`


Note 1: `boost::T::scoped_lock` is just a typedef for `boost::unique_lock<T>`. I could have used the corresponding `std::unique_lock<T>`, but for our usage, `std::lock_guard<T>` is fully equivalent and may have slightly less overhead. `std::scoped_lock` supersedes `std::lock_guard`, but is only available in C++17.

Note 2: Although `boost::ptr_vector` offers a lot of functionality/optimizations that `std::vector` doesn't, in our case we're just holding pointers until they are destructed, we never do anything with them, so we don't care about these differences.