### PR TITLE
Fixes part 2 of issue#448 [Noetic] Rework and re-enable spawning and switching CLI tests

### DIFF
--- a/controller_manager_tests/CMakeLists.txt
+++ b/controller_manager_tests/CMakeLists.txt
@@ -52,6 +52,8 @@ if(CATKIN_ENABLE_TESTING)
   add_rostest(test/cm_msgs_utils_rostest.test)
 
   add_rostest(test/controller_manager_scripts.test DEPENDENCIES dummy_app)
+
+  add_rostest(test/controller_manager_interface_test.test DEPENDENCIES dummy_app)
 endif()
 
 

--- a/controller_manager_tests/test/controller_manager_interface_test.test
+++ b/controller_manager_tests/test/controller_manager_interface_test.test
@@ -21,5 +21,5 @@
   </rosparam>
 
   <node pkg="controller_manager_tests" type="dummy_app" name="dummy_app"/>
-  <test test-name="controller_manager_scripts_test" pkg="controller_manager_tests" type="controller_manager_scripts.py"/>
+  <test test-name="controller_manager_interface_test" pkg="controller_manager_tests" type="controller_manager_interface_test.py"/>
 </launch>

--- a/controller_manager_tests/test/controller_manager_scripts.py
+++ b/controller_manager_tests/test/controller_manager_scripts.py
@@ -135,24 +135,24 @@ class TestUtils(unittest.TestCase):
              '  group3\n      my_controller1\n      my_controller2\n').encode("utf-8"))
 
         # spawn
-        # self.assertEqual(
-        #     run_cg('spawn group1'),
-        #     ('Loaded \'my_controller1\'\n' +
-        #      'Loaded \'my_controller3\'\n' +
-        #      'Started [\'my_controller1\'] successfully\n' +
-        #      'Started [\'my_controller3\'] successfully\n').encode("utf-8"))
+        self.assertEqual(
+             run_cg('spawn group1'),
+             ('Loaded \'my_controller1\'\n' +
+              'Loaded \'my_controller3\'\n' +
+              'Started [\'my_controller1\'] successfully\n' +
+              'Started [\'my_controller3\'] successfully\n').encode("utf-8"))
 
         # switch
-        # self.assertEqual(
-        #     run_cg('switch group2'),
-        #     ('Loaded \'my_controller2\'\n' +
-        #      'Started [\'my_controller2\'] successfully\n' +
-        #      'Stopped [\'my_controller1\'] successfully\n').encode("utf-8"))
+        self.assertEqual(
+             run_cg('switch group2'),
+             ('Loaded \'my_controller2\'\n' +
+              'Started [\'my_controller2\'] successfully\n' +
+              'Stopped [\'my_controller1\'] successfully\n').encode("utf-8"))
 
         # switch to faulty group because my_controller1 conflicts with my_controller2
-        # self.assertEqual(
-        #     run_cg('switch group3'),
-        #     b'Error when starting [\'my_controller1\'] and stopping [\'my_controller3\']\n')
+        self.assertEqual(
+             run_cg('switch group3'),
+             b'Error when starting [\'my_controller1\'] and stopping [\'my_controller3\']\n')
 
 
 if __name__ == '__main__':

--- a/controller_manager_tests/test/controller_manager_scripts.py
+++ b/controller_manager_tests/test/controller_manager_scripts.py
@@ -135,12 +135,17 @@ class TestUtils(unittest.TestCase):
              '  group3\n      my_controller1\n      my_controller2\n').encode("utf-8"))
 
         # spawn
-        self.assertEqual(
-             run_cg('spawn group1'),
-             ('Loaded \'my_controller1\'\n' +
+        result_spawn_group1 = run_cg('spawn group1')
+        first_sgp1_solution = ('Loaded \'my_controller1\'\n' +
               'Loaded \'my_controller3\'\n' +
               'Started [\'my_controller1\'] successfully\n' +
-              'Started [\'my_controller3\'] successfully\n').encode("utf-8"))
+              'Started [\'my_controller3\'] successfully\n').encode("utf-8")
+        second_sgp1_solution = ('Loaded \'my_controller3\'\n' +
+              'Loaded \'my_controller1\'\n' +
+              'Started [\'my_controller3\'] successfully\n' +
+              'Started [\'my_controller1\'] successfully\n').encode("utf-8")
+        self.assertTrue( (result_spawn_group1==first_sgp1_solution) or
+                         ( result_spawn_group1 == second_sgp1_solution))
 
         # switch
         self.assertEqual(


### PR DESCRIPTION
The result is fine if the two tests controller_manager_interface_test oller_manager_scripts. (in test_controller_manager_scripts.test) are not done together.
This PR split the test controller_manager_scripts.test, and adds controller_manager_interface_test.test
The code is fine with python3.