### PR TITLE
WIP: Adds isResetRequired to RobotHW and combinedRobotHW

### DIFF
--- a/combined_robot_hw/include/combined_robot_hw/combined_robot_hw.h
+++ b/combined_robot_hw/include/combined_robot_hw/combined_robot_hw.h
@@ -98,6 +98,12 @@ public:
    */
   virtual void write(const ros::Time& time, const ros::Duration& period);
 
+  /**
+   * Checks whether the robot HW requires to reset controllers
+   *
+   */
+  virtual bool isResetRequired();
+
 protected:
   ros::NodeHandle root_nh_;
   ros::NodeHandle robot_hw_nh_;

--- a/combined_robot_hw/src/combined_robot_hw.cpp
+++ b/combined_robot_hw/src/combined_robot_hw.cpp
@@ -195,6 +195,18 @@ namespace combined_robot_hw
     }
   }
 
+  bool CombinedRobotHW::isResetRequired()
+  {
+    // Call the isResetRequired method of the single RobotHW objects.
+    std::vector<hardware_interface::RobotHWSharedPtr>::iterator robot_hw;
+    for (robot_hw = robot_hw_list_.begin(); robot_hw != robot_hw_list_.end(); ++robot_hw)
+    {
+      if((*robot_hw)->isResetRequired())
+        return true;
+    }
+    return false;
+  }
+
   void CombinedRobotHW::filterControllerList(const std::list<hardware_interface::ControllerInfo>& list,
                                              std::list<hardware_interface::ControllerInfo>& filtered_list,
                                              hardware_interface::RobotHWSharedPtr robot_hw)

--- a/hardware_interface/include/hardware_interface/robot_hw.h
+++ b/hardware_interface/include/hardware_interface/robot_hw.h
@@ -175,6 +175,26 @@ public:
    * \param period The time passed since the last call to \ref write
    */
   virtual void write(const ros::Time& /*time*/, const ros::Duration& /*period*/) {}
+
+  /**
+  * Each robot HW might require to reset controllers, rising reset_ to true, this
+  * method returns true if that is the case
+  */
+  virtual bool isResetRequired()
+  {
+      if(reset_once_)
+      {
+        reset_once_ = false;
+        return true;
+      }
+      else
+      {
+        return false;
+      }
+  }
+
+protected:
+  bool reset_once_;
 };
 
 typedef std::shared_ptr<RobotHW> RobotHWSharedPtr;


### PR DESCRIPTION
Hi all,

I've found common for a driver to require a _re-arm_ routine after a fault, protective stop, or emergency stop. And most implementations add a public method asking whether controllers should be reset, which it is advisable after calling for a re-arm of any kind. Couple of examples are:

HAL: https://github.com/zultron/hal_ros_control/blob/kinetic-devel/hal_hw_interface/src/hal_control_loop.cpp#L138

Universal Robots: https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/blob/master/ur_robot_driver/src/ros/hardware_interface_node.cpp#L144

Problem becomes when using such implementations in a combined manner, then access to that method is somehow difficult, but quite necessary to avoid re-launching everything.

Thus, I was wondering if it'd be good to have it by default (i.e. in the base robotHW class, so it can be called by the combinedRobotHW class), since the controller manager has the ability to do it, but it is the hardware interface the one able to tell when to.

The way to trigger the reset is setting the protected member `bool reset_once_;` to true. Solution is inspired by the implementation int he UR package. This will make the controller manager to call a start/stop in all controllers.

I believe this PR is similar to https://github.com/ros-controls/ros_control/pull/357 and https://github.com/ros-controls/ros_control/pull/294 but no consensus so far. I used different naming though and simpler way to do it IMHO.

Problem I see so far is that, working in combined mode, one hardware requiring the reset will trigger the reset of all controllers, no matter if some of them might not be plugged into that hardware.

Already tested it in custom hardware, just proposing the change upstream for more discussion...

PS: I'll add test coverage and fix typos in comments after a merge is considered ;)