### PR TITLE
Migrate to new industrial_ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 # Travis Continuous Integration Configuration File For ROS Control Projects
 # Author: Dave Coleman
-sudo: required
-dist: trusty
 language: generic
+services:
+  - docker
 
 notifications:
   email:
@@ -23,6 +23,6 @@ env:
     - ROS_DISTRO=melodic ROS_REPO=ros-testing
 
 install:
-  - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
+  - git clone --quiet --depth 1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci -b master
 script:
-  - .ci_config/travis.sh
+  - .industrial_ci/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ notifications:
 
 env:
   global:
-    - UPSTREAM_WORKSPACE=file
-    - ROSINSTALL_FILENAME=ros_control.rosinstall
+    - UPSTREAM_WORKSPACE=ros_control.rosinstall
   matrix:
     - ROS_DISTRO=melodic ROS_REPO=ros
     - ROS_DISTRO=melodic ROS_REPO=ros-testing

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ env:
   global:
     - UPSTREAM_WORKSPACE=file
     - ROSINSTALL_FILENAME=ros_control.rosinstall
-    - ROS_PARALLEL_TEST_JOBS=-j1
   matrix:
     - ROS_DISTRO=melodic ROS_REPO=ros
     - ROS_DISTRO=melodic ROS_REPO=ros-testing


### PR DESCRIPTION
This is required for `industrial_ci`'s experimental Noetic support, and I'd also like to get it in before spending time on the codecov integration in `ros_controllers`. Plus, might as well stay up to date :)

Will duplicate over to the other repos (`ros_controllers`, `urdf_geometry_parser`, `realtime_tools`, etc) once approved.

See https://github.com/ros-industrial/industrial_ci/blob/master/doc/migration_guide.md