### PR TITLE
Adding extra time counter to exit while loop so that controller manager doesn't freeze

### DIFF
--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -613,7 +613,7 @@ bool ControllerManager::switchController(const std::vector<std::string>& start_c
       return false;
     }
     std::chrono::duration<double> diff = std::chrono::system_clock::now() - start_time;
-    if (diff.count() < timeout || timeout == 0){
+    if (diff.count() < timeout){
         std::this_thread::sleep_for(std::chrono::microseconds(100));
     } else {
         ROS_DEBUG("Time Out while Switching the controllers. Exiting cleanly");

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -604,17 +604,29 @@ bool ControllerManager::switchController(const std::vector<std::string>& start_c
 
   // wait until switch is finished
   ROS_DEBUG("Request atomic controller switch from realtime loop");
+  auto start_time = std::chrono::system_clock::now();
+  bool timed_out = false;
   while (ros::ok() && switch_params_.do_switch)
   {
     if (!ros::ok())
     {
       return false;
     }
-    std::this_thread::sleep_for(std::chrono::microseconds(100));
+    std::chrono::duration<double> diff = std::chrono::system_clock::now() - start_time;
+    if (diff.count() < timeout || timeout == 0){
+        std::this_thread::sleep_for(std::chrono::microseconds(100));
+    } else{
+        ROS_DEBUG("Time Out while Switching the controllers. Exiting cleanly");
+        timed_out = true;
+        break;
+    }
+
   }
   start_request_.clear();
   stop_request_.clear();
-
+  if(timed_out){
+      return false;
+  }
   ROS_DEBUG("Successfully switched controllers");
   return true;
 }

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -616,7 +616,7 @@ bool ControllerManager::switchController(const std::vector<std::string>& start_c
     if (diff.count() < timeout+1.0 || timeout == 0){
         std::this_thread::sleep_for(std::chrono::microseconds(100));
     } else {
-        ROS_DEBUG("Time Out while Switching the controllers. Exiting cleanly");
+        ROS_DEBUG("Timed out while switching controllers. Exiting...");
         timed_out = true;
         break;
     }
@@ -624,7 +624,7 @@ bool ControllerManager::switchController(const std::vector<std::string>& start_c
   start_request_.clear();
   stop_request_.clear();
   if(timed_out){
-      ROS_DEBUG("Exited while loop forcibly without ROS handling timeout");
+      ROS_DEBUG("Exited wait until switch is finished loop using non-ROS-time timeout");
       return false;
   }
   ROS_DEBUG("Successfully switched controllers");

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -612,20 +612,21 @@ bool ControllerManager::switchController(const std::vector<std::string>& start_c
     {
       return false;
     }
-    std::chrono::duration<double> diff = std::chrono::system_clock::now() - start_time;
-    if (diff.count() < timeout){
-        std::this_thread::sleep_for(std::chrono::microseconds(100));
-    } else {
-        ROS_DEBUG("Time Out while Switching the controllers. Exiting cleanly");
-        timed_out = true;
-        break;
-    }
+    std::this_thread::sleep_for(std::chrono::microseconds(100));
+//    std::chrono::duration<double> diff = std::chrono::system_clock::now() - start_time;
+//    if (diff.count() < timeout || timeout == 0){
+//        std::this_thread::sleep_for(std::chrono::microseconds(100));
+//    } else {
+//        ROS_DEBUG("Time Out while Switching the controllers. Exiting cleanly");
+//        timed_out = true;
+//        break;
+//    }
   }
   start_request_.clear();
   stop_request_.clear();
-  if(timed_out){
-      return false;
-  }
+//  if(timed_out){
+//      return false;
+//  }
   ROS_DEBUG("Successfully switched controllers");
   return true;
 }

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -623,9 +623,9 @@ bool ControllerManager::switchController(const std::vector<std::string>& start_c
   }
   start_request_.clear();
   stop_request_.clear();
-  if(timed_out){
-      return false;
-  }
+//  if(timed_out){
+//      return false;
+//  }
   ROS_DEBUG("Successfully switched controllers");
   return true;
 }

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -613,7 +613,7 @@ bool ControllerManager::switchController(const std::vector<std::string>& start_c
       return false;
     }
     std::chrono::duration<double> diff = std::chrono::system_clock::now() - start_time;
-    if (diff.count() < timeout+2 || timeout == 0){
+    if (diff.count() < timeout+2.0 || timeout == 0){
         std::this_thread::sleep_for(std::chrono::microseconds(100));
     } else {
         ROS_DEBUG("Time Out while Switching the controllers. Exiting cleanly");

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -623,9 +623,9 @@ bool ControllerManager::switchController(const std::vector<std::string>& start_c
   }
   start_request_.clear();
   stop_request_.clear();
-//  if(timed_out){
-//      return false;
-//  }
+  if(timed_out){
+      return false;
+  }
   ROS_DEBUG("Successfully switched controllers");
   return true;
 }

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -624,6 +624,7 @@ bool ControllerManager::switchController(const std::vector<std::string>& start_c
   start_request_.clear();
   stop_request_.clear();
   if(timed_out){
+      ROS_DEBUG("Exited while loop forcibly without ROS handling timeout");
       return false;
   }
   ROS_DEBUG("Successfully switched controllers");

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -613,7 +613,7 @@ bool ControllerManager::switchController(const std::vector<std::string>& start_c
       return false;
     }
     std::chrono::duration<double> diff = std::chrono::system_clock::now() - start_time;
-    if (diff.count() < timeout || timeout == 0){
+    if (diff.count() < timeout+2 || timeout == 0){
         std::this_thread::sleep_for(std::chrono::microseconds(100));
     } else {
         ROS_DEBUG("Time Out while Switching the controllers. Exiting cleanly");

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -615,12 +615,11 @@ bool ControllerManager::switchController(const std::vector<std::string>& start_c
     std::chrono::duration<double> diff = std::chrono::system_clock::now() - start_time;
     if (diff.count() < timeout || timeout == 0){
         std::this_thread::sleep_for(std::chrono::microseconds(100));
-    } else{
+    } else {
         ROS_DEBUG("Time Out while Switching the controllers. Exiting cleanly");
         timed_out = true;
         break;
     }
-
   }
   start_request_.clear();
   stop_request_.clear();

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -612,21 +612,20 @@ bool ControllerManager::switchController(const std::vector<std::string>& start_c
     {
       return false;
     }
-    std::this_thread::sleep_for(std::chrono::microseconds(100));
-//    std::chrono::duration<double> diff = std::chrono::system_clock::now() - start_time;
-//    if (diff.count() < timeout || timeout == 0){
-//        std::this_thread::sleep_for(std::chrono::microseconds(100));
-//    } else {
-//        ROS_DEBUG("Time Out while Switching the controllers. Exiting cleanly");
-//        timed_out = true;
-//        break;
-//    }
+    std::chrono::duration<double> diff = std::chrono::system_clock::now() - start_time;
+    if (diff.count() < timeout || timeout == 0){
+        std::this_thread::sleep_for(std::chrono::microseconds(100));
+    } else {
+        ROS_DEBUG("Time Out while Switching the controllers. Exiting cleanly");
+        timed_out = true;
+        break;
+    }
   }
   start_request_.clear();
   stop_request_.clear();
-//  if(timed_out){
-//      return false;
-//  }
+  if(timed_out){
+      return false;
+  }
   ROS_DEBUG("Successfully switched controllers");
   return true;
 }

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -613,7 +613,7 @@ bool ControllerManager::switchController(const std::vector<std::string>& start_c
       return false;
     }
     std::chrono::duration<double> diff = std::chrono::system_clock::now() - start_time;
-    if (diff.count() < timeout+2.0 || timeout == 0){
+    if (diff.count() < timeout+1.0 || timeout == 0){
         std::this_thread::sleep_for(std::chrono::microseconds(100));
     } else {
         ROS_DEBUG("Time Out while Switching the controllers. Exiting cleanly");


### PR DESCRIPTION
This PR addresses issue #443. When I switch the controllers sometimes the controller manager is stuck [here](https://github.com/krishnachaitanya9/ros_control/blob/melodic-devel/controller_manager/src/controller_manager.cpp#L609) at this unending while loop. The problem I am facing is similar to #265. The only way out of this loop is either when 
- switch_params_.do_switch is False 
- ROS core exits 
- when there is a timeout. 

In the first case, switch_params_.do_switch becomes False if switching is successful which is the ideal case

Exiting ROS Core means either simulation is shutdown or ROS core exited with non zero exit code

If the timeout is specified after the timeout the switching is stopped and the response code returned back is False. The timeout is calculated using the ROS time. When I ran my simulation using Gazebo the ROS time freezes hence the timeout is never possible. Due to this issue,  the code is stuck at the aforementioned while loop and never comes out. This gives rise to Denial of Service. The simulation seems to be stuck. No further switching of controllers happen. Even the controller manager does not list the current controllers which are stopped or running because the controller manager is in denial of service and it's lock is not released. The only way out of this is to restart the entire simulation.  

Hence I have added a time check in the while loop which uses system time contrary to ROS time and if something like this happens at least the code can safely exit rather than go into denial of service. The code edits suggested in this PR will give every opportunity for ROS time to function but it will also monitor the timeout from a system clock perspective and after timeout+1 seconds if the while loop didn't break, it will forcibly break out of the while loop. Finally when the while loop is exited by forcibly breaking out "False" is returned signaling the end-user that controller switching wasn't successful.