### PR TITLE
Add xmlns for URDF, remove xmlns:xacro

### DIFF
--- a/transmission_interface/test/transmission_parser_test.cpp
+++ b/transmission_interface/test/transmission_parser_test.cpp
@@ -49,7 +49,7 @@ TEST(TransmissionParserTest, InvalidFile)
 TEST(TransmissionParserTest, EmptyFile)
 {
   TransmissionParser parser;
-  std::string urdf = "<?xml version=\"1.0\"?><robot name=\"robot\" xmlns:xacro=\"http://www.ros.org/wiki/xacro\"></robot>";
+  std::string urdf = "<?xml version=\"1.0\"?><robot name=\"robot\" xmlns=\"http://www.ros.org\"></robot>";
   std::vector<TransmissionInfo> infos;
 
   ASSERT_TRUE(parser.parse(urdf, infos));

--- a/transmission_interface/test/urdf/differential_transmission_loader_full.urdf
+++ b/transmission_interface/test/urdf/differential_transmission_loader_full.urdf
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<robot name="robot" xmlns:xacro="http://www.ros.org/wiki/xacro">
+<robot name="robot" xmlns="http://www.ros.org">
 
   <transmission name="differential_trans">
     <type>transmission_interface/DifferentialTransmission</type>

--- a/transmission_interface/test/urdf/differential_transmission_loader_invalid.urdf
+++ b/transmission_interface/test/urdf/differential_transmission_loader_invalid.urdf
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<robot name="robot" xmlns:xacro="http://www.ros.org/wiki/xacro">
+<robot name="robot" xmlns="http://www.ros.org">
 
   <transmission name="differential_trans">
     <type>transmission_interface/DifferentialTransmission</type>

--- a/transmission_interface/test/urdf/differential_transmission_loader_minimal.urdf
+++ b/transmission_interface/test/urdf/differential_transmission_loader_minimal.urdf
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<robot name="robot" xmlns:xacro="http://www.ros.org/wiki/xacro">
+<robot name="robot" xmlns="http://www.ros.org">
 
   <transmission name="differential_trans">
     <type>transmission_interface/DifferentialTransmission</type>

--- a/transmission_interface/test/urdf/four_bar_linkage_transmission_loader_full.urdf
+++ b/transmission_interface/test/urdf/four_bar_linkage_transmission_loader_full.urdf
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<robot name="robot" xmlns:xacro="http://www.ros.org/wiki/xacro">
+<robot name="robot" xmlns="http://www.ros.org">
 
   <transmission name="four_bar_linkage_trans">
     <type>transmission_interface/FourBarLinkageTransmission</type>

--- a/transmission_interface/test/urdf/four_bar_linkage_transmission_loader_invalid.urdf
+++ b/transmission_interface/test/urdf/four_bar_linkage_transmission_loader_invalid.urdf
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<robot name="robot" xmlns:xacro="http://www.ros.org/wiki/xacro">
+<robot name="robot" xmlns="http://www.ros.org">
 
   <transmission name="four_bar_linkage_trans">
     <type>transmission_interface/FourBarLinkageTransmission</type>

--- a/transmission_interface/test/urdf/four_bar_linkage_transmission_loader_minimal.urdf
+++ b/transmission_interface/test/urdf/four_bar_linkage_transmission_loader_minimal.urdf
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<robot name="robot" xmlns:xacro="http://www.ros.org/wiki/xacro">
+<robot name="robot" xmlns="http://www.ros.org">
 
   <transmission name="four_bar_linkage_trans">
     <type>transmission_interface/FourBarLinkageTransmission</type>

--- a/transmission_interface/test/urdf/parser_test_invalid.urdf
+++ b/transmission_interface/test/urdf/parser_test_invalid.urdf
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<robot name="robot" xmlns:xacro="http://www.ros.org/wiki/xacro">
+<robot name="robot" xmlns="http://www.ros.org">
 
 <!-- No transmission name -->
 <transmission>

--- a/transmission_interface/test/urdf/parser_test_valid.urdf
+++ b/transmission_interface/test/urdf/parser_test_valid.urdf
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<robot name="robot" xmlns:xacro="http://www.ros.org/wiki/xacro">
+<robot name="robot" xmlns="http://www.ros.org">
 
   <transmission name="differential_trans">
     <type>transmission_interface/DifferentialTransmission</type>

--- a/transmission_interface/test/urdf/simple_transmission_loader_full.urdf
+++ b/transmission_interface/test/urdf/simple_transmission_loader_full.urdf
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<robot name="robot" xmlns:xacro="http://www.ros.org/wiki/xacro">
+<robot name="robot" xmlns="http://www.ros.org">
 
   <transmission name="simple_trans">
     <type>transmission_interface/SimpleTransmission</type>

--- a/transmission_interface/test/urdf/simple_transmission_loader_invalid.urdf
+++ b/transmission_interface/test/urdf/simple_transmission_loader_invalid.urdf
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<robot name="robot" xmlns:xacro="http://www.ros.org/wiki/xacro">
+<robot name="robot" xmlns="http://www.ros.org">
 
   <transmission name="simple_trans">
     <type>transmission_interface/SimpleTransmission</type>

--- a/transmission_interface/test/urdf/simple_transmission_loader_minimal.urdf
+++ b/transmission_interface/test/urdf/simple_transmission_loader_minimal.urdf
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<robot name="robot" xmlns:xacro="http://www.ros.org/wiki/xacro">
+<robot name="robot" xmlns="http://www.ros.org">
 
   <transmission name="simple_trans">
     <type>transmission_interface/SimpleTransmission</type>

--- a/transmission_interface/test/urdf/transmission_interface_loader_bidirectional_valid.urdf
+++ b/transmission_interface/test/urdf/transmission_interface_loader_bidirectional_valid.urdf
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<robot name="robot" xmlns:xacro="http://www.ros.org/wiki/xacro">
+<robot name="robot" xmlns="http://www.ros.org">
 
   <transmission name="simple_trans">
     <type>transmission_interface/SimpleTransmission</type>

--- a/transmission_interface/test/urdf/transmission_interface_loader_duplicate.urdf
+++ b/transmission_interface/test/urdf/transmission_interface_loader_duplicate.urdf
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<robot name="robot" xmlns:xacro="http://www.ros.org/wiki/xacro">
+<robot name="robot" xmlns="http://www.ros.org">
 
   <transmission name="simple_trans">
     <type>transmission_interface/SimpleTransmission</type>

--- a/transmission_interface/test/urdf/transmission_interface_loader_hw_iface_permutation.urdf
+++ b/transmission_interface/test/urdf/transmission_interface_loader_hw_iface_permutation.urdf
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<robot name="robot" xmlns:xacro="http://www.ros.org/wiki/xacro">
+<robot name="robot" xmlns="http://www.ros.org">
 
   <transmission name="differential_trans">
     <type>transmission_interface/DifferentialTransmission</type>

--- a/transmission_interface/test/urdf/transmission_interface_loader_unsupported.urdf
+++ b/transmission_interface/test/urdf/transmission_interface_loader_unsupported.urdf
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<robot name="robot" xmlns:xacro="http://www.ros.org/wiki/xacro">
+<robot name="robot" xmlns="http://www.ros.org">
 
   <transmission name="differential_trans">
     <type>transmission_interface/DifferentialTransmission</type>

--- a/transmission_interface/test/urdf/transmission_interface_loader_valid.urdf
+++ b/transmission_interface/test/urdf/transmission_interface_loader_valid.urdf
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<robot name="robot" xmlns:xacro="http://www.ros.org/wiki/xacro">
+<robot name="robot" xmlns="http://www.ros.org">
 
   <transmission name="simple_trans">
     <type>transmission_interface/SimpleTransmission</type>


### PR DESCRIPTION
Drops the unused `xmlns:xacro`, since we aren't using any `xacro`, and replaces it with the URDF ns.

Although not widely used (As far as I can see), technically URDF should specify an `xmlns` of `http://www.ros.org`, as specified by the `targetNamespace` of the [URDF schema](https://github.com/ros/urdfdom/blob/master/xsd/urdf.xsd). Might as well set a good example :)

---

Interesting note, this removes every instance of the string "xacro" in the repo.