### PR TITLE
QTimer::setInterval expects int argument

### DIFF
--- a/combined_robot_hw_tests/package.xml
+++ b/combined_robot_hw_tests/package.xml
@@ -24,6 +24,8 @@
 
   <depend>combined_robot_hw</depend>
   <depend>controller_manager</depend>
+  <depend>controller_manager_msgs</depend>
+  <depend>controller_manager_tests</depend>
   <depend>hardware_interface</depend> <!-- exec_depend required for plugin -->
   <depend>roscpp</depend>
 
@@ -31,8 +33,6 @@
 
   <build_export_depend>pluginlib</build_export_depend>
 
-  <test_depend>controller_manager_msgs</test_depend>
-  <test_depend>controller_manager_tests</test_depend>
   <test_depend>rostest</test_depend>
 
   <export>

--- a/rqt_controller_manager/src/rqt_controller_manager/controller_manager.py
+++ b/rqt_controller_manager/src/rqt_controller_manager/controller_manager.py
@@ -120,15 +120,13 @@ class ControllerManager(Plugin):
         # Timer for controller manager updates
         self._list_cm = ControllerManagerLister()
         self._update_cm_list_timer = QTimer(self)
-        self._update_cm_list_timer.setInterval(1000.0 /
-                                               self._cm_update_freq)
+        self._update_cm_list_timer.setInterval(int(1000.0 / self._cm_update_freq))
         self._update_cm_list_timer.timeout.connect(self._update_cm_list)
         self._update_cm_list_timer.start()
 
         # Timer for running controller updates
         self._update_ctrl_list_timer = QTimer(self)
-        self._update_ctrl_list_timer.setInterval(1000.0 /
-                                                 self._cm_update_freq)
+        self._update_ctrl_list_timer.setInterval(int(1000.0 / self._cm_update_freq))
         self._update_ctrl_list_timer.timeout.connect(self._update_controllers)
         self._update_ctrl_list_timer.start()
 


### PR DESCRIPTION
Since Ubuntu 22.04 / Qt 5.15, Qt seems to be pickier about the correct type, and loading the rqt plugin fails.
https://doc.qt.io/qt-5/qtimer.html#interval-prop