### PR TITLE
[Noetic] Use CamelCase for ResourceManagerType typedef

### DIFF
--- a/hardware_interface/include/hardware_interface/internal/interface_manager.h
+++ b/hardware_interface/include/hardware_interface/internal/interface_manager.h
@@ -51,10 +51,10 @@ template <typename T>
 struct CheckIsResourceManager {
   // method called if C is a ResourceManager
   template <typename C>
-  static void callCM(typename std::vector<C*>& managers, C* result, typename C::resource_manager_type*)
+  static void callCM(typename std::vector<C*>& managers, C* result, typename C::ResourceManagerType*)
   {
     // We have to typecast back to base class
-    std::vector<typename C::resource_manager_type*> managers_in(managers.begin(), managers.end());
+    std::vector<typename C::ResourceManagerType*> managers_in(managers.begin(), managers.end());
     C::concatManagers(managers_in, result);
   }
 
@@ -69,7 +69,7 @@ struct CheckIsResourceManager {
 
   // method called if C is a ResourceManager
   template <typename C>
-  static void callGR(std::vector<std::string> &resources, C* iface, typename C::resource_manager_type*)
+  static void callGR(std::vector<std::string> &resources, C* iface, typename C::ResourceManagerType*)
   {
     resources = iface->getNames();
   }
@@ -83,7 +83,7 @@ struct CheckIsResourceManager {
   { return callGR<T>(resources, iface, nullptr); }
 
   template <typename C>
-  static T* newCI(std::vector<ResourceManagerBase*> &guards, typename C::resource_manager_type*)
+  static T* newCI(std::vector<ResourceManagerBase*> &guards, typename C::ResourceManagerType*)
   {
     T* iface_combo = new T;
     // save the new interface pointer to allow for its correct destruction

--- a/hardware_interface/include/hardware_interface/internal/resource_manager.h
+++ b/hardware_interface/include/hardware_interface/internal/resource_manager.h
@@ -69,7 +69,7 @@ template <class ResourceHandle>
 class ResourceManager : public ResourceManagerBase
 {
 public:
-  typedef ResourceManager<ResourceHandle> resource_manager_type;
+  typedef ResourceManager<ResourceHandle> ResourceManagerType;
   /** \name Non Real-Time Safe Functions
    *\{*/
 
@@ -133,8 +133,8 @@ public:
    * \param result The interface where all the handles will be registered.
    * \return Resource associated to \e name. If the resource name is not found, an exception is thrown.
    */
-  static void concatManagers(std::vector<resource_manager_type*>& managers,
-                             resource_manager_type* result)
+  static void concatManagers(std::vector<ResourceManagerType*>& managers,
+                             ResourceManagerType* result)
   {
     for (const auto& manager : managers) {
       for (const auto& handle_name : manager->getNames()) {


### PR DESCRIPTION
All other classes and typedefs follow CamelCase, so just updating this to match.

Should target `noetic-devel` once we branch, since it breaks API.