### PR TITLE
Move ros_controllers to DOWNSTREAM_WORKSPACE (noetic CI)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ notifications:
 
 env:
   global:
-    - UPSTREAM_WORKSPACE='ros_control.rosinstall -ros_control'
+    - UPSTREAM_WORKSPACE='ros_control.rosinstall -ros_control -ros_controllers'
   matrix:
     - ROS_DISTRO=noetic ROS_REPO=ros
     - ROS_DISTRO=noetic ROS_REPO=ros-testing

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,10 @@ notifications:
     on_failure: change #[always|never|change] # default: always
 
 env:
-  global:
-    - UPSTREAM_WORKSPACE='ros_control.rosinstall -ros_control -ros_controllers'
   matrix:
     - ROS_DISTRO=noetic ROS_REPO=ros
     - ROS_DISTRO=noetic ROS_REPO=ros-testing
-
+    - ROS_DISTRO=noetic NOT_TEST_DOWNSTREAM=true UPSTREAM_WORKSPACE='ros_control.rosinstall -ros_control -ros_controllers' DOWNSTREAM_WORKSPACE=github:ros_controls/ros_controllers#noetic-devel
 install:
   - git clone --quiet --depth 1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci -b master
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,13 @@ notifications:
       - bence.magyar.robotics@gmail.com
     on_success: change #[always|never|change] # default: change
     on_failure: change #[always|never|change] # default: always
-
 env:
+  global:
+    - UPSTREAM_WORKSPACE='ros_control.rosinstall -ros_control -ros_controllers'
   matrix:
     - ROS_DISTRO=noetic ROS_REPO=ros
     - ROS_DISTRO=noetic ROS_REPO=ros-testing
-    - ROS_DISTRO=noetic NOT_TEST_DOWNSTREAM=true UPSTREAM_WORKSPACE='ros_control.rosinstall -ros_control -ros_controllers' DOWNSTREAM_WORKSPACE=github:ros_controls/ros_controllers#noetic-devel
+    - DOWNSTREAM_WORKSPACE='ros_control.rosinstall -ros_control -realtime_tools -control_toolbox -control_msgs'
 install:
   - git clone --quiet --depth 1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci -b master
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
   matrix:
     - ROS_DISTRO=noetic ROS_REPO=ros
     - ROS_DISTRO=noetic ROS_REPO=ros-testing
-    - DOWNSTREAM_WORKSPACE='ros_control.rosinstall -ros_control -realtime_tools -control_toolbox -control_msgs'
+    - ROS_DISTRO=noetic DOWNSTREAM_WORKSPACE='ros_control.rosinstall -ros_control -realtime_tools -control_toolbox -control_msgs'
 install:
   - git clone --quiet --depth 1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci -b master
 script:


### PR DESCRIPTION
Since `ros_controllers` is a package that depends on `ros_control`, I think it should be tested too, but in DOWNSTREAM_WORKSPACE. If you just want to check it builds (and not run all its tests), it is possible to set `NOT_TEST_DOWNSTREAM=true`