### PR TITLE
Add JointDynamicStateInterface.

### DIFF
--- a/hardware_interface/CMakeLists.txt
+++ b/hardware_interface/CMakeLists.txt
@@ -40,6 +40,9 @@ if(CATKIN_ENABLE_TESTING)
   catkin_add_gtest(joint_state_interface_test               test/joint_state_interface_test.cpp)
   target_link_libraries(joint_state_interface_test          ${catkin_LIBRARIES})
 
+  catkin_add_gtest(joint_dynamic_state_interface_test       test/joint_dynamic_state_interface_test.cpp)
+  target_link_libraries(joint_dynamic_state_interface_test  ${catkin_LIBRARIES})
+
   catkin_add_gtest(joint_command_interface_test             test/joint_command_interface_test.cpp)
   target_link_libraries(joint_command_interface_test        ${catkin_LIBRARIES})
 

--- a/hardware_interface/include/hardware_interface/joint_dynamic_state_interface.h
+++ b/hardware_interface/include/hardware_interface/joint_dynamic_state_interface.h
@@ -1,0 +1,118 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2020, CNRS
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of hiDOF, Inc. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+/// \author Olivier Stasse
+/// \author Wim Meeussen
+
+#pragma once
+
+
+#include <hardware_interface/internal/hardware_resource_manager.h>
+#include <cassert>
+#include <string>
+
+namespace hardware_interface
+{
+
+/**
+ * \brief A handle used to read the state of a single joint.
+ * This class is generic and handle a std::vector<double>.
+ */
+class JointDynamicStateHandle
+{
+public:
+  JointDynamicStateHandle() = delete;
+
+  /**
+   * \param name The name of the joint
+   * \param interface_name The interface name, preferably this should follow
+   * the standard sets by ros_control for interoperability among controllers.
+   * \param state_vector The vector of informations.
+   */
+  JointDynamicStateHandle(const std::string& name,
+                   const std::string& interface_name,
+                   const std::vector<double> * state_vector)
+    : name_(name),
+      interface_name_(interface_name),
+      state_vector_(state_vector)
+  {
+    if (!state_vector)
+    {      throw HardwareInterfaceException
+          ("Cannot create handle '" +
+           name + " for interface " +
+           interface_name +
+           "'. state_vector is null.");
+    }
+  }
+
+  JointDynamicStateHandle
+  (const JointDynamicStateHandle &joint_dyn_handle)
+      :name_(joint_dyn_handle.getName()),
+       interface_name_(joint_dyn_handle.getInterfaceName()),
+       state_vector_(joint_dyn_handle.getStateVectorPtr())
+  {
+  }
+      
+  JointDynamicStateHandle & operator=
+  (const JointDynamicStateHandle &joint_dyn_handle)
+  {
+    name_ =joint_dyn_handle.getName();
+    interface_name_=joint_dyn_handle.getInterfaceName();
+    state_vector_=joint_dyn_handle.getStateVectorPtr();
+    return *this;
+  }
+  
+  std::string getName() const {return name_;}
+  std::string getInterfaceName() const {return interface_name_;}
+        
+  const std::vector<double> &
+  getStateVector() const
+  {
+    assert(state_vector_);
+    return *state_vector_;
+  }
+
+  const std::vector<double> *
+  getStateVectorPtr() const
+  { return state_vector_; }
+  
+private:
+  std::string name_;
+  std::string interface_name_;
+  const std::vector<double> * state_vector_;
+};
+
+/** \brief Hardware interface to support reading the state of an array of joints
+ *
+ * This \ref HardwareInterface supports reading the state of an array of named
+ * joints, each of which has a std::vector.
+ *
+ */
+class JointDynamicStateInterface :
+      public HardwareResourceManager<JointDynamicStateHandle> {};
+
+}

--- a/hardware_interface/test/joint_dynamic_state_interface_test.cpp
+++ b/hardware_interface/test/joint_dynamic_state_interface_test.cpp
@@ -1,0 +1,109 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2020, CNRS
+// Copyright (C) 2013, PAL Robotics S.L.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of hiDOF, Inc. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+/// \author Olivier Stasse
+/// \author Adolfo Rodriguez Tsouroukdissian
+
+#include <string>
+#include <gtest/gtest.h>
+#include <ros/console.h>
+#include <hardware_interface/joint_dynamic_state_interface.h>
+
+using std::string;
+using namespace hardware_interface;
+
+TEST(JointDynamicStateHandleTest, HandleConstruction)
+{
+  string name = "name1";
+  string interface_name="pos_vel_eff";
+  std::vector<double> state_pve;
+  state_pve.resize(3);
+  EXPECT_NO_THROW(JointDynamicStateHandle tmp(name, interface_name,&state_pve));
+  EXPECT_THROW(JointDynamicStateHandle(name, interface_name, nullptr),
+               HardwareInterfaceException);
+
+  // Print error messages
+  // Requires manual output inspection,
+  // but exception message should be descriptive
+  try {JointDynamicStateHandle(name, interface_name, nullptr);}
+  catch(const HardwareInterfaceException& e) {ROS_ERROR_STREAM(e.what());}
+
+
+}
+
+
+class JointDynamicStateInterfaceTest : public ::testing::Test
+{
+protected:
+  std::vector<double> pve1 = {1.0, 2.0, 3.0,4.0};
+  std::vector<double> pve2 = {5000.0, 6.0, 70.0};
+  string name1 = {"name_1"};
+  string name2 = {"name_2"};
+  string interface_name1 = {"pos_vel_eff_stiffness"};
+  string interface_name2 = {"pids"};
+
+  JointDynamicStateHandle h1 = {name1, interface_name1, &pve1};
+  JointDynamicStateHandle h2 = {name2, interface_name2, &pve2};
+};
+
+TEST_F(JointDynamicStateInterfaceTest, ExcerciseApi)
+{
+  JointDynamicStateInterface iface;
+  iface.registerHandle(h1);
+  iface.registerHandle(h2);
+
+  // Get handles
+  EXPECT_NO_THROW(iface.getHandle(name1));
+  EXPECT_NO_THROW(iface.getHandle(name2));
+
+  JointDynamicStateHandle h1_tmp = iface.getHandle(name1);
+  EXPECT_EQ(name1, h1_tmp.getName());
+  EXPECT_EQ(interface_name1, h1_tmp.getInterfaceName());  
+  EXPECT_EQ(pve1, h1_tmp.getStateVector());
+
+  JointDynamicStateHandle h2_tmp = iface.getHandle(name2);
+  EXPECT_EQ(name2, h2_tmp.getName());
+  EXPECT_EQ(interface_name2, h2_tmp.getInterfaceName());    
+  EXPECT_EQ(pve2, h2_tmp.getStateVector());
+
+  // This interface does not claim resources
+  EXPECT_TRUE(iface.getClaims().empty());
+
+  // Print error message
+  // Requires manual output inspection,
+  // but exception message should contain
+  // the interface name (not its base class)
+  try {iface.getHandle("unknown_name");}
+  catch(const HardwareInterfaceException& e) {ROS_ERROR_STREAM(e.what());}
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This is a request for comment.

This PR is one building block to exploit DynamicJointState (https://github.com/ros-controls/ros2_control/issues/89).
The practical issues to be solved are the followings:
 * Sending PID values to the power electronics working at a higher frequency (see  https://en.wikipedia.org/wiki/Differential_dynamic_programming for a quick introduction, feedback gains)
 * New actuators often have additional motors, sensors and it is difficult to use ros_control without breaking the API for one joint.

It is following as much as possible JointStateInterface.
My C++ is rusty but I guess it would be possible to filter interface_name using Concept together with Template.


