### PR TITLE
Handle building without GMock

### DIFF
--- a/controller_interface/CMakeLists.txt
+++ b/controller_interface/CMakeLists.txt
@@ -31,7 +31,9 @@ include_directories(include ${catkin_INCLUDE_DIRS})
 
 if(CATKIN_ENABLE_TESTING)
   catkin_add_gmock(controller_base_test test/controller_base_test.cpp)
-  target_link_libraries(controller_base_test ${catkin_LIBRARIES})
+  if(TARGET controller_base_test)
+    target_link_libraries(controller_base_test ${catkin_LIBRARIES})
+  endif()
 endif()
 
 

--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -62,8 +62,10 @@ if(CATKIN_ENABLE_TESTING)
     test/hwi_update_test.test
     test/hwi_update_test.cpp
   )
-  add_dependencies(${PROJECT_NAME}_hwi_update_test ${catkin_EXPORTED_TARGETS})
-  target_link_libraries(${PROJECT_NAME}_hwi_update_test ${PROJECT_NAME} ${catkin_LIBRARIES})
+  if(TARGET ${PROJECT_NAME}_hwi_update_test)
+    add_dependencies(${PROJECT_NAME}_hwi_update_test ${catkin_EXPORTED_TARGETS})
+    target_link_libraries(${PROJECT_NAME}_hwi_update_test ${PROJECT_NAME} ${catkin_LIBRARIES})
+  endif()
 endif()
 
 


### PR DESCRIPTION
These macros will not fail if GMock is not available at build time, and will not produce a target under these circumstances. However, the subsequent CMake lines are assuming that the target will exist, and cause CMake to fail if not.

This change makes the packages tolerant to the absence of GMock at build time.

Example failure:
```
CMake Warning at /ros1/install/share/catkin/cmake/test/gtest.cmake:160 (message):
  skipping gmock 'controller_base_test' in project 'controller_interface'
  because gmock was not found
Call Stack (most recent call first):
  /ros1/install/share/catkin/cmake/test/gtest.cmake:89 (_catkin_add_executable_with_google_test)
  /ros1/install/share/catkin/cmake/test/gtest.cmake:63 (_catkin_add_google_test)
  CMakeLists.txt:33 (catkin_add_gmock)


CMake Error at CMakeLists.txt:34 (target_link_libraries):
  Cannot specify link libraries for target "controller_base_test" which is
  not built by this project.
```