### PR TITLE
Fixed compile tests

### DIFF
--- a/transmission_interface/CMakeLists.txt
+++ b/transmission_interface/CMakeLists.txt
@@ -87,7 +87,7 @@ target_link_libraries(${PROJECT_NAME}_loader_plugins ${PROJECT_NAME}_loader)
 
 if(CATKIN_ENABLE_TESTING)
   find_package(resource_retriever REQUIRED)
-  include_directories(include ${resource_retriever_INCLUDE_DIRS})
+  include_directories(${resource_retriever_INCLUDE_DIRS})
 
   catkin_add_gtest(simple_transmission_test                       test/simple_transmission_test.cpp)
 

--- a/transmission_interface/CMakeLists.txt
+++ b/transmission_interface/CMakeLists.txt
@@ -87,6 +87,7 @@ target_link_libraries(${PROJECT_NAME}_loader_plugins ${PROJECT_NAME}_loader)
 
 if(CATKIN_ENABLE_TESTING)
   find_package(resource_retriever REQUIRED)
+  include_directories(include ${resource_retriever_INCLUDE_DIRS})
 
   catkin_add_gtest(simple_transmission_test                       test/simple_transmission_test.cpp)
 


### PR DESCRIPTION
Tests are not able to find `resource_retriever/retriever.h` headers

Signed-off-by: ahcorde <ahcorde@gmail.com>