### PR TITLE
Use an explicit relative import path instead of implicit.

### DIFF
--- a/rqt_controller_manager/src/rqt_controller_manager/controller_manager.py
+++ b/rqt_controller_manager/src/rqt_controller_manager/controller_manager.py
@@ -44,7 +44,7 @@ from controller_manager_msgs.utils\
     import ControllerLister, ControllerManagerLister,\
     get_rosparam_controller_names
 
-from update_combo import update_combo
+from .update_combo import update_combo
 
 
 class ControllerManager(Plugin):


### PR DESCRIPTION
On python3 systems the implicit relative import will not work. The explicit
notation, however, should work on python >= 2.5

I am targeting melodic, as I myself am using ROS melodic with a python3 environment. According to [REP-0003](https://www.ros.org/reps/rep-0003.html) `noetic-devel` would probably be a more appropriate target branch, but it probably wouldn't hurt to include it into melodic, as well.