### PR TITLE
Add function specifiers and modernize constructors

### DIFF
--- a/combined_robot_hw/include/combined_robot_hw/combined_robot_hw.h
+++ b/combined_robot_hw/include/combined_robot_hw/combined_robot_hw.h
@@ -52,7 +52,7 @@ namespace combined_robot_hw
 class CombinedRobotHW : public hardware_interface::RobotHW
 {
 public:
-  virtual ~CombinedRobotHW(){}
+  ~CombinedRobotHW() override = default;
 
   /** \brief The init function is called to initialize the RobotHW from a
    * non-realtime thread.
@@ -64,7 +64,7 @@ public:
    *
    * \returns True if initialization was successful
    */
-  virtual bool init(ros::NodeHandle& root_nh, ros::NodeHandle &robot_hw_nh);
+  bool init(ros::NodeHandle& root_nh, ros::NodeHandle &robot_hw_nh) override;
 
 
   /**
@@ -72,15 +72,15 @@ public:
    * with regard to necessary hardware interface switches and prepare the switching. Start and stop list are disjoint.
    * This handles the check and preparation, the actual switch is commited in doSwitch()
    */
-  virtual bool prepareSwitch(const std::list<hardware_interface::ControllerInfo>& start_list,
-                             const std::list<hardware_interface::ControllerInfo>& stop_list);
+  bool prepareSwitch(const std::list<hardware_interface::ControllerInfo>& start_list,
+                     const std::list<hardware_interface::ControllerInfo>& stop_list) override;
 
   /**
    * Perform (in realtime) all necessary hardware interface switches in order to start and stop the given controllers.
    * Start and stop list are disjoint. The feasability was checked in prepareSwitch() beforehand.
    */
-  virtual void doSwitch(const std::list<hardware_interface::ControllerInfo>& start_list,
-                        const std::list<hardware_interface::ControllerInfo>& stop_list);
+  void doSwitch(const std::list<hardware_interface::ControllerInfo>& start_list,
+                const std::list<hardware_interface::ControllerInfo>& stop_list) override;
 
   /**
    * Reads data from the robot HW
@@ -88,7 +88,7 @@ public:
    * \param time The current time
    * \param period The time passed since the last call to \ref read
    */
-  virtual void read(const ros::Time& time, const ros::Duration& period);
+  void read(const ros::Time& time, const ros::Duration& period) override;
 
   /**
    * Writes data to the robot HW
@@ -96,7 +96,7 @@ public:
    * \param time The current time
    * \param period The time passed since the last call to \ref write
    */
-  virtual void write(const ros::Time& time, const ros::Duration& period);
+  void write(const ros::Time& time, const ros::Duration& period) override;
 
 protected:
   ros::NodeHandle root_nh_;

--- a/combined_robot_hw/include/combined_robot_hw/combined_robot_hw.h
+++ b/combined_robot_hw/include/combined_robot_hw/combined_robot_hw.h
@@ -52,7 +52,6 @@ namespace combined_robot_hw
 class CombinedRobotHW : public hardware_interface::RobotHW
 {
 public:
-  ~CombinedRobotHW() override = default;
 
   /** \brief The init function is called to initialize the RobotHW from a
    * non-realtime thread.

--- a/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_1.h
+++ b/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_1.h
@@ -38,15 +38,15 @@ namespace combined_robot_hw_tests
 class MyRobotHW1 : public hardware_interface::RobotHW
 {
 public:
-  MyRobotHW1();
-  virtual ~MyRobotHW1(){};
-  virtual bool init(ros::NodeHandle& root_nh, ros::NodeHandle &robot_hw_nh);
-  virtual void read(const ros::Time& time, const ros::Duration& period);
-  virtual void write(const ros::Time& time, const ros::Duration& period);
-  virtual bool prepareSwitch(const std::list<hardware_interface::ControllerInfo>& start_list,
-                             const std::list<hardware_interface::ControllerInfo>& stop_list);
-  virtual void doSwitch(const std::list<hardware_interface::ControllerInfo>& start_list,
-                        const std::list<hardware_interface::ControllerInfo>& stop_list);
+  MyRobotHW1() = default;
+  ~MyRobotHW1() override = default;
+  bool init(ros::NodeHandle& root_nh, ros::NodeHandle &robot_hw_nh) override;
+  void read(const ros::Time& time, const ros::Duration& period) override;
+  void write(const ros::Time& time, const ros::Duration& period) override;
+  bool prepareSwitch(const std::list<hardware_interface::ControllerInfo>& start_list,
+                     const std::list<hardware_interface::ControllerInfo>& stop_list) override;
+  void doSwitch(const std::list<hardware_interface::ControllerInfo>& start_list,
+                const std::list<hardware_interface::ControllerInfo>& stop_list) override;
 
 protected:
 

--- a/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_1.h
+++ b/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_1.h
@@ -38,7 +38,6 @@ namespace combined_robot_hw_tests
 class MyRobotHW1 : public hardware_interface::RobotHW
 {
 public:
-  MyRobotHW1() = default;
   ~MyRobotHW1() override = default;
   bool init(ros::NodeHandle& root_nh, ros::NodeHandle &robot_hw_nh) override;
   void read(const ros::Time& time, const ros::Duration& period) override;

--- a/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_1.h
+++ b/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_1.h
@@ -38,7 +38,6 @@ namespace combined_robot_hw_tests
 class MyRobotHW1 : public hardware_interface::RobotHW
 {
 public:
-  ~MyRobotHW1() override = default;
   bool init(ros::NodeHandle& root_nh, ros::NodeHandle &robot_hw_nh) override;
   void read(const ros::Time& time, const ros::Duration& period) override;
   void write(const ros::Time& time, const ros::Duration& period) override;

--- a/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_2.h
+++ b/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_2.h
@@ -38,7 +38,6 @@ namespace combined_robot_hw_tests
 class MyRobotHW2 : public hardware_interface::RobotHW
 {
 public:
-  ~MyRobotHW2() override = default;
   bool init(ros::NodeHandle& root_nh, ros::NodeHandle &robot_hw_nh) override;
   void read(const ros::Time& time, const ros::Duration& period) override;
   void write(const ros::Time& time, const ros::Duration& period) override;

--- a/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_2.h
+++ b/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_2.h
@@ -38,7 +38,6 @@ namespace combined_robot_hw_tests
 class MyRobotHW2 : public hardware_interface::RobotHW
 {
 public:
-  MyRobotHW2() = default;
   ~MyRobotHW2() override = default;
   bool init(ros::NodeHandle& root_nh, ros::NodeHandle &robot_hw_nh) override;
   void read(const ros::Time& time, const ros::Duration& period) override;

--- a/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_2.h
+++ b/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_2.h
@@ -38,15 +38,15 @@ namespace combined_robot_hw_tests
 class MyRobotHW2 : public hardware_interface::RobotHW
 {
 public:
-  MyRobotHW2();
-  virtual ~MyRobotHW2(){};
-  virtual bool init(ros::NodeHandle& root_nh, ros::NodeHandle &robot_hw_nh);
-  void read(const ros::Time& time, const ros::Duration& period);
-  void write(const ros::Time& time, const ros::Duration& period);
-  virtual bool prepareSwitch(const std::list<hardware_interface::ControllerInfo>& start_list,
-                             const std::list<hardware_interface::ControllerInfo>& stop_list);
-  virtual void doSwitch(const std::list<hardware_interface::ControllerInfo>& start_list,
-                        const std::list<hardware_interface::ControllerInfo>& stop_list);
+  MyRobotHW2() = default;
+  ~MyRobotHW2() override = default;
+  bool init(ros::NodeHandle& root_nh, ros::NodeHandle &robot_hw_nh) override;
+  void read(const ros::Time& time, const ros::Duration& period) override;
+  void write(const ros::Time& time, const ros::Duration& period) override;
+  bool prepareSwitch(const std::list<hardware_interface::ControllerInfo>& start_list,
+                     const std::list<hardware_interface::ControllerInfo>& stop_list) override;
+  void doSwitch(const std::list<hardware_interface::ControllerInfo>& start_list,
+                const std::list<hardware_interface::ControllerInfo>& stop_list) override;
 
 protected:
 

--- a/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_3.h
+++ b/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_3.h
@@ -38,11 +38,11 @@ namespace combined_robot_hw_tests
 class MyRobotHW3 : public hardware_interface::RobotHW
 {
 public:
-  MyRobotHW3();
-  virtual ~MyRobotHW3(){};
-  virtual bool init(ros::NodeHandle& root_nh, ros::NodeHandle &robot_hw_nh);
-  void read(const ros::Time& time, const ros::Duration& period);
-  void write(const ros::Time& time, const ros::Duration& period);
+  MyRobotHW3() = default;
+  ~MyRobotHW3() override = default;
+  bool init(ros::NodeHandle& root_nh, ros::NodeHandle &robot_hw_nh) override;
+  void read(const ros::Time& time, const ros::Duration& period) override;
+  void write(const ros::Time& time, const ros::Duration& period) override;
 
 protected:
 

--- a/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_3.h
+++ b/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_3.h
@@ -38,7 +38,6 @@ namespace combined_robot_hw_tests
 class MyRobotHW3 : public hardware_interface::RobotHW
 {
 public:
-  ~MyRobotHW3() override = default;
   bool init(ros::NodeHandle& root_nh, ros::NodeHandle &robot_hw_nh) override;
   void read(const ros::Time& time, const ros::Duration& period) override;
   void write(const ros::Time& time, const ros::Duration& period) override;

--- a/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_3.h
+++ b/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_3.h
@@ -38,7 +38,6 @@ namespace combined_robot_hw_tests
 class MyRobotHW3 : public hardware_interface::RobotHW
 {
 public:
-  MyRobotHW3() = default;
   ~MyRobotHW3() override = default;
   bool init(ros::NodeHandle& root_nh, ros::NodeHandle &robot_hw_nh) override;
   void read(const ros::Time& time, const ros::Duration& period) override;

--- a/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_4.h
+++ b/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_4.h
@@ -38,15 +38,15 @@ namespace combined_robot_hw_tests
 class MyRobotHW4 : public hardware_interface::RobotHW
 {
 public:
-  MyRobotHW4();
-  virtual ~MyRobotHW4(){};
-  virtual bool init(ros::NodeHandle& root_nh, ros::NodeHandle &robot_hw_nh);
-  void read(const ros::Time& time, const ros::Duration& period);
-  void write(const ros::Time& time, const ros::Duration& period);
-  virtual bool prepareSwitch(const std::list<hardware_interface::ControllerInfo>& start_list,
-                             const std::list<hardware_interface::ControllerInfo>& stop_list);
-  virtual void doSwitch(const std::list<hardware_interface::ControllerInfo>& start_list,
-                        const std::list<hardware_interface::ControllerInfo>& stop_list);
+  MyRobotHW4() = default;
+  ~MyRobotHW4() override = default;
+  bool init(ros::NodeHandle& root_nh, ros::NodeHandle &robot_hw_nh) override;
+  void read(const ros::Time& time, const ros::Duration& period) override;
+  void write(const ros::Time& time, const ros::Duration& period) override;
+  bool prepareSwitch(const std::list<hardware_interface::ControllerInfo>& start_list,
+                     const std::list<hardware_interface::ControllerInfo>& stop_list) override;
+  void doSwitch(const std::list<hardware_interface::ControllerInfo>& start_list,
+                const std::list<hardware_interface::ControllerInfo>& stop_list) override;
 
 protected:
 

--- a/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_4.h
+++ b/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_4.h
@@ -38,7 +38,6 @@ namespace combined_robot_hw_tests
 class MyRobotHW4 : public hardware_interface::RobotHW
 {
 public:
-  MyRobotHW4() = default;
   ~MyRobotHW4() override = default;
   bool init(ros::NodeHandle& root_nh, ros::NodeHandle &robot_hw_nh) override;
   void read(const ros::Time& time, const ros::Duration& period) override;

--- a/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_4.h
+++ b/combined_robot_hw_tests/include/combined_robot_hw_tests/my_robot_hw_4.h
@@ -38,7 +38,6 @@ namespace combined_robot_hw_tests
 class MyRobotHW4 : public hardware_interface::RobotHW
 {
 public:
-  ~MyRobotHW4() override = default;
   bool init(ros::NodeHandle& root_nh, ros::NodeHandle &robot_hw_nh) override;
   void read(const ros::Time& time, const ros::Duration& period) override;
   void write(const ros::Time& time, const ros::Duration& period) override;

--- a/combined_robot_hw_tests/src/my_robot_hw_1.cpp
+++ b/combined_robot_hw_tests/src/my_robot_hw_1.cpp
@@ -32,10 +32,6 @@
 namespace combined_robot_hw_tests
 {
 
-MyRobotHW1::MyRobotHW1()
-{
-}
-
 bool MyRobotHW1::init(ros::NodeHandle& /*root_nh*/, ros::NodeHandle &/*robot_hw_nh*/)
 {
   using namespace hardware_interface;

--- a/combined_robot_hw_tests/src/my_robot_hw_2.cpp
+++ b/combined_robot_hw_tests/src/my_robot_hw_2.cpp
@@ -32,10 +32,6 @@
 namespace combined_robot_hw_tests
 {
 
-MyRobotHW2::MyRobotHW2()
-{
-}
-
 bool MyRobotHW2::init(ros::NodeHandle& /*root_nh*/, ros::NodeHandle &robot_hw_nh)
 {
   using namespace hardware_interface;

--- a/combined_robot_hw_tests/src/my_robot_hw_3.cpp
+++ b/combined_robot_hw_tests/src/my_robot_hw_3.cpp
@@ -31,10 +31,6 @@
 namespace combined_robot_hw_tests
 {
 
-MyRobotHW3::MyRobotHW3()
-{
-}
-
 bool MyRobotHW3::init(ros::NodeHandle& /*root_nh*/, ros::NodeHandle &robot_hw_nh)
 {
   using namespace hardware_interface;
@@ -91,4 +87,3 @@ void MyRobotHW3::write(const ros::Time& /*time*/, const ros::Duration& /*period*
 }
 
 PLUGINLIB_EXPORT_CLASS( combined_robot_hw_tests::MyRobotHW3, hardware_interface::RobotHW)
-

--- a/combined_robot_hw_tests/src/my_robot_hw_4.cpp
+++ b/combined_robot_hw_tests/src/my_robot_hw_4.cpp
@@ -31,10 +31,6 @@
 namespace combined_robot_hw_tests
 {
 
-MyRobotHW4::MyRobotHW4()
-{
-}
-
 bool MyRobotHW4::init(ros::NodeHandle& /*root_nh*/, ros::NodeHandle &/*robot_hw_nh*/)
 {
   using namespace hardware_interface;

--- a/controller_interface/include/controller_interface/controller.h
+++ b/controller_interface/include/controller_interface/controller.h
@@ -52,7 +52,6 @@ template <class T>
 class Controller: public virtual ControllerBase
 {
 public:
-  Controller() = default;
   ~Controller<T>() override = default;
 
   /** \brief The init function is called to initialize the controller from a

--- a/controller_interface/include/controller_interface/controller.h
+++ b/controller_interface/include/controller_interface/controller.h
@@ -52,8 +52,8 @@ template <class T>
 class Controller: public virtual ControllerBase
 {
 public:
-  Controller() {}
-  virtual ~Controller<T>(){}
+  Controller() = default;
+  ~Controller<T>() override = default;
 
   /** \brief The init function is called to initialize the controller from a
    * non-realtime thread with a pointer to the hardware interface, itself,
@@ -95,10 +95,10 @@ protected:
    * can extract the correct interface from \c robot_hw.
    *
    */
-  virtual bool initRequest(hardware_interface::RobotHW* robot_hw,
-                           ros::NodeHandle&             root_nh,
-                           ros::NodeHandle&             controller_nh,
-                           ClaimedResources&            claimed_resources)
+  bool initRequest(hardware_interface::RobotHW* robot_hw,
+                   ros::NodeHandle&             root_nh,
+                   ros::NodeHandle&             controller_nh,
+                   ClaimedResources&            claimed_resources) override
   {
     // check if construction finished cleanly
     if (state_ != CONSTRUCTED){

--- a/controller_interface/include/controller_interface/controller.h
+++ b/controller_interface/include/controller_interface/controller.h
@@ -137,11 +137,6 @@ protected:
   {
     return hardware_interface::internal::demangledTypeName<T>();
   }
-
-private:
-  Controller<T>(const Controller<T> &c);
-  Controller<T>& operator =(const Controller<T> &c);
-
 };
 
 }

--- a/controller_interface/include/controller_interface/controller.h
+++ b/controller_interface/include/controller_interface/controller.h
@@ -52,7 +52,6 @@ template <class T>
 class Controller: public virtual ControllerBase
 {
 public:
-  ~Controller<T>() override = default;
 
   /** \brief The init function is called to initialize the controller from a
    * non-realtime thread with a pointer to the hardware interface, itself,

--- a/controller_interface/include/controller_interface/controller_base.h
+++ b/controller_interface/include/controller_interface/controller_base.h
@@ -50,6 +50,10 @@ class ControllerBase
 public:
   ControllerBase() = default;
   virtual ~ControllerBase() = default;
+  ControllerBase(const ControllerBase&) = delete;
+  ControllerBase& operator=(const ControllerBase&) = delete;
+  ControllerBase(ControllerBase&&) = delete;
+  ControllerBase& operator=(ControllerBase&&) = delete;
 
   /** \name Real-Time Safe Functions
    *\{*/
@@ -238,12 +242,6 @@ public:
 
   /// The current execution state of the controller
   enum {CONSTRUCTED, INITIALIZED, RUNNING, STOPPED, WAITING, ABORTED} state_ = {CONSTRUCTED};
-
-
-private:
-  ControllerBase(const ControllerBase &c);
-  ControllerBase& operator =(const ControllerBase &c);
-
 };
 
 typedef std::shared_ptr<ControllerBase> ControllerBaseSharedPtr;

--- a/controller_interface/include/controller_interface/controller_base.h
+++ b/controller_interface/include/controller_interface/controller_base.h
@@ -48,8 +48,8 @@ namespace controller_interface
 class ControllerBase
 {
 public:
-  ControllerBase() {}
-  virtual ~ControllerBase(){}
+  ControllerBase() = default;
+  virtual ~ControllerBase() = default;
 
   /** \name Real-Time Safe Functions
    *\{*/

--- a/controller_interface/include/controller_interface/multi_interface_controller.h
+++ b/controller_interface/include/controller_interface/multi_interface_controller.h
@@ -157,8 +157,6 @@ public:
   MultiInterfaceController(bool allow_optional_interfaces = false)
     : allow_optional_interfaces_(allow_optional_interfaces) {}
 
-  ~MultiInterfaceController() override = default;
-
   /** \name Non Real-Time Safe Functions
    *\{*/
 

--- a/controller_interface/include/controller_interface/multi_interface_controller.h
+++ b/controller_interface/include/controller_interface/multi_interface_controller.h
@@ -155,10 +155,9 @@ public:
    * If set to false (the default), all requested interfaces are required.
    */
   MultiInterfaceController(bool allow_optional_interfaces = false)
-    : allow_optional_interfaces_(allow_optional_interfaces)
-  {}
+    : allow_optional_interfaces_(allow_optional_interfaces) {}
 
-  virtual ~MultiInterfaceController() {}
+  ~MultiInterfaceController() override = default;
 
   /** \name Non Real-Time Safe Functions
    *\{*/
@@ -245,10 +244,10 @@ protected:
    * \returns True if initialization was successful and the controller
    * is ready to be started.
    */
-  virtual bool initRequest(hardware_interface::RobotHW* robot_hw,
-                           ros::NodeHandle&             root_nh,
-                           ros::NodeHandle&             controller_nh,
-                           ClaimedResources&            claimed_resources)
+  bool initRequest(hardware_interface::RobotHW* robot_hw,
+                   ros::NodeHandle&             root_nh,
+                   ros::NodeHandle&             controller_nh,
+                   ClaimedResources&            claimed_resources) override
   {
     // check if construction finished cleanly
     if (state_ != CONSTRUCTED){

--- a/controller_interface/include/controller_interface/multi_interface_controller.h
+++ b/controller_interface/include/controller_interface/multi_interface_controller.h
@@ -339,10 +339,6 @@ protected:
 
   /** Flag to indicate if hardware interfaces are considered optional (i.e. non-required). */
   bool allow_optional_interfaces_;
-
-private:
-  MultiInterfaceController(const MultiInterfaceController& c);
-  MultiInterfaceController& operator =(const MultiInterfaceController& c);
 };
 
 } // namespace

--- a/controller_interface/test/controller_base_test.cpp
+++ b/controller_interface/test/controller_base_test.cpp
@@ -43,13 +43,9 @@ using ::testing::Return;
 class ControllerMock : public controller_interface::ControllerBase
 {
 public:
-  ControllerMock() : controller_interface::ControllerBase()
-  {
-  }
+  ControllerMock() : controller_interface::ControllerBase() {}
 
-  ~ControllerMock()
-  {
-  }
+  ~ControllerMock() override = default;
 
   void initializeState()
   {

--- a/controller_interface/test/controller_base_test.cpp
+++ b/controller_interface/test/controller_base_test.cpp
@@ -43,8 +43,6 @@ using ::testing::Return;
 class ControllerMock : public controller_interface::ControllerBase
 {
 public:
-  ControllerMock() : controller_interface::ControllerBase() {}
-
   ~ControllerMock() override = default;
 
   void initializeState()

--- a/controller_interface/test/controller_base_test.cpp
+++ b/controller_interface/test/controller_base_test.cpp
@@ -43,7 +43,6 @@ using ::testing::Return;
 class ControllerMock : public controller_interface::ControllerBase
 {
 public:
-  ~ControllerMock() override = default;
 
   void initializeState()
   {

--- a/controller_manager/include/controller_manager/controller_loader.h
+++ b/controller_manager/include/controller_manager/controller_loader.h
@@ -56,17 +56,17 @@ public:
     reload();
   }
 
-  controller_interface::ControllerBaseSharedPtr createInstance(const std::string& lookup_name)
+  controller_interface::ControllerBaseSharedPtr createInstance(const std::string& lookup_name) override
   {
     return controller_loader_->createUniqueInstance(lookup_name);
   }
 
-  std::vector<std::string> getDeclaredClasses()
+  std::vector<std::string> getDeclaredClasses() override
   {
     return controller_loader_->getDeclaredClasses();
   }
 
-  void reload()
+  void reload() override
   {
     controller_loader_.reset(new pluginlib::ClassLoader<T>(package_, base_class_) );
   }

--- a/controller_manager/include/controller_manager/controller_loader_interface.h
+++ b/controller_manager/include/controller_manager/controller_loader_interface.h
@@ -45,15 +45,16 @@ namespace controller_manager
 class ControllerLoaderInterface
 {
 public:
-  ControllerLoaderInterface(const std::string& name) : name_(name) { }
+  ControllerLoaderInterface(const std::string& name) : name_(name) {}
+  virtual ~ControllerLoaderInterface() = default;
+
   virtual controller_interface::ControllerBaseSharedPtr createInstance(const std::string& lookup_name) = 0;
   virtual std::vector<std::string> getDeclaredClasses() = 0;
   virtual void reload() = 0;
   const std::string& getName() { return name_; }
-  virtual ~ControllerLoaderInterface() = default;
+
 private:
   const std::string name_;
-
 };
 
 typedef std::shared_ptr<ControllerLoaderInterface> ControllerLoaderInterfaceSharedPtr;

--- a/controller_manager/include/controller_manager/controller_loader_interface.h
+++ b/controller_manager/include/controller_manager/controller_loader_interface.h
@@ -50,7 +50,7 @@ public:
   virtual std::vector<std::string> getDeclaredClasses() = 0;
   virtual void reload() = 0;
   const std::string& getName() { return name_; }
-  virtual ~ControllerLoaderInterface() { }
+  virtual ~ControllerLoaderInterface() = default;
 private:
   const std::string name_;
 

--- a/controller_manager/include/controller_manager/controller_manager.h
+++ b/controller_manager/include/controller_manager/controller_manager.h
@@ -75,7 +75,7 @@ public:
    */
   ControllerManager(hardware_interface::RobotHW *robot_hw,
                    const ros::NodeHandle& nh=ros::NodeHandle());
-  virtual ~ControllerManager();
+  virtual ~ControllerManager() = default;
 
   /** \name Real-Time Safe Functions
    *\{*/

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -62,10 +62,6 @@ ControllerManager::ControllerManager(hardware_interface::RobotHW *robot_hw, cons
 }
 
 
-ControllerManager::~ControllerManager()
-{}
-
-
 // Must be realtime safe.
 void ControllerManager::update(const ros::Time& time, const ros::Duration& period, bool reset_controllers)
 {

--- a/controller_manager/test/hwi_switch_test.cpp
+++ b/controller_manager/test/hwi_switch_test.cpp
@@ -137,8 +137,8 @@ public:
 
     }
 
-    virtual bool prepareSwitch(const std::list<hardware_interface::ControllerInfo>& start_list,
-                               const std::list<hardware_interface::ControllerInfo>& stop_list)
+    bool prepareSwitch(const std::list<hardware_interface::ControllerInfo>& start_list,
+                       const std::list<hardware_interface::ControllerInfo>& stop_list) override
     {
 
         if(!RobotHW::prepareSwitch(start_list, stop_list))
@@ -188,7 +188,7 @@ public:
         }
         return !(j_pe_e && j_ve_v); // check inter-joint hardware interface conflict
     }
-    virtual void doSwitch(const std::list<hardware_interface::ControllerInfo> &start_list, const std::list<hardware_interface::ControllerInfo> &stop_list)
+    void doSwitch(const std::list<hardware_interface::ControllerInfo> &start_list, const std::list<hardware_interface::ControllerInfo> &stop_list) override
     {
         RobotHW::doSwitch(start_list, stop_list); // check if member is defined
 
@@ -236,11 +236,11 @@ class DummyControllerLoader: public controller_manager::ControllerLoaderInterfac
         const std::string type_name;
     public:
         DummyController(const std::string &name) : type_name(name) {}
-        virtual void update(const ros::Time& /*time*/, const ros::Duration& /*period*/) {}
-        virtual bool initRequest(hardware_interface::RobotHW* /*hw*/,
-                                 ros::NodeHandle&             /*root_nh*/,
-                                 ros::NodeHandle&             controller_nh,
-                                 ClaimedResources&            claimed_resources)
+        void update(const ros::Time& /*time*/, const ros::Duration& /*period*/) override {}
+        bool initRequest(hardware_interface::RobotHW* /*hw*/,
+                         ros::NodeHandle&             /*root_nh*/,
+                         ros::NodeHandle&             controller_nh,
+                         ClaimedResources&            claimed_resources) override
         {
             std::vector<std::string> joints;
             if(!controller_nh.getParam("joints", joints))
@@ -272,11 +272,11 @@ public:
         add("PositionJointInterface");
         add("VelocityJointInterface");
     }
-    virtual controller_interface::ControllerBaseSharedPtr createInstance(const std::string& lookup_name)
+    controller_interface::ControllerBaseSharedPtr createInstance(const std::string& lookup_name) override
     {
         return controller_interface::ControllerBaseSharedPtr(new DummyController(classes.at(lookup_name)));
     }
-    virtual std::vector<std::string> getDeclaredClasses()
+    std::vector<std::string> getDeclaredClasses() override
     {
         std::vector<std::string> v;
         for (const auto& declared_class : classes)
@@ -285,7 +285,7 @@ public:
         }
         return v;
     }
-    virtual void reload() {}
+    void reload() override {}
 };
 
 void update(controller_manager::ControllerManager &cm, const ros::TimerEvent& e)

--- a/controller_manager/test/hwi_update_test.cpp
+++ b/controller_manager/test/hwi_update_test.cpp
@@ -51,13 +51,9 @@ using ::testing::Return;
 class RobotHWMock : public hardware_interface::RobotHW
 {
 public:
-  RobotHWMock()
-  {
-  }
+  RobotHWMock() = default;
 
-  ~RobotHWMock()
-  {
-  }
+  ~RobotHWMock() override = default;
 
   MOCK_METHOD2(init, bool(ros::NodeHandle &, ros::NodeHandle &));
   MOCK_CONST_METHOD1(checkForConflict,
@@ -75,13 +71,9 @@ public:
 class ControllerLoaderMock : public controller_manager::ControllerLoaderInterface
 {
 public:
-  ControllerLoaderMock() : ControllerLoaderInterface("ControllerLoaderMock")
-  {
-  }
+  ControllerLoaderMock() : ControllerLoaderInterface("ControllerLoaderMock") {}
 
-  ~ControllerLoaderMock()
-  {
-  }
+  ~ControllerLoaderMock() override = default;
 
   MOCK_METHOD1(createInstance,
                controller_interface::ControllerBaseSharedPtr(const std::string &));
@@ -92,13 +84,9 @@ public:
 class ControllerMock : public controller_interface::ControllerBase
 {
 public:
-  ControllerMock()
-  {
-  }
+  ControllerMock() = default;
 
-  ~ControllerMock()
-  {
-  }
+  ~ControllerMock() override = default;
 
   void initializeState()
   {
@@ -117,7 +105,7 @@ public:
 class ControllerManagerTest : public ::testing::Test
 {
 public:
-  void SetUp()
+  void SetUp() override
   {
     prepareMocks();
     loadControllers();

--- a/controller_manager/test/hwi_update_test.cpp
+++ b/controller_manager/test/hwi_update_test.cpp
@@ -51,7 +51,6 @@ using ::testing::Return;
 class RobotHWMock : public hardware_interface::RobotHW
 {
 public:
-  ~RobotHWMock() override = default;
 
   MOCK_METHOD2(init, bool(ros::NodeHandle &, ros::NodeHandle &));
   MOCK_CONST_METHOD1(checkForConflict,
@@ -71,8 +70,6 @@ class ControllerLoaderMock : public controller_manager::ControllerLoaderInterfac
 public:
   ControllerLoaderMock() : ControllerLoaderInterface("ControllerLoaderMock") {}
 
-  ~ControllerLoaderMock() override = default;
-
   MOCK_METHOD1(createInstance,
                controller_interface::ControllerBaseSharedPtr(const std::string &));
   MOCK_METHOD0(getDeclaredClasses, std::vector<std::string>(void));
@@ -82,7 +79,6 @@ public:
 class ControllerMock : public controller_interface::ControllerBase
 {
 public:
-  ~ControllerMock() override = default;
 
   void initializeState()
   {

--- a/controller_manager/test/hwi_update_test.cpp
+++ b/controller_manager/test/hwi_update_test.cpp
@@ -51,8 +51,6 @@ using ::testing::Return;
 class RobotHWMock : public hardware_interface::RobotHW
 {
 public:
-  RobotHWMock() = default;
-
   ~RobotHWMock() override = default;
 
   MOCK_METHOD2(init, bool(ros::NodeHandle &, ros::NodeHandle &));
@@ -84,8 +82,6 @@ public:
 class ControllerMock : public controller_interface::ControllerBase
 {
 public:
-  ControllerMock() = default;
-
   ~ControllerMock() override = default;
 
   void initializeState()

--- a/controller_manager_tests/include/controller_manager_tests/effort_test_controller.h
+++ b/controller_manager_tests/include/controller_manager_tests/effort_test_controller.h
@@ -40,8 +40,6 @@ namespace controller_manager_tests
 class EffortTestController: public controller_interface::Controller<hardware_interface::EffortJointInterface>
 {
 public:
-  EffortTestController() = default;
-
   using controller_interface::Controller<hardware_interface::EffortJointInterface>::init;
   bool init(hardware_interface::EffortJointInterface* hw, ros::NodeHandle& /*n*/) override;
   void starting(const ros::Time& /*time*/) override;

--- a/controller_manager_tests/include/controller_manager_tests/effort_test_controller.h
+++ b/controller_manager_tests/include/controller_manager_tests/effort_test_controller.h
@@ -40,13 +40,13 @@ namespace controller_manager_tests
 class EffortTestController: public controller_interface::Controller<hardware_interface::EffortJointInterface>
 {
 public:
-  EffortTestController(){}
+  EffortTestController() = default;
 
   using controller_interface::Controller<hardware_interface::EffortJointInterface>::init;
-  bool init(hardware_interface::EffortJointInterface* hw, ros::NodeHandle& /*n*/);
-  void starting(const ros::Time& /*time*/);
-  void update(const ros::Time& /*time*/, const ros::Duration& /*period*/);
-  void stopping(const ros::Time& /*time*/);
+  bool init(hardware_interface::EffortJointInterface* hw, ros::NodeHandle& /*n*/) override;
+  void starting(const ros::Time& /*time*/) override;
+  void update(const ros::Time& /*time*/, const ros::Duration& /*period*/) override;
+  void stopping(const ros::Time& /*time*/) override;
 
 private:
   std::vector<hardware_interface::JointHandle> joint_effort_commands_;

--- a/controller_manager_tests/include/controller_manager_tests/extensible_controllers.h
+++ b/controller_manager_tests/include/controller_manager_tests/extensible_controllers.h
@@ -43,9 +43,9 @@ class ExtensibleController : public virtual BaseControllerInterface
 {
 public:
   bool init(hardware_interface::RobotHW* robot_hw,
-            ros::NodeHandle& root_nh, ros::NodeHandle& controller_nh);
+            ros::NodeHandle& root_nh, ros::NodeHandle& controller_nh) override;
   virtual int helper();
-  void update(const ros::Time&, const ros::Duration&);
+  void update(const ros::Time&, const ros::Duration&) override;
 };
 
 /**
@@ -58,10 +58,10 @@ class DerivedController : public ExtensibleController, public DerivedControllerI
 {
 public:
   bool initRequest(hardware_interface::RobotHW* hw, ros::NodeHandle& nh, ros::NodeHandle& pnh,
-      controller_interface::ControllerBase::ClaimedResources& cr);
+      controller_interface::ControllerBase::ClaimedResources& cr) override;
   bool init(hardware_interface::RobotHW* robot_hw,
-            ros::NodeHandle& root_nh, ros::NodeHandle& controller_nh);
-  virtual int helper();
+            ros::NodeHandle& root_nh, ros::NodeHandle& controller_nh) override;
+  int helper() override;
 };
 
 }  // namespace controller_manager_tests

--- a/controller_manager_tests/include/controller_manager_tests/my_dummy_controller.h
+++ b/controller_manager_tests/include/controller_manager_tests/my_dummy_controller.h
@@ -40,22 +40,19 @@ namespace controller_manager_tests
 class MyDummyInterface : public hardware_interface::HardwareInterface
 {
 public:
-  MyDummyInterface()
-  {
-
-  }
+  MyDummyInterface() = default;
 };
 
 class MyDummyController : public controller_interface::Controller<MyDummyInterface>
 {
 public:
-  MyDummyController() { }
+  MyDummyController() = default;
 
   using controller_interface::Controller<MyDummyInterface>::init;
-  bool init(MyDummyInterface* /*hw*/, ros::NodeHandle& /*n*/) { return true; }
-  void starting(const ros::Time& /*time*/) { }
-  void update(const ros::Time& /*time*/, const ros::Duration& /*period*/) { }
-  void stopping(const ros::Time& /*time*/) { }
+  bool init(MyDummyInterface* /*hw*/, ros::NodeHandle& /*n*/) override { return true; }
+  void starting(const ros::Time& /*time*/) override { }
+  void update(const ros::Time& /*time*/, const ros::Duration& /*period*/) override { }
+  void stopping(const ros::Time& /*time*/) override { }
 };
 
 }

--- a/controller_manager_tests/include/controller_manager_tests/my_dummy_controller.h
+++ b/controller_manager_tests/include/controller_manager_tests/my_dummy_controller.h
@@ -37,17 +37,11 @@
 namespace controller_manager_tests
 {
 
-class MyDummyInterface : public hardware_interface::HardwareInterface
-{
-public:
-  MyDummyInterface() = default;
-};
+class MyDummyInterface : public hardware_interface::HardwareInterface {};
 
 class MyDummyController : public controller_interface::Controller<MyDummyInterface>
 {
 public:
-  MyDummyController() = default;
-
   using controller_interface::Controller<MyDummyInterface>::init;
   bool init(MyDummyInterface* /*hw*/, ros::NodeHandle& /*n*/) override { return true; }
   void starting(const ros::Time& /*time*/) override { }

--- a/controller_manager_tests/include/controller_manager_tests/pos_eff_controller.h
+++ b/controller_manager_tests/include/controller_manager_tests/pos_eff_controller.h
@@ -40,12 +40,12 @@ class PosEffController : public
                                                      hardware_interface::EffortJointInterface>
 {
 public:
-  PosEffController() {}
+  PosEffController() = default;
 
-  bool init(hardware_interface::RobotHW* robot_hw, ros::NodeHandle &n);
-  void starting(const ros::Time& time);
-  void update(const ros::Time& time, const ros::Duration& period);
-  void stopping(const ros::Time& time);
+  bool init(hardware_interface::RobotHW* robot_hw, ros::NodeHandle &n) override;
+  void starting(const ros::Time& time) override;
+  void update(const ros::Time& time, const ros::Duration& period) override;
+  void stopping(const ros::Time& time) override;
 
 private:
   std::vector<hardware_interface::JointHandle> pos_cmd_;

--- a/controller_manager_tests/include/controller_manager_tests/pos_eff_controller.h
+++ b/controller_manager_tests/include/controller_manager_tests/pos_eff_controller.h
@@ -40,8 +40,6 @@ class PosEffController : public
                                                      hardware_interface::EffortJointInterface>
 {
 public:
-  PosEffController() = default;
-
   bool init(hardware_interface::RobotHW* robot_hw, ros::NodeHandle &n) override;
   void starting(const ros::Time& time) override;
   void update(const ros::Time& time, const ros::Duration& period) override;

--- a/controller_manager_tests/include/controller_manager_tests/pos_eff_opt_controller.h
+++ b/controller_manager_tests/include/controller_manager_tests/pos_eff_opt_controller.h
@@ -45,10 +45,10 @@ public:
    : controller_interface::MultiInterfaceController<hardware_interface::PositionJointInterface,
                                                     hardware_interface::EffortJointInterface> (true) {}
 
-  bool init(hardware_interface::RobotHW* robot_hw, ros::NodeHandle &n);
-  void starting(const ros::Time& time);
-  void update(const ros::Time& time, const ros::Duration& period);
-  void stopping(const ros::Time& time);
+  bool init(hardware_interface::RobotHW* robot_hw, ros::NodeHandle &n) override;
+  void starting(const ros::Time& time) override;
+  void update(const ros::Time& time, const ros::Duration& period) override;
+  void stopping(const ros::Time& time) override;
 
 private:
   std::vector<hardware_interface::JointHandle> pos_cmd_;

--- a/controller_manager_tests/include/controller_manager_tests/vel_eff_controller.h
+++ b/controller_manager_tests/include/controller_manager_tests/vel_eff_controller.h
@@ -40,12 +40,12 @@ class VelEffController : public
                                                      hardware_interface::EffortJointInterface>
 {
 public:
-  VelEffController() {}
+  VelEffController() = default;
 
-  bool init(hardware_interface::RobotHW* robot_hw, ros::NodeHandle &n);
-  void starting(const ros::Time& time);
-  void update(const ros::Time& time, const ros::Duration& period);
-  void stopping(const ros::Time& time);
+  bool init(hardware_interface::RobotHW* robot_hw, ros::NodeHandle &n) override;
+  void starting(const ros::Time& time) override;
+  void update(const ros::Time& time, const ros::Duration& period) override;
+  void stopping(const ros::Time& time) override;
 
 private:
   std::vector<hardware_interface::JointHandle> vel_cmd_;

--- a/controller_manager_tests/include/controller_manager_tests/vel_eff_controller.h
+++ b/controller_manager_tests/include/controller_manager_tests/vel_eff_controller.h
@@ -40,8 +40,6 @@ class VelEffController : public
                                                      hardware_interface::EffortJointInterface>
 {
 public:
-  VelEffController() = default;
-
   bool init(hardware_interface::RobotHW* robot_hw, ros::NodeHandle &n) override;
   void starting(const ros::Time& time) override;
   void update(const ros::Time& time, const ros::Duration& period) override;

--- a/hardware_interface/include/hardware_interface/actuator_command_interface.h
+++ b/hardware_interface/include/hardware_interface/actuator_command_interface.h
@@ -40,7 +40,7 @@ namespace hardware_interface
 class ActuatorHandle : public ActuatorStateHandle
 {
 public:
-  ActuatorHandle() {}
+  ActuatorHandle() = default;
 
   /**
    * \param as This actuator's state handle

--- a/hardware_interface/include/hardware_interface/actuator_state_interface.h
+++ b/hardware_interface/include/hardware_interface/actuator_state_interface.h
@@ -45,7 +45,7 @@ namespace hardware_interface
 class ActuatorStateHandle
 {
 public:
-  ActuatorStateHandle() {}
+  ActuatorStateHandle() = default;
 
   /**
    * \param name The name of the actuator

--- a/hardware_interface/include/hardware_interface/force_torque_sensor_interface.h
+++ b/hardware_interface/include/hardware_interface/force_torque_sensor_interface.h
@@ -40,7 +40,7 @@ namespace hardware_interface
 class ForceTorqueSensorHandle
 {
 public:
-  ForceTorqueSensorHandle() {}
+  ForceTorqueSensorHandle() = default;
 
   /**
    * \param name The name of the sensor

--- a/hardware_interface/include/hardware_interface/hardware_interface.h
+++ b/hardware_interface/include/hardware_interface/hardware_interface.h
@@ -71,17 +71,8 @@ private:
 class HardwareInterfaceException: public std::exception
 {
 public:
-  HardwareInterfaceException(const std::string& message)
-    : msg(message) {}
-
-  ~HardwareInterfaceException() noexcept override = default;
-
-  const char* what() const noexcept override
-  {
-    return msg.c_str();
-  }
-
-
+  HardwareInterfaceException(const std::string& message) : msg(message) {}
+  const char* what() const noexcept override {return msg.c_str();}
 private:
   std::string msg;
 };

--- a/hardware_interface/include/hardware_interface/hardware_interface.h
+++ b/hardware_interface/include/hardware_interface/hardware_interface.h
@@ -46,7 +46,7 @@ namespace hardware_interface{
 class HardwareInterface
 {
 public:
-  virtual ~HardwareInterface() {}
+  virtual ~HardwareInterface() = default;
 
   /** \name Resource management
    *\{**/
@@ -74,9 +74,9 @@ public:
   HardwareInterfaceException(const std::string& message)
     : msg(message) {}
 
-  virtual ~HardwareInterfaceException() throw() {}
+  ~HardwareInterfaceException() noexcept override = default;
 
-  virtual const char* what() const throw()
+  const char* what() const noexcept override
   {
     return msg.c_str();
   }

--- a/hardware_interface/include/hardware_interface/imu_sensor_interface.h
+++ b/hardware_interface/include/hardware_interface/imu_sensor_interface.h
@@ -47,7 +47,7 @@ public:
   struct Data
   {
     // Note: User-provided constructor required due to a defect in the standard. See https://stackoverflow.com/a/17436088/1932358
-    Data() {};
+    Data() {}
 
     std::string name;                                   ///< The name of the sensor
     std::string frame_id;                               ///< The reference frame to which this sensor is associated

--- a/hardware_interface/include/hardware_interface/imu_sensor_interface.h
+++ b/hardware_interface/include/hardware_interface/imu_sensor_interface.h
@@ -46,7 +46,8 @@ class ImuSensorHandle
 public:
   struct Data
   {
-    Data() = default;
+    // Note: User-provided constructor required due to a defect in the standard. See https://stackoverflow.com/a/17436088/1932358
+    Data() {};
 
     std::string name;                                   ///< The name of the sensor
     std::string frame_id;                               ///< The reference frame to which this sensor is associated

--- a/hardware_interface/include/hardware_interface/imu_sensor_interface.h
+++ b/hardware_interface/include/hardware_interface/imu_sensor_interface.h
@@ -46,7 +46,7 @@ class ImuSensorHandle
 public:
   struct Data
   {
-    Data() {};
+    Data() = default;
 
     std::string name;                                   ///< The name of the sensor
     std::string frame_id;                               ///< The reference frame to which this sensor is associated

--- a/hardware_interface/include/hardware_interface/interface_resources.h
+++ b/hardware_interface/include/hardware_interface/interface_resources.h
@@ -41,7 +41,7 @@ namespace hardware_interface
  */
 struct InterfaceResources
 {
-  InterfaceResources() {}
+  InterfaceResources() = default;
 
   InterfaceResources(const std::string& hw_iface, const std::set<std::string>& res)
     : hardware_interface(hw_iface),

--- a/hardware_interface/include/hardware_interface/internal/resource_manager.h
+++ b/hardware_interface/include/hardware_interface/internal/resource_manager.h
@@ -73,8 +73,6 @@ public:
   /** \name Non Real-Time Safe Functions
    *\{*/
 
-  ~ResourceManager() override = default;
-
   /** \return Vector of resource names registered to this interface. */
   std::vector<std::string> getNames() const
   {

--- a/hardware_interface/include/hardware_interface/internal/resource_manager.h
+++ b/hardware_interface/include/hardware_interface/internal/resource_manager.h
@@ -52,7 +52,7 @@ namespace hardware_interface
 class ResourceManagerBase
 {
 public:
-  virtual ~ResourceManagerBase() {}
+  virtual ~ResourceManagerBase() = default;
 };
 
 /**
@@ -73,7 +73,7 @@ public:
   /** \name Non Real-Time Safe Functions
    *\{*/
 
-  virtual ~ResourceManager() {}
+  ~ResourceManager() override = default;
 
   /** \return Vector of resource names registered to this interface. */
   std::vector<std::string> getNames() const

--- a/hardware_interface/include/hardware_interface/joint_command_interface.h
+++ b/hardware_interface/include/hardware_interface/joint_command_interface.h
@@ -42,7 +42,7 @@ namespace hardware_interface
 class JointHandle : public JointStateHandle
 {
 public:
-  JointHandle() {}
+  JointHandle() = default;
 
   /**
    * \param js This joint's state handle

--- a/hardware_interface/include/hardware_interface/joint_mode_interface.h
+++ b/hardware_interface/include/hardware_interface/joint_mode_interface.h
@@ -62,8 +62,7 @@ namespace hardware_interface
   class JointModeHandle
   {
   public:
-
-    JointModeHandle() {}
+    JointModeHandle() = default;
 
     /** \param mode Which mode to start in */
     JointModeHandle(std::string name, JointCommandModes* mode)

--- a/hardware_interface/include/hardware_interface/joint_state_interface.h
+++ b/hardware_interface/include/hardware_interface/joint_state_interface.h
@@ -45,7 +45,7 @@ namespace hardware_interface
 class JointStateHandle
 {
 public:
-  JointStateHandle() {}
+  JointStateHandle() = default;
 
   /**
    * \param name The name of the joint

--- a/hardware_interface/include/hardware_interface/posvel_command_interface.h
+++ b/hardware_interface/include/hardware_interface/posvel_command_interface.h
@@ -42,7 +42,7 @@ namespace hardware_interface
 class PosVelJointHandle : public JointStateHandle
 {
 public:
-  PosVelJointHandle() {}
+  PosVelJointHandle() = default;
 
   /**
    * \param js This joint's state handle

--- a/hardware_interface/include/hardware_interface/posvelacc_command_interface.h
+++ b/hardware_interface/include/hardware_interface/posvelacc_command_interface.h
@@ -42,7 +42,7 @@ namespace hardware_interface
 class PosVelAccJointHandle : public PosVelJointHandle
 {
 public:
-  PosVelAccJointHandle() {}
+  PosVelAccJointHandle() = default;
 
   /**
    * \param js This joint's state handle

--- a/hardware_interface/include/hardware_interface/robot_hw.h
+++ b/hardware_interface/include/hardware_interface/robot_hw.h
@@ -58,8 +58,6 @@ namespace hardware_interface
 class RobotHW : public InterfaceManager
 {
 public:
-  RobotHW() = default;
-
   virtual ~RobotHW() = default;
 
   /** \brief The init function is called to initialize the RobotHW from a

--- a/hardware_interface/include/hardware_interface/robot_hw.h
+++ b/hardware_interface/include/hardware_interface/robot_hw.h
@@ -58,15 +58,9 @@ namespace hardware_interface
 class RobotHW : public InterfaceManager
 {
 public:
-  RobotHW()
-  {
+  RobotHW() = default;
 
-  }
-
-  virtual ~RobotHW()
-  {
-
-  }
+  virtual ~RobotHW() = default;
 
   /** \brief The init function is called to initialize the RobotHW from a
    * non-realtime thread.

--- a/joint_limits_interface/include/joint_limits_interface/joint_limits_interface.h
+++ b/joint_limits_interface/include/joint_limits_interface/joint_limits_interface.h
@@ -160,7 +160,7 @@ private:
 class PositionJointSoftLimitsHandle
 {
 public:
-  PositionJointSoftLimitsHandle() {}
+  PositionJointSoftLimitsHandle() = default;
 
   PositionJointSoftLimitsHandle(const hardware_interface::JointHandle& jh,
                                 const JointLimits&                     limits,
@@ -316,7 +316,7 @@ private:
 class EffortJointSoftLimitsHandle
 {
 public:
-  EffortJointSoftLimitsHandle() {}
+  EffortJointSoftLimitsHandle() = default;
 
   EffortJointSoftLimitsHandle(const hardware_interface::JointHandle& jh,
                               const JointLimits&                     limits,
@@ -402,7 +402,7 @@ private:
 class VelocityJointSaturationHandle
 {
 public:
-  VelocityJointSaturationHandle() {}
+  VelocityJointSaturationHandle() = default;
 
   VelocityJointSaturationHandle(const hardware_interface::JointHandle& jh, const JointLimits& limits)
     : jh_(jh)

--- a/joint_limits_interface/include/joint_limits_interface/joint_limits_interface_exception.h
+++ b/joint_limits_interface/include/joint_limits_interface/joint_limits_interface_exception.h
@@ -28,6 +28,9 @@
 #pragma once
 
 
+#include <exception>
+#include <string>
+
 namespace joint_limits_interface
 {
 
@@ -35,16 +38,8 @@ namespace joint_limits_interface
 class JointLimitsInterfaceException: public std::exception
 {
 public:
-  JointLimitsInterfaceException(const std::string& message)
-    : msg(message) {}
-
-  ~JointLimitsInterfaceException() noexcept override = default;
-
-  const char* what() const noexcept override
-  {
-    return msg.c_str();
-  }
-
+  JointLimitsInterfaceException(const std::string& message) : msg(message) {}
+  const char* what() const noexcept override {return msg.c_str();}
 private:
   std::string msg;
 };

--- a/joint_limits_interface/include/joint_limits_interface/joint_limits_interface_exception.h
+++ b/joint_limits_interface/include/joint_limits_interface/joint_limits_interface_exception.h
@@ -38,9 +38,9 @@ public:
   JointLimitsInterfaceException(const std::string& message)
     : msg(message) {}
 
-  virtual ~JointLimitsInterfaceException() throw() {}
+  ~JointLimitsInterfaceException() noexcept override = default;
 
-  virtual const char* what() const throw()
+  const char* what() const noexcept override
   {
     return msg.c_str();
   }

--- a/transmission_interface/include/transmission_interface/bidirectional_effort_joint_interface_provider.h
+++ b/transmission_interface/include/transmission_interface/bidirectional_effort_joint_interface_provider.h
@@ -38,9 +38,8 @@ namespace transmission_interface
 class BiDirectionalEffortJointInterfaceProvider : public EffortJointInterfaceProvider
 {
 protected:
-
   bool registerTransmission(TransmissionLoaderData& loader_data,
-                            TransmissionHandleData& handle_data);
+                            TransmissionHandleData& handle_data) override;
 };
 
 } // namespace

--- a/transmission_interface/include/transmission_interface/bidirectional_position_joint_interface_provider.h
+++ b/transmission_interface/include/transmission_interface/bidirectional_position_joint_interface_provider.h
@@ -38,9 +38,8 @@ namespace transmission_interface
 class BiDirectionalPositionJointInterfaceProvider : public PositionJointInterfaceProvider
 {
 protected:
-
   bool registerTransmission(TransmissionLoaderData& loader_data,
-                            TransmissionHandleData& handle_data);
+                            TransmissionHandleData& handle_data) override;
 };
 
 } // namespace

--- a/transmission_interface/include/transmission_interface/bidirectional_velocity_joint_interface_provider.h
+++ b/transmission_interface/include/transmission_interface/bidirectional_velocity_joint_interface_provider.h
@@ -38,9 +38,8 @@ namespace transmission_interface
 class BiDirectionalVelocityJointInterfaceProvider : public VelocityJointInterfaceProvider
 {
 protected:
-
   bool registerTransmission(TransmissionLoaderData& loader_data,
-                            TransmissionHandleData& handle_data);
+                            TransmissionHandleData& handle_data) override;
 };
 
 } // namespace

--- a/transmission_interface/include/transmission_interface/differential_transmission.h
+++ b/transmission_interface/include/transmission_interface/differential_transmission.h
@@ -147,7 +147,7 @@ public:
    *  To call this method it is not required that all other data vectors contain valid data, and can even remain empty.
    */
   void actuatorToJointEffort(const ActuatorData& act_data,
-                                   JointData&    jnt_data);
+                                   JointData&    jnt_data) override;
 
   /**
    * \brief Transform \e velocity variables from actuator to joint space.
@@ -157,7 +157,7 @@ public:
    *  To call this method it is not required that all other data vectors contain valid data, and can even remain empty.
    */
   void actuatorToJointVelocity(const ActuatorData& act_data,
-                                     JointData&    jnt_data);
+                                     JointData&    jnt_data) override;
 
   /**
    * \brief Transform \e position variables from actuator to joint space.
@@ -167,7 +167,7 @@ public:
    *  To call this method it is not required that all other data vectors contain valid data, and can even remain empty.
    */
   void actuatorToJointPosition(const ActuatorData& act_data,
-                                     JointData&    jnt_data);
+                                     JointData&    jnt_data) override;
 
   /**
    * \brief Transform \e absolute encoder values from actuator to joint space.
@@ -177,7 +177,7 @@ public:
    *  To call this method it is not required that all other data vectors contain valid data, and can even remain empty.
    */
   void actuatorToJointAbsolutePosition(const ActuatorData& act_data,
-                                             JointData&    jnt_data);
+                                             JointData&    jnt_data) override;
 
   /**
    * \brief Transform \e torque sensor values from actuator to joint space.
@@ -187,7 +187,7 @@ public:
    *  To call this method it is not required that all other data vectors contain valid data, and can even remain empty.
    */
   void actuatorToJointTorqueSensor(const ActuatorData& act_data,
-                                         JointData&    jnt_data);
+                                         JointData&    jnt_data) override;
 
   /**
    * \brief Transform \e effort variables from joint to actuator space.
@@ -197,7 +197,7 @@ public:
    *  To call this method it is not required that all other data vectors contain valid data, and can even remain empty.
    */
   void jointToActuatorEffort(const JointData&    jnt_data,
-                                   ActuatorData& act_data);
+                                   ActuatorData& act_data) override;
 
   /**
    * \brief Transform \e velocity variables from joint to actuator space.
@@ -207,7 +207,7 @@ public:
    *  To call this method it is not required that all other data vectors contain valid data, and can even remain empty.
    */
   void jointToActuatorVelocity(const JointData&    jnt_data,
-                                     ActuatorData& act_data);
+                                     ActuatorData& act_data) override;
 
   /**
    * \brief Transform \e position variables from joint to actuator space.
@@ -217,12 +217,12 @@ public:
    *  To call this method it is not required that all other data vectors contain valid data, and can even remain empty.
    */
   void jointToActuatorPosition(const JointData&    jnt_data,
-                                     ActuatorData& act_data);
+                                     ActuatorData& act_data) override;
 
-  std::size_t numActuators() const {return 2;}
-  std::size_t numJoints()    const {return 2;}
-  bool hasActuatorToJointAbsolutePosition()  const {return true;}
-  bool hasActuatorToJointTorqueSensor()      const {return true;}
+  std::size_t numActuators() const override {return 2;}
+  std::size_t numJoints()    const override {return 2;}
+  bool hasActuatorToJointAbsolutePosition()  const override {return true;}
+  bool hasActuatorToJointTorqueSensor()      const override {return true;}
 
   const std::vector<double>& getActuatorReduction() const {return act_reduction_;}
   const std::vector<double>& getJointReduction()    const {return jnt_reduction_;}

--- a/transmission_interface/include/transmission_interface/differential_transmission_loader.h
+++ b/transmission_interface/include/transmission_interface/differential_transmission_loader.h
@@ -45,7 +45,7 @@ namespace transmission_interface
 class DifferentialTransmissionLoader : public TransmissionLoader
 {
 public:
-  TransmissionSharedPtr load(const TransmissionInfo& transmission_info);
+  TransmissionSharedPtr load(const TransmissionInfo& transmission_info) override;
 
 private:
   static bool getActuatorConfig(const TransmissionInfo& transmission_info,

--- a/transmission_interface/include/transmission_interface/effort_joint_interface_provider.h
+++ b/transmission_interface/include/transmission_interface/effort_joint_interface_provider.h
@@ -44,20 +44,20 @@ public:
   bool updateJointInterfaces(const TransmissionInfo&      transmission_info,
                              hardware_interface::RobotHW* robot_hw,
                              JointInterfaces&             joint_interfaces,
-                             RawJointDataMap&             raw_joint_data_map);
+                             RawJointDataMap&             raw_joint_data_map) override;
 
 protected:
 
   bool getJointCommandData(const TransmissionInfo& transmission_info,
                            const RawJointDataMap&  raw_joint_data_map,
-                           JointData&              jnt_cmd_data);
+                           JointData&              jnt_cmd_data) override;
 
   bool getActuatorCommandData(const TransmissionInfo&      transmission_info,
                               hardware_interface::RobotHW* robot_hw,
-                              ActuatorData&                act_cmd_data);
+                              ActuatorData&                act_cmd_data) override;
 
   bool registerTransmission(TransmissionLoaderData& loader_data,
-                            TransmissionHandleData& handle_data);
+                            TransmissionHandleData& handle_data) override;
 };
 
 } // namespace

--- a/transmission_interface/include/transmission_interface/four_bar_linkage_transmission.h
+++ b/transmission_interface/include/transmission_interface/four_bar_linkage_transmission.h
@@ -135,7 +135,7 @@ public:
    *  To call this method it is not required that all other data vectors contain valid data, and can even remain empty.
    */
   void actuatorToJointEffort(const ActuatorData& act_data,
-                                   JointData&    jnt_data);
+                                   JointData&    jnt_data) override;
 
   /**
    * \brief Transform \e velocity variables from actuator to joint space.
@@ -145,7 +145,7 @@ public:
    *  To call this method it is not required that all other data vectors contain valid data, and can even remain empty.
    */
   void actuatorToJointVelocity(const ActuatorData& act_data,
-                                     JointData&    jnt_data);
+                                     JointData&    jnt_data) override;
 
   /**
    * \brief Transform \e position variables from actuator to joint space.
@@ -155,7 +155,7 @@ public:
    *  To call this method it is not required that all other data vectors contain valid data, and can even remain empty.
    */
   void actuatorToJointPosition(const ActuatorData& act_data,
-                                     JointData&    jnt_data);
+                                     JointData&    jnt_data) override;
 
   /**
    * \brief Transform \e absolute encoder values from actuator to joint space.
@@ -165,7 +165,7 @@ public:
    *  To call this method it is not required that all other data vectors contain valid data, and can even remain empty.
    */
   void actuatorToJointAbsolutePosition(const ActuatorData& act_data,
-                                             JointData&    jnt_data);
+                                             JointData&    jnt_data) override;
 
   /**
    * \brief Transform \e torque sensor values from actuator to joint space.
@@ -174,7 +174,7 @@ public:
    * \pre Actuator, joint position and torque sensor vectors must have the same size.
    */
   void actuatorToJointTorqueSensor(const ActuatorData& act_data,
-                                         JointData&    jnt_data);
+                                         JointData&    jnt_data) override;
 
   /**
    * \brief Transform \e effort variables from joint to actuator space.
@@ -184,7 +184,7 @@ public:
    *  To call this method it is not required that all other data vectors contain valid data, and can even remain empty.
    */
   void jointToActuatorEffort(const JointData&    jnt_data,
-                                   ActuatorData& act_data);
+                                   ActuatorData& act_data) override;
 
   /**
    * \brief Transform \e velocity variables from joint to actuator space.
@@ -194,7 +194,7 @@ public:
    *  To call this method it is not required that all other data vectors contain valid data, and can even remain empty.
    */
   void jointToActuatorVelocity(const JointData&    jnt_data,
-                                     ActuatorData& act_data);
+                                     ActuatorData& act_data) override;
 
   /**
    * \brief Transform \e position variables from joint to actuator space.
@@ -204,12 +204,12 @@ public:
    *  To call this method it is not required that all other data vectors contain valid data, and can even remain empty.
    */
   void jointToActuatorPosition(const JointData&    jnt_data,
-                                     ActuatorData& act_data);
+                                     ActuatorData& act_data) override;
 
-  std::size_t numActuators() const {return 2;}
-  std::size_t numJoints()    const {return 2;}
-  bool hasActuatorToJointAbsolutePosition()  const {return true;}
-  bool hasActuatorToJointTorqueSensor()      const {return true;}
+  std::size_t numActuators() const override {return 2;}
+  std::size_t numJoints()    const override {return 2;}
+  bool hasActuatorToJointAbsolutePosition()  const override {return true;}
+  bool hasActuatorToJointTorqueSensor()      const override {return true;}
 
   const std::vector<double>& getActuatorReduction() const {return act_reduction_;}
   const std::vector<double>& getJointReduction()    const {return jnt_reduction_;}

--- a/transmission_interface/include/transmission_interface/four_bar_linkage_transmission_loader.h
+++ b/transmission_interface/include/transmission_interface/four_bar_linkage_transmission_loader.h
@@ -45,7 +45,7 @@ namespace transmission_interface
 class FourBarLinkageTransmissionLoader : public TransmissionLoader
 {
 public:
-  TransmissionSharedPtr load(const TransmissionInfo& transmission_info);
+  TransmissionSharedPtr load(const TransmissionInfo& transmission_info) override;
 
 private:
   static bool getActuatorConfig(const TransmissionInfo& transmission_info,

--- a/transmission_interface/include/transmission_interface/joint_state_interface_provider.h
+++ b/transmission_interface/include/transmission_interface/joint_state_interface_provider.h
@@ -43,27 +43,27 @@ public:
   bool updateJointInterfaces(const TransmissionInfo&      transmission_info,
                              hardware_interface::RobotHW* robot_hw,
                              JointInterfaces&             joint_interfaces,
-                             RawJointDataMap&             raw_joint_data_map);
+                             RawJointDataMap&             raw_joint_data_map) override;
 
 protected:
   bool getJointStateData(const TransmissionInfo& transmission_info,
                          const RawJointDataMap&  raw_joint_data_map,
-                         JointData&              jnt_state_data);
+                         JointData&              jnt_state_data) override;
 
   bool getJointCommandData(const TransmissionInfo& /*transmission_info*/,
                            const RawJointDataMap&  /*raw_joint_data_map*/,
-                           JointData&              /*jnt_cmd_data*/) {return true;}
+                           JointData&              /*jnt_cmd_data*/) override {return true;}
 
   bool getActuatorStateData(const TransmissionInfo&      transmission_info,
                             hardware_interface::RobotHW* robot_hw,
-                            ActuatorData&                act_state_data);
+                            ActuatorData&                act_state_data) override;
 
   bool getActuatorCommandData(const TransmissionInfo&      /*transmission_info*/,
                               hardware_interface::RobotHW* /*robot_hw*/,
-                              ActuatorData&                /*act_cmd_data*/) {return true;}
+                              ActuatorData&                /*act_cmd_data*/) override {return true;}
 
   bool registerTransmission(TransmissionLoaderData& loader_data,
-                            TransmissionHandleData& handle_data);
+                            TransmissionHandleData& handle_data) override;
 };
 
 } // namespace

--- a/transmission_interface/include/transmission_interface/position_joint_interface_provider.h
+++ b/transmission_interface/include/transmission_interface/position_joint_interface_provider.h
@@ -44,20 +44,20 @@ public:
   bool updateJointInterfaces(const TransmissionInfo&      transmission_info,
                              hardware_interface::RobotHW* robot_hw,
                              JointInterfaces&             joint_interfaces,
-                             RawJointDataMap&             raw_joint_data_map);
+                             RawJointDataMap&             raw_joint_data_map) override;
 
 protected:
 
   bool getJointCommandData(const TransmissionInfo& transmission_info,
                            const RawJointDataMap&  raw_joint_data_map,
-                           JointData&              jnt_cmd_data);
+                           JointData&              jnt_cmd_data) override;
 
   bool getActuatorCommandData(const TransmissionInfo&      transmission_info,
                               hardware_interface::RobotHW* robot_hw,
-                              ActuatorData&                act_cmd_data);
+                              ActuatorData&                act_cmd_data) override;
 
   bool registerTransmission(TransmissionLoaderData& loader_data,
-                            TransmissionHandleData& handle_data);
+                            TransmissionHandleData& handle_data) override;
 };
 
 } // namespace

--- a/transmission_interface/include/transmission_interface/simple_transmission.h
+++ b/transmission_interface/include/transmission_interface/simple_transmission.h
@@ -111,7 +111,7 @@ public:
    *  To call this method it is not required that all other data vectors contain valid data, and can even remain empty.
    */
   void actuatorToJointEffort(const ActuatorData& act_data,
-                                   JointData&    jnt_data);
+                                   JointData&    jnt_data) override;
 
   /**
    * \brief Transform \e velocity variables from actuator to joint space.
@@ -121,7 +121,7 @@ public:
    *  To call this method it is not required that all other data vectors contain valid data, and can even remain empty.
    */
   void actuatorToJointVelocity(const ActuatorData& act_data,
-                                     JointData&    jnt_data);
+                                     JointData&    jnt_data) override;
 
   /**
    * \brief Transform \e position variables from actuator to joint space.
@@ -131,13 +131,13 @@ public:
    *  To call this method it is not required that all other data vectors contain valid data, and can even remain empty.
    */
   void actuatorToJointPosition(const ActuatorData& act_data,
-                                     JointData&    jnt_data);
+                                     JointData&    jnt_data) override;
 
   void actuatorToJointAbsolutePosition(const ActuatorData& act_data,
-                                             JointData&    jnt_data);
+                                             JointData&    jnt_data) override;
 
   void actuatorToJointTorqueSensor(const ActuatorData& act_data,
-                                         JointData&    jnt_data);
+                                         JointData&    jnt_data) override;
 
   /**
    * \brief Transform \e effort variables from joint to actuator space.
@@ -147,7 +147,7 @@ public:
    *  To call this method it is not required that all other data vectors contain valid data, and can even remain empty.
    */
   void jointToActuatorEffort(const JointData&    jnt_data,
-                                   ActuatorData& act_data);
+                                   ActuatorData& act_data) override;
 
   /**
    * \brief Transform \e velocity variables from joint to actuator space.
@@ -157,7 +157,7 @@ public:
    *  To call this method it is not required that all other data vectors contain valid data, and can even remain empty.
    */
   void jointToActuatorVelocity(const JointData&    jnt_data,
-                                     ActuatorData& act_data);
+                                     ActuatorData& act_data) override;
 
   /**
    * \brief Transform \e position variables from joint to actuator space.
@@ -167,12 +167,12 @@ public:
    *  To call this method it is not required that all other data vectors contain valid data, and can even remain empty.
    */
   void jointToActuatorPosition(const JointData&    jnt_data,
-                                     ActuatorData& act_data);
+                                     ActuatorData& act_data) override;
 
