### PR TITLE
Remove ParseStatus enum

### DIFF
--- a/transmission_interface/include/transmission_interface/transmission_loader.h
+++ b/transmission_interface/include/transmission_interface/transmission_loader.h
@@ -66,12 +66,6 @@ public:
   virtual TransmissionSharedPtr load(const TransmissionInfo& transmission_info) = 0;
 
 protected:
-  enum class ParseStatus
-  {
-    SUCCESS,
-    NO_DATA,
-    BAD_TYPE
-  };
 
   static bool checkActuatorDimension(const TransmissionInfo& transmission_info, const unsigned int expected_dim)
   {
@@ -108,31 +102,31 @@ protected:
     return element;
   }
 
-  static ParseStatus getActuatorReduction(const TiXmlElement& parent_el,
+  static bool getActuatorReduction(const TiXmlElement& parent_el,
                                           const std::string&  actuator_name,
                                           const std::string&  transmission_name,
                                           bool                required,
                                           double&             reduction);
 
-  static ParseStatus getJointReduction(const TiXmlElement& parent_el,
+  static bool getJointReduction(const TiXmlElement& parent_el,
                                        const std::string&  joint_name,
                                        const std::string&  transmission_name,
                                        bool                required,
                                        double&             reduction);
 
-  static ParseStatus getJointOffset(const TiXmlElement& parent_el,
+  static bool getJointOffset(const TiXmlElement& parent_el,
                                     const std::string&  joint_name,
                                     const std::string&  transmission_name,
                                     bool                required,
                                     double&             offset);
 
-  static ParseStatus getActuatorRole(const TiXmlElement& parent_el,
+  static bool getActuatorRole(const TiXmlElement& parent_el,
                                      const std::string&  actuator_name,
                                      const std::string&  transmission_name,
                                      bool                required,
                                      std::string&        role);
 
-  static ParseStatus getJointRole(const TiXmlElement& parent_el,
+  static bool getJointRole(const TiXmlElement& parent_el,
                                   const std::string&  joint_name,
                                   const std::string&  transmission_name,
                                   bool                required,

--- a/transmission_interface/src/differential_transmission_loader.cpp
+++ b/transmission_interface/src/differential_transmission_loader.cpp
@@ -99,12 +99,12 @@ bool DifferentialTransmissionLoader::getActuatorConfig(const TransmissionInfo& t
 
     // Populate role string
     std::string& act_role = act_roles[i];
-    const ParseStatus act_role_status = getActuatorRole(act_elements[i],
-                                                        act_names[i],
-                                                        transmission_info.name_,
-                                                        true, // Required
-                                                        act_role);
-    if (act_role_status != ParseStatus::SUCCESS) {return false;}
+    if(!getActuatorRole(act_elements[i], 
+                      act_names[i], 
+                      transmission_info.name_, 
+                      true, // Required
+                      act_role))
+    {return false;}
 
     // Validate role string
     if (ACTUATOR1_ROLE != act_role && ACTUATOR2_ROLE != act_role)
@@ -144,12 +144,12 @@ bool DifferentialTransmissionLoader::getActuatorConfig(const TransmissionInfo& t
   for (unsigned int i = 0; i < 2; ++i)
   {
     const unsigned int id = id_map[i];
-    const ParseStatus reduction_status = getActuatorReduction(act_elements[id],
-                                                              act_names[id],
-                                                              transmission_info.name_,
-                                                              true, // Required
-                                                              actuator_reduction[i]);
-    if (reduction_status != ParseStatus::SUCCESS) {return false;}
+    if(!getActuatorReduction(act_elements[id], 
+                             act_names[id], 
+                             transmission_info.name_, 
+                             true, // Required 
+                             actuator_reduction[i]))
+    {return false;}
   }
 
   return true;
@@ -177,12 +177,12 @@ bool DifferentialTransmissionLoader::getJointConfig(const TransmissionInfo& tran
 
     // Populate role string
     std::string& jnt_role = jnt_roles[i];
-    const ParseStatus jnt_role_status = getJointRole(jnt_elements[i],
-                                                     jnt_names[i],
-                                                     transmission_info.name_,
-                                                     true, // Required
-                                                     jnt_role);
-    if (jnt_role_status != ParseStatus::SUCCESS) {return false;}
+    if(!getJointRole(jnt_elements[i],
+                     jnt_names[i],
+                     transmission_info.name_,
+                     true, // Required
+                     jnt_role))
+      {return false;}
 
     // Validate role string
     if (JOINT1_ROLE != jnt_role && JOINT2_ROLE != jnt_role)
@@ -226,21 +226,21 @@ bool DifferentialTransmissionLoader::getJointConfig(const TransmissionInfo& tran
 
     // Parse optional mechanical reductions. Even though it's optional --and to avoid surprises-- we fail if the element
     // is specified but is of the wrong type
-    const ParseStatus reduction_status = getJointReduction(jnt_elements[id],
-                                                           jnt_names[id],
-                                                           transmission_info.name_,
-                                                           false, // Optional
-                                                           joint_reduction[i]);
-    if (reduction_status == ParseStatus::BAD_TYPE) {return false;}
+    if(!getJointReduction(jnt_elements[id],
+                          jnt_names[id],
+                          transmission_info.name_,
+                          false, // Optional
+                          joint_reduction[i]))
+    {return false;}
 
     // Parse optional joint offset. Even though it's optional --and to avoid surprises-- we fail if the element is
     // specified but is of the wrong type
-    const ParseStatus offset_status = getJointOffset(jnt_elements[id],
-                                                     jnt_names[id],
-                                                     transmission_info.name_,
-                                                     false, // Optional
-                                                     joint_offset[i]);
-    if (offset_status == ParseStatus::BAD_TYPE) {return false;}
+    if(!getJointOffset(jnt_elements[id],
+                       jnt_names[id],
+                       transmission_info.name_,
+                       false, // Optional
+                       joint_offset[i]))
+      {return false;}
   }
 
   // Parse if transmision has to be ignored for absolute encoders

--- a/transmission_interface/src/four_bar_linkage_transmission_loader.cpp
+++ b/transmission_interface/src/four_bar_linkage_transmission_loader.cpp
@@ -96,12 +96,12 @@ bool FourBarLinkageTransmissionLoader::getActuatorConfig(const TransmissionInfo&
 
     // Populate role string
     std::string& act_role = act_roles[i];
-    const ParseStatus act_role_status = getActuatorRole(act_elements[i],
-                                                        act_names[i],
-                                                        transmission_info.name_,
-                                                        true, // Required
-                                                        act_role);
-    if (act_role_status != ParseStatus::SUCCESS) {return false;}
+    if(!getActuatorRole(act_elements[i],
+                        act_names[i],
+                        transmission_info.name_,
+                        true, // Required
+                        act_role))
+    {return false;}
 
     // Validate role string
     if (ACTUATOR1_ROLE != act_role && ACTUATOR2_ROLE != act_role)
@@ -141,12 +141,12 @@ bool FourBarLinkageTransmissionLoader::getActuatorConfig(const TransmissionInfo&
   for (unsigned int i = 0; i < 2; ++i)
   {
     const unsigned int id = id_map[i];
-    const ParseStatus reduction_status = getActuatorReduction(act_elements[id],
-                                                              act_names[id],
-                                                              transmission_info.name_,
-                                                              true, // Required
-                                                              actuator_reduction[i]);
-    if (reduction_status != ParseStatus::SUCCESS) {return false;}
+    if(!getActuatorReduction(act_elements[id],
+                             act_names[id],
+                             transmission_info.name_,
+                             true, // Required
+                             actuator_reduction[i]))
+    {return false;}
   }
 
   return true;
@@ -173,12 +173,12 @@ bool FourBarLinkageTransmissionLoader::getJointConfig(const TransmissionInfo& tr
 
     // Populate role string
     std::string& jnt_role = jnt_roles[i];
-    const ParseStatus jnt_role_status = getJointRole(jnt_elements[i],
-                                                     jnt_names[i],
-                                                     transmission_info.name_,
-                                                     true, // Required
-                                                     jnt_role);
-    if (jnt_role_status != ParseStatus::SUCCESS) {return false;}
+    if(!getJointRole(jnt_elements[i],
+                     jnt_names[i],
+                     transmission_info.name_,
+                     true, // Required
+                     jnt_role))
+    {return false;}
 
     // Validate role string
     if (JOINT1_ROLE != jnt_role && JOINT2_ROLE != jnt_role)
@@ -222,21 +222,21 @@ bool FourBarLinkageTransmissionLoader::getJointConfig(const TransmissionInfo& tr
 
     // Parse optional mechanical reductions. Even though it's optional --and to avoid surprises-- we fail if the element
     // is specified but is of the wrong type
-    const ParseStatus reduction_status = getJointReduction(jnt_elements[id],
-                                                           jnt_names[id],
-                                                           transmission_info.name_,
-                                                           false, // Optional
-                                                           joint_reduction[i]);
-    if (reduction_status == ParseStatus::BAD_TYPE) {return false;}
+    if(!getJointReduction(jnt_elements[id],
+                          jnt_names[id],
+                          transmission_info.name_,
+                          false, // Optional
+                          joint_reduction[i]))
+      {return false;}
 
     // Parse optional joint offset. Even though it's optional --and to avoid surprises-- we fail if the element is
     // specified but is of the wrong type
-    const ParseStatus offset_status = getJointOffset(jnt_elements[id],
-                                                     jnt_names[id],
-                                                     transmission_info.name_,
-                                                     false, // Optional
-                                                     joint_offset[i]);
-    if (offset_status == ParseStatus::BAD_TYPE) {return false;}
+    if(!getJointOffset(jnt_elements[id],
+                       jnt_names[id],
+                       transmission_info.name_,
+                       false, // Optional
+                       joint_offset[i]))
+      {return false;}
   }
 
   return true;

--- a/transmission_interface/src/simple_transmission_loader.cpp
+++ b/transmission_interface/src/simple_transmission_loader.cpp
@@ -51,22 +51,22 @@ TransmissionSharedPtr SimpleTransmissionLoader::load(const TransmissionInfo& tra
 
   // Parse required mechanical reduction
   double reduction = 0.0;
-  const ParseStatus reduction_status = getActuatorReduction(actuator_el,
-                                                            transmission_info.actuators_.front().name_,
-                                                            transmission_info.name_,
-                                                            true, // Required
-                                                            reduction);
-  if (reduction_status != ParseStatus::SUCCESS) {return TransmissionSharedPtr();}
+  if(!getActuatorReduction(actuator_el,
+                           transmission_info.actuators_.front().name_,
+                           transmission_info.name_,
+                           true, // Required
+                           reduction))
+    {return TransmissionSharedPtr();}
 
   // Parse optional joint offset. Even though it's optional --and to avoid surprises-- we fail if the element is
   // specified but is of the wrong type
   double joint_offset = 0.0;
-  const ParseStatus joint_offset_status = getJointOffset(joint_el,
-                                                         transmission_info.joints_.front().name_,
-                                                         transmission_info.name_,
-                                                         false, // Optional
-                                                         joint_offset);
-  if (joint_offset_status == ParseStatus::BAD_TYPE) {return TransmissionSharedPtr();}
+  if(!getJointOffset(joint_el,
+                 transmission_info.joints_.front().name_,
+                 transmission_info.name_,
+                 false, // Optional
+                 joint_offset))
+    {return TransmissionSharedPtr();}
 
   // Transmission instance
   try

--- a/transmission_interface/src/transmission_loader.cpp
+++ b/transmission_interface/src/transmission_loader.cpp
@@ -32,7 +32,7 @@
 namespace transmission_interface
 {
 
-TransmissionLoader::ParseStatus
+bool
 TransmissionLoader::getActuatorReduction(const TiXmlElement& parent_el,
                                          const std::string&  actuator_name,
                                          const std::string&  transmission_name,
@@ -47,13 +47,14 @@ TransmissionLoader::getActuatorReduction(const TiXmlElement& parent_el,
     {
       ROS_ERROR_STREAM_NAMED("parser", "Actuator '" << actuator_name << "' of transmission '" << transmission_name <<
                              "' does not specify the required <mechanicalReduction> element.");
+      return false;
     }
     else
     {
       ROS_DEBUG_STREAM_NAMED("parser", "Actuator '" << actuator_name << "' of transmission '" << transmission_name <<
                              "' does not specify the optional <mechanicalReduction> element.");
+      return true;
     }
-    return ParseStatus::NO_DATA;
   }
 
   // Cast to number
@@ -62,12 +63,12 @@ TransmissionLoader::getActuatorReduction(const TiXmlElement& parent_el,
   {
     ROS_ERROR_STREAM_NAMED("parser", "Actuator '" << actuator_name << "' of transmission '" << transmission_name <<
                            "' specifies the <mechanicalReduction> element, but is not a number.");
-    return ParseStatus::BAD_TYPE;
+    return false;
   }
-  return ParseStatus::SUCCESS;
+  return true;
 }
 
-TransmissionLoader::ParseStatus
+bool
 TransmissionLoader::getJointReduction(const TiXmlElement& parent_el,
                                       const std::string&  joint_name,
                                       const std::string&  transmission_name,
@@ -82,13 +83,14 @@ TransmissionLoader::getJointReduction(const TiXmlElement& parent_el,
     {
       ROS_ERROR_STREAM_NAMED("parser", "Joint '" << joint_name << "' of transmission '" << transmission_name <<
                              "' does not specify the required <mechanicalReduction> element.");
+      return false;
     }
     else
     {
       ROS_DEBUG_STREAM_NAMED("parser", "Joint '" << joint_name << "' of transmission '" << transmission_name <<
                              "' does not specify the optional <mechanicalReduction> element.");
+      return true;
     }
-    return ParseStatus::NO_DATA;
   }
 
   // Cast to number
@@ -97,12 +99,12 @@ TransmissionLoader::getJointReduction(const TiXmlElement& parent_el,
   {
     ROS_ERROR_STREAM_NAMED("parser", "Joint '" << joint_name << "' of transmission '" << transmission_name <<
                            "' specifies the <mechanicalReduction> element, but is not a number.");
-    return ParseStatus::BAD_TYPE;
+    return false;
   }
-  return ParseStatus::SUCCESS;
+  return true;
 }
 
-TransmissionLoader::ParseStatus
+bool
 TransmissionLoader::getJointOffset(const TiXmlElement& parent_el,
                                    const std::string&  joint_name,
                                    const std::string&  transmission_name,
@@ -117,13 +119,14 @@ TransmissionLoader::getJointOffset(const TiXmlElement& parent_el,
     {
       ROS_ERROR_STREAM_NAMED("parser", "Joint '" << joint_name << "' of transmission '" << transmission_name <<
                              "' does not specify the required <offset> element.");
+      return false;
     }
     else
     {
       ROS_DEBUG_STREAM_NAMED("parser", "Joint '" << joint_name << "' of transmission '" << transmission_name <<
                              "' does not specify the optional <offset> element.");
+      return true;
     }
-    return ParseStatus::NO_DATA;
   }
 
   // Cast to number
@@ -132,12 +135,12 @@ TransmissionLoader::getJointOffset(const TiXmlElement& parent_el,
   {
     ROS_ERROR_STREAM_NAMED("parser", "Joint '" << joint_name << "' of transmission '" << transmission_name <<
                            "' specifies the <offset> element, but is not a number.");
-    return ParseStatus::BAD_TYPE;
+    return false;
   }
-  return ParseStatus::SUCCESS;
+  return true;
 }
 
-TransmissionLoader::ParseStatus
+bool
 TransmissionLoader::getActuatorRole(const TiXmlElement& parent_el,
                                     const std::string&  actuator_name,
                                     const std::string&  transmission_name,
@@ -152,13 +155,14 @@ TransmissionLoader::getActuatorRole(const TiXmlElement& parent_el,
     {
       ROS_ERROR_STREAM_NAMED("parser", "Actuator '" << actuator_name << "' of transmission '" << transmission_name <<
                              "' does not specify the required <role> element.");
+      return false;
     }
     else
     {
       ROS_DEBUG_STREAM_NAMED("parser", "Actuator '" << actuator_name << "' of transmission '" << transmission_name <<
                              "' does not specify the optional <offset> element.");
+      return true;
     }
-    return ParseStatus::NO_DATA;
   }
 
   // Cast to number
@@ -168,20 +172,21 @@ TransmissionLoader::getActuatorRole(const TiXmlElement& parent_el,
     {
       ROS_ERROR_STREAM_NAMED("parser", "Actuator '" << actuator_name << "' of transmission '" << transmission_name <<
                              "' specifies an empty <role> element.");
+      return false;
     }
     else
     {
       ROS_DEBUG_STREAM_NAMED("parser", "Actuator '" << actuator_name << "' of transmission '" << transmission_name <<
                              "' specifies an empty <role> element.");
+      return true;
     }
-    return ParseStatus::NO_DATA;
   }
   role = role_el->GetText();
 
-  return ParseStatus::SUCCESS;
+  return true;
 }
 
-TransmissionLoader::ParseStatus
+bool
 TransmissionLoader::getJointRole(const TiXmlElement& parent_el,
                                  const std::string&  joint_name,
                                  const std::string&  transmission_name,
@@ -196,13 +201,14 @@ TransmissionLoader::getJointRole(const TiXmlElement& parent_el,
     {
       ROS_ERROR_STREAM_NAMED("parser", "Joint '" << joint_name << "' of transmission '" << transmission_name <<
                              "' does not specify the required <role> element.");
+      return false;
     }
     else
     {
       ROS_DEBUG_STREAM_NAMED("parser", "Joint '" << joint_name << "' of transmission '" << transmission_name <<
                              "' does not specify the optional <offset> element.");
+      return true;
     }
-    return ParseStatus::NO_DATA;
   }
 
   // Cast to number
@@ -212,17 +218,18 @@ TransmissionLoader::getJointRole(const TiXmlElement& parent_el,
     {
       ROS_ERROR_STREAM_NAMED("parser", "Joint '" << joint_name << "' of transmission '" << transmission_name <<
                              "' specifies an empty <role> element.");
+      return false;
     }
     else
     {
       ROS_DEBUG_STREAM_NAMED("parser", "Joint '" << joint_name << "' of transmission '" << transmission_name <<
                              "' specifies an empty <role> element.");
+      return true;
     }
-    return ParseStatus::NO_DATA;
   }
   role = role_el->GetText();
 
-  return ParseStatus::SUCCESS;
+  return true;
 }
 
 } // namespace


### PR DESCRIPTION
This is to fix https://github.com/ros-controls/ros_control/issues/333. I ultimately removed the `ParseStatus` enum. It didn't appear there being 3 valid return types was adding value so I thought removing it made the most sense. Let me know what you think