### PR TITLE
Use setuptools instead of distutils

### DIFF
--- a/combined_robot_hw/package.xml
+++ b/combined_robot_hw/package.xml
@@ -1,4 +1,8 @@
-<package format="2">
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>combined_robot_hw</name>
   <version>0.19.0</version>
   <description>Combined Robot HW class.</description>

--- a/combined_robot_hw_tests/package.xml
+++ b/combined_robot_hw_tests/package.xml
@@ -1,4 +1,8 @@
-<package format="2">
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>combined_robot_hw_tests</name>
   <version>0.19.0</version>
   <description>Tests for the combined Robot HW class.</description>

--- a/controller_interface/package.xml
+++ b/controller_interface/package.xml
@@ -1,4 +1,8 @@
-<package format="2">
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>controller_interface</name>
   <version>0.19.0</version>
   <description>Interface base class for controllers.</description>

--- a/controller_manager/package.xml
+++ b/controller_manager/package.xml
@@ -1,4 +1,8 @@
-<package format="2">
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>controller_manager</name>
   <version>0.19.0</version>
   <description>The controller manager.</description>
@@ -17,6 +21,8 @@
   <author>Mathias Lüdtke</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <depend>roscpp</depend>
 

--- a/controller_manager/setup.py
+++ b/controller_manager/setup.py
@@ -1,11 +1,9 @@
-#!/usr/bin/env python
-
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
-# fetch values from package.xml
-setup_args = generate_distutils_setup(
-          packages=['controller_manager'],
-              package_dir={'': 'src'})
+d = generate_distutils_setup(
+    packages=['controller_manager'],
+    package_dir={'': 'src'}
+)
 
-setup(**setup_args)
+setup(**d)

--- a/controller_manager_msgs/package.xml
+++ b/controller_manager_msgs/package.xml
@@ -1,4 +1,8 @@
-<package format="2">
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>controller_manager_msgs</name>
   <version>0.19.0</version>
   <description>Messages and services for the controller manager.</description>
@@ -16,6 +20,8 @@
   <author>Wim Meeussen</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <depend>std_msgs</depend>
 

--- a/controller_manager_msgs/setup.py
+++ b/controller_manager_msgs/setup.py
@@ -1,11 +1,9 @@
-#!/usr/bin/env python
-
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
-# fetch values from package.xml
-setup_args = generate_distutils_setup(
-          packages=['controller_manager_msgs'],
-              package_dir={'': 'src'})
+d = generate_distutils_setup(
+    packages=['controller_manager_msgs'],
+    package_dir={'': 'src'}
+)
 
-setup(**setup_args)
+setup(**d)

--- a/controller_manager_tests/package.xml
+++ b/controller_manager_tests/package.xml
@@ -1,4 +1,8 @@
-<package format="2">
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>controller_manager_tests</name>
   <version>0.19.0</version>
   <description>Tests for the controller manager.</description>
@@ -17,6 +21,8 @@
   <author>Adolfo Rodriguez Tsouroukdissian</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <depend>controller_interface</depend> <!-- exec_depend required for plugin -->
   <depend>controller_manager</depend>

--- a/controller_manager_tests/setup.py
+++ b/controller_manager_tests/setup.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(

--- a/hardware_interface/package.xml
+++ b/hardware_interface/package.xml
@@ -1,4 +1,8 @@
-<package format="2">
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>hardware_interface</name>
   <version>0.19.0</version>
   <description>Hardware Interface base class.</description>

--- a/joint_limits_interface/package.xml
+++ b/joint_limits_interface/package.xml
@@ -1,4 +1,8 @@
-<package format="2">
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>joint_limits_interface</name>
   <version>0.19.0</version>
   <description>Interface for enforcing joint limits.</description>

--- a/ros_control/package.xml
+++ b/ros_control/package.xml
@@ -1,4 +1,8 @@
-<package format="2">
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>ros_control</name>
   <version>0.19.0</version>
   <description>A set of packages that include controller interfaces, controller managers, transmissions and hardware_interfaces.</description>

--- a/rqt_controller_manager/package.xml
+++ b/rqt_controller_manager/package.xml
@@ -1,4 +1,8 @@
-<package format="2">
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>rqt_controller_manager</name>
   <version>0.19.0</version>
   <description>Graphical frontend for interacting with the controller manager.</description>
@@ -17,6 +21,8 @@
   <author email="adolfo.rodriguez@pal-robotics.com">Adolfo Rodríguez Tsouroukdissian</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <exec_depend>controller_manager_msgs</exec_depend>
   <exec_depend>rospy</exec_depend>

--- a/rqt_controller_manager/setup.py
+++ b/rqt_controller_manager/setup.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(

--- a/transmission_interface/package.xml
+++ b/transmission_interface/package.xml
@@ -1,4 +1,8 @@
-<package format="2">
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>transmission_interface</name>
   <version>0.19.0</version>
   <description>Transmission Interface.</description>


### PR DESCRIPTION
Use `setuptools` rather than `distutils`. See http://wiki.ros.org/noetic/Migration and ros/catkin#1048.

This PR also removes shebangs from `setup.py` files, since they should not be executed directly.

Note that it is not necessary to update all `package.xml` versions to 3, it is only required for packages containing `setup.py` files. But I updated them all for consistency.