### PR TITLE
[hardware_interface::RobotHW] doc: update read and write, fix: group …

### DIFF
--- a/hardware_interface/include/hardware_interface/robot_hw.h
+++ b/hardware_interface/include/hardware_interface/robot_hw.h
@@ -51,7 +51,7 @@ namespace hardware_interface
  * hardware.
  *
  * The hardware interface map (\ref interfaces_) is a 1-to-1 map between
- * the names of interface types derived from \ref HardwareInterface  and
+ * the names of interface types derived from \ref HardwareInterface and
  * instances of those interface types.
  *
  */
@@ -123,7 +123,9 @@ public:
 
     return in_conflict;
   }
-/** \name Hardware Interface Switching
+  /**\}*/
+
+  /** \name Hardware Interface Switching
    *\{*/
 
   /**
@@ -148,33 +150,59 @@ public:
     ERROR
   };
 
-  // Return (in realtime) the state of the last doSwitch()
+  /** \brief Return (in realtime) the state of the last doSwitch(). */
   virtual SwitchState switchResult() const
   {
     return SwitchState::DONE;
   }
 
-  // Return (in realtime) the state of the last doSwitch() for a given controller
+  /** \brief Return (in realtime) the state of the last doSwitch() for a given controller. */
   virtual SwitchState switchResult(const ControllerInfo& /*controller*/) const
   {
     return SwitchState::DONE;
   }
+  /**\}*/
 
-  /**
-   * Reads data from the robot HW
+  /** \name Control Loop
+   *\{*/
+
+  /** \brief Read data from the robot hardware.
+   *
+   * The read method is part of the control loop cycle (\ref read, update, \ref write) 
+   * and is used to populate the robot state from the robot's hardware resources
+   * (joints, sensors, actuators). This method should be called before 
+   * controller_manager::ControllerManager::update() and \ref write.
+   * 
+   * \note The name \ref read refers to reading state from the hardware.
+   * This complements \ref write, which refers to writing commands to the hardware.
+   *
+   * Querying WallTime inside \ref read is not realtime safe. The parameters
+   * \ref time and \ref period make it possible to inject time from a realtime source.
    *
    * \param time The current time
    * \param period The time passed since the last call to \ref read
    */
   virtual void read(const ros::Time& /*time*/, const ros::Duration& /*period*/) {}
 
-  /**
-   * Writes data to the robot HW
+  /** \brief Write commands to the robot hardware.
+   * 
+   * The write method is part of the control loop cycle (\ref read, update, \ref write) 
+   * and is used to send out commands to the robot's hardware 
+   * resources (joints, actuators). This method should be called after 
+   * \ref read and controller_manager::ControllerManager::update.
+   * 
+   * \note The name \ref write refers to writing commands to the hardware.
+   * This complements \ref read, which refers to reading state from the hardware.
+   *
+   * Querying WallTime inside \ref write is not realtime safe. The parameters
+   * \ref time and \ref period make it possible to inject time from a realtime source.
    *
    * \param time The current time
    * \param period The time passed since the last call to \ref write
    */
   virtual void write(const ros::Time& /*time*/, const ros::Duration& /*period*/) {}
+
+  /**\}*/
 };
 
 typedef std::shared_ptr<RobotHW> RobotHWSharedPtr;


### PR DESCRIPTION
…names (#444)

* doc: update read and write, fix: group names

* update brief and detailes of read and write methods
* fix doxygen group names
* remove too many details of class description -> new PR
* remove too many details of init method -> new PR
* apply suggestions from code review
* add doxygen group name "Control Loop" to read and write methods.
  Removes these methods from group Hardware Interface Switching

Co-Authored-By: Matt Reynolds <mtreynolds@uwaterloo.ca>

* Update hardware_interface/include/hardware_interface/robot_hw.h

add "is" from suggestion

Co-Authored-By: Matt Reynolds <mtreynolds@uwaterloo.ca>

* Add sugestions from code review to robot_hw.h

- Remove whitespaces
- Remove newline
- Add periods to briefs
- Add "is" to docstring

Co-Authored-By: Matt Reynolds <mtreynolds@uwaterloo.ca>

* remove trailing space

Co-authored-by: Matt Reynolds <mtreynolds@uwaterloo.ca>