### PR TITLE
Do not block when spawner is shut down while waiting for services

### DIFF
--- a/controller_manager/scripts/spawner
+++ b/controller_manager/scripts/spawner
@@ -118,6 +118,8 @@ def main():
 
     services_found = False
     while not services_found:
+        if rospy.is_shutdown():
+            return
         try:
             # loader
             rospy.loginfo("Controller Spawner: Waiting for service "+load_controller_service)


### PR DESCRIPTION
Hello everyone,
a while ago, I contributed this PR #508. However, a small oversight is that I did not check for `rospy.is_shutdown()` in the introduced while-loop. So if you manage to kill the node while it is still waiting for services, you receive a nasty message spam.

This commit simply adds the missing check for a running node. 

Best regards,
Martin