### PR TITLE
Fix Windows compilation

### DIFF
--- a/hardware_interface/include/hardware_interface/robot_hw.h
+++ b/hardware_interface/include/hardware_interface/robot_hw.h
@@ -39,6 +39,10 @@
 #include <ros/console.h>
 #include <ros/node_handle.h>
 
+#ifdef ERROR
+#undef ERROR
+#endif
+
 namespace hardware_interface
 {
 


### PR DESCRIPTION
`ERROR` needs to be undefined on Windows, otherwise compilation fails.