-  std::size_t numActuators() const {return 1;}
-  std::size_t numJoints()    const {return 1;}
-  bool hasActuatorToJointAbsolutePosition() const {return true;}
-  bool hasActuatorToJointTorqueSensor()     const {return true;}
+  std::size_t numActuators() const override {return 1;}
+  std::size_t numJoints()    const override {return 1;}
+  bool hasActuatorToJointAbsolutePosition() const override {return true;}
+  bool hasActuatorToJointTorqueSensor()     const override {return true;}
 
   double getActuatorReduction() const {return reduction_;}
   double getJointOffset()       const {return jnt_offset_;}

--- a/transmission_interface/include/transmission_interface/simple_transmission_loader.h
+++ b/transmission_interface/include/transmission_interface/simple_transmission_loader.h
@@ -43,7 +43,7 @@ class SimpleTransmissionLoader : public TransmissionLoader
 {
 public:
 
-  TransmissionSharedPtr load(const TransmissionInfo& transmission_info);
+  TransmissionSharedPtr load(const TransmissionInfo& transmission_info) override;
 };
 
 } // namespace

--- a/transmission_interface/include/transmission_interface/transmission.h
+++ b/transmission_interface/include/transmission_interface/transmission.h
@@ -91,7 +91,7 @@ struct JointData
 class Transmission
 {
 public:
-  virtual ~Transmission() {}
+  virtual ~Transmission() = default;
 
   /**
    * \brief Transform \e effort variables from actuator to joint space.

--- a/transmission_interface/include/transmission_interface/transmission_interface_exception.h
+++ b/transmission_interface/include/transmission_interface/transmission_interface_exception.h
@@ -37,8 +37,8 @@ class TransmissionInterfaceException: public std::exception
 {
 public:
   TransmissionInterfaceException(const std::string& message) : msg(message) {}
-  virtual ~TransmissionInterfaceException() throw() {}
-  virtual const char* what() const throw() {return msg.c_str();}
+  ~TransmissionInterfaceException() noexcept override = default;
+  const char* what() const noexcept override {return msg.c_str();}
 private:
   std::string msg;
 };

--- a/transmission_interface/include/transmission_interface/transmission_interface_exception.h
+++ b/transmission_interface/include/transmission_interface/transmission_interface_exception.h
@@ -29,6 +29,7 @@
 
 
 #include <exception>
+#include <string>
 
 namespace transmission_interface
 {
@@ -37,7 +38,6 @@ class TransmissionInterfaceException: public std::exception
 {
 public:
   TransmissionInterfaceException(const std::string& message) : msg(message) {}
-  ~TransmissionInterfaceException() noexcept override = default;
   const char* what() const noexcept override {return msg.c_str();}
 private:
   std::string msg;

--- a/transmission_interface/include/transmission_interface/transmission_interface_loader.h
+++ b/transmission_interface/include/transmission_interface/transmission_interface_loader.h
@@ -129,7 +129,7 @@ class RequisiteProvider // TODO: There must be a more descriptive name for this 
 {
 public:
 
-  virtual ~RequisiteProvider() {}
+  virtual ~RequisiteProvider() = default;
 
   /**
    * \brief Update a robot's joint interfaces with joint information contained in a transmission.

--- a/transmission_interface/include/transmission_interface/transmission_interface_loader.h
+++ b/transmission_interface/include/transmission_interface/transmission_interface_loader.h
@@ -128,7 +128,6 @@ struct TransmissionLoaderData
 class RequisiteProvider // TODO: There must be a more descriptive name for this class!
 {
 public:
-
   virtual ~RequisiteProvider() = default;
 
   /**

--- a/transmission_interface/include/transmission_interface/transmission_loader.h
+++ b/transmission_interface/include/transmission_interface/transmission_loader.h
@@ -61,7 +61,6 @@ namespace transmission_interface
 class TransmissionLoader
 {
 public:
-
   virtual ~TransmissionLoader() = default;
 
   virtual TransmissionSharedPtr load(const TransmissionInfo& transmission_info) = 0;

--- a/transmission_interface/include/transmission_interface/transmission_loader.h
+++ b/transmission_interface/include/transmission_interface/transmission_loader.h
@@ -62,7 +62,7 @@ class TransmissionLoader
 {
 public:
 
-  virtual ~TransmissionLoader() {}
+  virtual ~TransmissionLoader() = default;
 
   virtual TransmissionSharedPtr load(const TransmissionInfo& transmission_info) = 0;
 

--- a/transmission_interface/include/transmission_interface/velocity_joint_interface_provider.h
+++ b/transmission_interface/include/transmission_interface/velocity_joint_interface_provider.h
@@ -44,20 +44,20 @@ public:
   bool updateJointInterfaces(const TransmissionInfo&      transmission_info,
                              hardware_interface::RobotHW* robot_hw,
                              JointInterfaces&             joint_interfaces,
-                             RawJointDataMap&             raw_joint_data_map);
+                             RawJointDataMap&             raw_joint_data_map) override;
 
 protected:
 
   bool getJointCommandData(const TransmissionInfo& transmission_info,
                            const RawJointDataMap&  raw_joint_data_map,
-                           JointData&              jnt_cmd_data);
+                           JointData&              jnt_cmd_data) override;
 
   bool getActuatorCommandData(const TransmissionInfo&      transmission_info,
                               hardware_interface::RobotHW* robot_hw,
-                              ActuatorData&                act_cmd_data);
+                              ActuatorData&                act_cmd_data) override;
 
   bool registerTransmission(TransmissionLoaderData& loader_data,
-                            TransmissionHandleData& handle_data);
+                            TransmissionHandleData& handle_data) override;
 };
 
 } // namespace


### PR DESCRIPTION
Part of #403.

Add function specifiers (`override`, `noexcept`) and cleanup ctors & dtors (`= default`, `= delete`, and removing unnecessary).

A couple of notes:
 - Per [CppCoreGuidelines C.128](http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c128-virtual-functions-should-specify-exactly-one-of-virtual-override-or-final), **Virtual functions should specify exactly one of virtual, override, or final**. Therefore, lots of `virtual` specifiers were removed in favour of `override`s.
 - We had a lot of unnecessary empty constructors and overriding destructors. Wherever possible, these have been removed.
 - `throw()` -> `noexcept`. I did not add any additional `noexcept`s though, only updated the existing ones in the custom exceptions.
 - `ImuSensorHandle::Data::Data()` must be user-defined, it cannot be `= default`. See https://stackoverflow.com/a/17436088/1932358

---

This was mostly done using `clang-tidy`:
```
Checks: '-*,
        modernize-use-equals-default,
        modernize-use-equals-delete,
        modernize-use-override,
        modernize-use-noexcept
        '
```