### PR TITLE
[hardware_interface::RobotHW] doc: update read and write, fix: group names

### DIFF
--- a/hardware_interface/include/hardware_interface/robot_hw.h
+++ b/hardware_interface/include/hardware_interface/robot_hw.h
@@ -51,9 +51,9 @@ namespace hardware_interface
  * hardware.
  *
  * The hardware interface map (\ref interfaces_) is a 1-to-1 map between
- * the names of interface types derived from \ref HardwareInterface  and
+ * the names of interface types derived from \ref HardwareInterface and
  * instances of those interface types.
- *
+ * 
  */
 class RobotHW : public InterfaceManager
 {
@@ -70,7 +70,7 @@ public:
 
   /** \brief The init function is called to initialize the RobotHW from a
    * non-realtime thread.
-   *
+   * 
    * \param root_nh A NodeHandle in the root of the caller namespace.
    *
    * \param robot_hw_nh A NodeHandle in the namespace from which the RobotHW
@@ -79,6 +79,7 @@ public:
    * \returns True if initialization was successful
    */
   virtual bool init(ros::NodeHandle& /*root_nh*/, ros::NodeHandle &/*robot_hw_nh*/) {return true;}
+
 
   /** \name Resource Management
    *\{*/
@@ -123,7 +124,9 @@ public:
 
     return in_conflict;
   }
-/** \name Hardware Interface Switching
+  /**\}*/
+
+  /** \name Hardware Interface Switching
    *\{*/
 
   /**
@@ -148,33 +151,59 @@ public:
     ERROR
   };
 
-  // Return (in realtime) the state of the last doSwitch()
+  /** \brief Return (in realtime) the state of the last doSwitch() */
   virtual SwitchState switchResult() const
   {
     return DONE;
   }
 
-  // Return (in realtime) the state of the last doSwitch() for a given controller
+  /** \brief Return (in realtime) the state of the last doSwitch() for a given controller */
   virtual SwitchState switchResult(const ControllerInfo& /*controller*/) const
   {
     return DONE;
   }
+  /**\}*/
 
-  /**
-   * Reads data from the robot HW
+  /** \name Control Loop
+   *\{*/
+
+  /** \brief Read data from the robot hardware.
+   *
+   * The read method is part of the control loop cycle (\ref read, update, \ref write) 
+   * and is used to populate the robot state from the robot's hardware resources
+   * (joints, sensors, actuators). This method should be called before 
+   * controller_manager::ControllerManager::update() and \ref write.
+   * 
+   * \note The name \ref read refers to reading state from the hardware.
+   * This complements \ref write, which refers to writing commands to the hardware.
+   *
+   * Querying WallTime inside \ref read is not realtime safe. The parameters
+   * \ref time and \ref period make it possible to inject time from a realtime source.
    *
    * \param time The current time
    * \param period The time passed since the last call to \ref read
    */
   virtual void read(const ros::Time& /*time*/, const ros::Duration& /*period*/) {}
 
-  /**
-   * Writes data to the robot HW
+  /** \brief Write commands to the robot hardware.
+   * 
+   * The write method is part of the control loop cycle (\ref read, update, \ref write) 
+   * and used to send out commands to the robot's hardware 
+   * resources (joints, actuators). This method should be called after 
+   * \ref read and controller_manager::ControllerManager::update.
+   * 
+   * \note The name \ref write refers to writing commands to the hardware.
+   * This complements \ref read, which refers to reading state from the hardware.
+   *
+   * Querying WallTime inside \ref write is not realtime safe. The parameters
+   * \ref time and \ref period make it possible to inject time from a realtime source.
    *
    * \param time The current time
    * \param period The time passed since the last call to \ref write
    */
   virtual void write(const ros::Time& /*time*/, const ros::Duration& /*period*/) {}
+
+  /**\}*/
 };
 
 typedef std::shared_ptr<RobotHW> RobotHWSharedPtr;

--- a/hardware_interface/include/hardware_interface/robot_hw.h
+++ b/hardware_interface/include/hardware_interface/robot_hw.h
@@ -70,7 +70,7 @@ public:
 
   /** \brief The init function is called to initialize the RobotHW from a
    * non-realtime thread.
-   * 
+   *
    * \param root_nh A NodeHandle in the root of the caller namespace.
    *
    * \param robot_hw_nh A NodeHandle in the namespace from which the RobotHW

--- a/hardware_interface/include/hardware_interface/robot_hw.h
+++ b/hardware_interface/include/hardware_interface/robot_hw.h
@@ -188,7 +188,7 @@ public:
   /** \brief Write commands to the robot hardware.
    * 
    * The write method is part of the control loop cycle (\ref read, update, \ref write) 
-   * and used to send out commands to the robot's hardware 
+   * and is used to send out commands to the robot's hardware 
    * resources (joints, actuators). This method should be called after 
    * \ref read and controller_manager::ControllerManager::update.
    * 

--- a/hardware_interface/include/hardware_interface/robot_hw.h
+++ b/hardware_interface/include/hardware_interface/robot_hw.h
@@ -53,7 +53,7 @@ namespace hardware_interface
  * The hardware interface map (\ref interfaces_) is a 1-to-1 map between
  * the names of interface types derived from \ref HardwareInterface and
  * instances of those interface types.
- * 
+ *
  */
 class RobotHW : public InterfaceManager
 {
@@ -79,7 +79,6 @@ public:
    * \returns True if initialization was successful
    */
   virtual bool init(ros::NodeHandle& /*root_nh*/, ros::NodeHandle &/*robot_hw_nh*/) {return true;}
-
 
   /** \name Resource Management
    *\{*/
@@ -151,13 +150,13 @@ public:
     ERROR
   };
 
-  /** \brief Return (in realtime) the state of the last doSwitch() */
+  /** \brief Return (in realtime) the state of the last doSwitch(). */
   virtual SwitchState switchResult() const
   {
     return DONE;
   }
 
-  /** \brief Return (in realtime) the state of the last doSwitch() for a given controller */
+  /** \brief Return (in realtime) the state of the last doSwitch() for a given controller. */
   virtual SwitchState switchResult(const ControllerInfo& /*controller*/) const
   {
     return DONE;
@@ -188,7 +187,7 @@ public:
   /** \brief Write commands to the robot hardware.
    * 
    * The write method is part of the control loop cycle (\ref read, update, \ref write) 
-   * and used to send out commands to the robot's hardware 
+   * and is used to send out commands to the robot's hardware 
    * resources (joints, actuators). This method should be called after 
    * \ref read and controller_manager::ControllerManager::update.
    * 


### PR DESCRIPTION
This PR is split from the large PR #433 and contains the following changes: 

- Update brief and detailes of read and write methods
- Fix doxygen group names and add new group name "Control Loop" to read and write methods.
  Removes these methods from group Hardware Interface Switching
- Remove too many details of class description in PR #433 -> new PR
- Remove too many details of `init` method in PR #433 -> new PR
- Apply suggestions from code review in #433 

It is related to [ros-controls/ros_controllers/#474](https://github.com/ros-controls/ros_controllers/pull/474).

Co-Authored-By: Matt Reynolds <mtreynolds@uwaterloo.ca>