### PR TITLE
Correct exception msg for missing abs pos ptr

### DIFF
--- a/hardware_interface/include/hardware_interface/joint_state_interface.h
+++ b/hardware_interface/include/hardware_interface/joint_state_interface.h
@@ -194,7 +194,7 @@ public:
   {
     if(!hasAbsolutePosition())
     {
-      throw std::runtime_error("Joint state handle does not contain torque sensor information");
+      throw std::runtime_error("Joint state handle does not contain absolute position sensor information");
     }
     return absolute_pos_;
   }


### PR DESCRIPTION
As per subject.

Minor, but thought I'd fix it.
